### PR TITLE
docs: trim stale agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,11 +11,6 @@ live in [TESTING_INSTRUCTIONS.md](TESTING_INSTRUCTIONS.md).
 - Plugin: Kotlin/Gradle (JetBrains 2025.x), requires Java 21.
 - MCP server: Kotlin/JVM (bundled in plugin, built via `mcp-server-jvm`).
 
-## Repo Skills
-
-- `jetbrains-inspection-workflow`: Use for plugin, MCP server, HTTP API, test,
-  smoke, release, or docs work in this repo.
-
 ## Always-on rules
 
 - If `/usr/libexec/java_home -v 21` fails on macOS, set `JAVA_HOME_21` to your
@@ -24,7 +19,6 @@ live in [TESTING_INSTRUCTIONS.md](TESTING_INSTRUCTIONS.md).
   "Operation not permitted" from NativeServices, re-run with escalation.
 - Prefer descriptive names to comments/docstrings; keep commentary minimal.
 - Avoid stale docs: keep this file evergreen and link to README for specifics.
-- Use `git mv` for file moves so history stays intact.
 
 ## Local-only overrides
 


### PR DESCRIPTION
## Summary
- remove stale repo-skill guidance that is not present in the current skill registry
- remove generic git-move guidance now covered by global agent behavior

## Verification
- git diff --check -- AGENTS.md
- commit hook Gradle checks passed