### PR TITLE
fix(release): generate richer release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,29 +87,11 @@ jobs:
       id: get_version
       run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
     
-    - name: Generate changelog
-      id: changelog
+    - name: Generate release notes
       run: |
-        current_tag="${{ steps.get_version.outputs.VERSION }}"
-        
-        # Last published release tag (empty if the project has no releases yet)
-        last_release="$(gh release list --limit 1 --json tagName --jq '.[0].tagName' 2>/dev/null || true)"
-        
-        if [ -n "$last_release" ] && [ "$last_release" != "null" ] && git rev-parse -q "$last_release" >/dev/null; then
-          title="## Changes since $last_release"
-          range="${last_release}..HEAD"
-        else
-          title="## Changes in this release"
-          range="-30"         
-        fi
-        
-        changelog="$title\n\n$(git log --pretty=format:'- %s' --no-merges $range)"
-        
-        {
-          echo 'CHANGELOG<<__CHANGELOG__'
-          printf '%b\n' "$changelog"
-          echo '__CHANGELOG__'
-        } >>"$GITHUB_OUTPUT"
+        scripts/generate-release-notes.sh \
+          --version "${{ steps.get_version.outputs.VERSION }}" \
+          --output release-notes.md
       env:
         GH_TOKEN: ${{ github.token }}
     
@@ -119,14 +101,7 @@ jobs:
       with:
         tag_name: ${{ github.ref }}
         name: Release ${{ steps.get_version.outputs.VERSION }}
-        body: |
-          ${{ steps.changelog.outputs.CHANGELOG }}
-          
-          ## Installation & Setup
-          
-          Download the `jetbrains-inspection-api-${{ steps.get_version.outputs.VERSION }}.zip` file below.
-          
-          For installation and setup instructions, see the [README Quick Start Guide](https://github.com/cbusillo/jetbrains-inspection-api#quick-start).
+        body_path: release-notes.md
         draft: false
         prerelease: false
         files: ./build/distributions/*.zip

--- a/scripts/generate-release-notes.sh
+++ b/scripts/generate-release-notes.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: scripts/generate-release-notes.sh --version VERSION --output FILE
+
+Generates GitHub release notes for the current tag from commit subjects since
+the previous GitHub release.
+USAGE
+}
+
+version=""
+output=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      version="${2:-}"
+      shift 2
+      ;;
+    --output)
+      output="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$version" || -z "$output" ]]; then
+  usage
+  exit 2
+fi
+
+last_release="$(gh release list --limit 1 --json tagName --jq '.[0].tagName' 2>/dev/null || true)"
+if [[ -n "$last_release" && "$last_release" != "null" ]] && git rev-parse -q "$last_release" >/dev/null; then
+  range="${last_release}..HEAD"
+else
+  range="-30"
+fi
+
+commit_summary="$(mktemp)"
+fixes="$(mktemp)"
+features="$(mktemp)"
+maintenance="$(mktemp)"
+other_updates="$(mktemp)"
+seen_subjects="$(mktemp)"
+
+git log --pretty=format:'%s' --no-merges $range > "$commit_summary"
+
+while IFS= read -r subject; do
+  [[ -n "$subject" ]] || continue
+  if grep -Fxq -- "$subject" "$seen_subjects"; then
+    continue
+  fi
+  printf '%s\n' "$subject" >> "$seen_subjects"
+  lower_subject="$(printf '%s' "$subject" | tr '[:upper:]' '[:lower:]')"
+  if [[ "$subject" =~ ^(fix|revert)(\(|:) ]]; then
+    printf '%s\n' "$subject" >> "$fixes"
+  elif [[ "$subject" =~ ^feat(\(|:) ]]; then
+    printf '%s\n' "$subject" >> "$features"
+  elif [[ "$subject" =~ ^(docs|test|chore|ci|build)(\(|:) ]] \
+    || [[ "$lower_subject" == *gradle* ]] \
+    || [[ "$lower_subject" == *release* ]]; then
+    printf '%s\n' "$subject" >> "$maintenance"
+  else
+    printf '%s\n' "$subject" >> "$other_updates"
+  fi
+done < "$commit_summary"
+
+write_section() {
+  local title="$1"
+  local file="$2"
+  if [[ -s "$file" ]]; then
+    echo "### $title"
+    echo ""
+    while IFS= read -r subject; do
+      [[ -n "$subject" ]] || continue
+      echo "- $subject"
+    done < "$file"
+    echo ""
+  fi
+}
+
+{
+  echo "## What's Changed"
+  echo ""
+  echo "This release publishes JetBrains Inspection API $version."
+  if [[ -n "$last_release" && "$last_release" != "null" ]]; then
+    echo "It includes changes since $last_release."
+  fi
+  echo ""
+
+  write_section "Fixes" "$fixes"
+  write_section "Features" "$features"
+  write_section "Maintenance" "$maintenance"
+  write_section "Other Updates" "$other_updates"
+
+  echo "## Verification"
+  echo ""
+  echo "- Commit gate passed in CI."
+  echo "- Plugin distribution was built with Gradle."
+  echo "- Plugin was published to JetBrains Marketplace."
+  echo ""
+  echo "## Installation & Setup"
+  echo ""
+  echo "Download the \`jetbrains-inspection-api-${version}.zip\` file below."
+  echo ""
+  echo "For installation and setup instructions, see the [README Quick Start Guide](https://github.com/cbusillo/jetbrains-inspection-api#quick-start)."
+} > "$output"


### PR DESCRIPTION
## Summary
- generate categorized release notes for plugin releases
- include verification and installation sections in the GitHub release body
- write release notes to a file and pass it with body_path

## Verification
- extracted release-note shell block and ran bash syntax check
- git diff --check
- commit hook ran Gradle checks successfully