### PR TITLE
Add PR and main CI gate

### DIFF
--- a/.github/github-repo-workflow.json
+++ b/.github/github-repo-workflow.json
@@ -39,7 +39,7 @@
       "manual smoke test flow changes"
     ]
   },
-  "importantWorkflows": ["Release"],
+  "importantWorkflows": ["CI", "Release"],
   "qaLabels": [],
   "deployLabels": [],
   "healthUrls": [],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+---
+name: CI
+
+"on":
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  commit-gate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: "21"
+          distribution: "temurin"
+          cache: "gradle"
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run commit gate
+        run: ./scripts/commit-gate.sh --ci
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: test-results
+          path: |
+            build/reports/tests/test/
+            inspection-core/build/reports/tests/test/
+            mcp-server-jvm/build/reports/tests/test/
+          retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,108 +1,103 @@
+---
 name: Release
 
-on:
+"on":
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 run-name: "Release ${{ github.ref_name }}"
+
+permissions:
+  contents: read
 
 jobs:
   test:
     runs-on: ubuntu-latest
-    
+
     steps:
-    - uses: actions/checkout@v6
-    
-    - name: Set up JDK 21
-      uses: actions/setup-java@v5
-      with:
-        java-version: '21'
-        distribution: 'temurin'
-    
-    - name: Cache Gradle packages
-      uses: actions/cache@v5
-      with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
-    
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
-    
-    - name: Run commit gate
-      run: ./scripts/commit-gate.sh --ci
-    
-    - name: Upload test results
-      uses: actions/upload-artifact@v7
-      if: failure()
-      with:
-        name: test-results
-        path: |
-          build/reports/tests/test/
-          mcp-server-jvm/build/reports/tests/test/
-        retention-days: 7
+      - uses: actions/checkout@v6
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: "21"
+          distribution: "temurin"
+          cache: "gradle"
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run commit gate
+        run: ./scripts/commit-gate.sh --ci
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: test-results
+          path: |
+            build/reports/tests/test/
+            inspection-core/build/reports/tests/test/
+            mcp-server-jvm/build/reports/tests/test/
+          retention-days: 7
 
   release:
     needs: [test]
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    
+
     steps:
-    - uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-    
-    - name: Set up JDK 21
-      uses: actions/setup-java@v5
-      with:
-        java-version: '21'
-        distribution: 'temurin'
-    
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
-    
-    - name: Build plugin
-      run: ./gradlew buildPlugin
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
-    - name: Verify Marketplace token
-      env:
-        PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
-      run: |
-        if [ -z "$PUBLISH_TOKEN" ]; then
-          echo "PUBLISH_TOKEN is not set in GitHub Secrets."
-          exit 1
-        fi
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: "21"
+          distribution: "temurin"
 
-    - name: Publish to JetBrains Marketplace
-      env:
-        PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
-      run: ./gradlew publishPlugin
-    
-    - name: Get version
-      id: get_version
-      run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-    
-    - name: Generate release notes
-      run: |
-        scripts/generate-release-notes.sh \
-          --version "${{ steps.get_version.outputs.VERSION }}" \
-          --output release-notes.md
-      env:
-        GH_TOKEN: ${{ github.token }}
-    
-    - name: Create Release
-      id: create_release
-      uses: softprops/action-gh-release@v3
-      with:
-        tag_name: ${{ github.ref }}
-        name: Release ${{ steps.get_version.outputs.VERSION }}
-        body_path: release-notes.md
-        draft: false
-        prerelease: false
-        files: ./build/distributions/*.zip
-    
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build plugin
+        run: ./gradlew buildPlugin
+
+      - name: Verify Marketplace token
+        env:
+          PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
+        run: |
+          if [ -z "$PUBLISH_TOKEN" ]; then
+            echo "PUBLISH_TOKEN is not set in GitHub Secrets."
+            exit 1
+          fi
+
+      - name: Publish to JetBrains Marketplace
+        env:
+          PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
+        run: ./gradlew publishPlugin
+
+      - name: Get version
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate release notes
+        run: |
+          scripts/generate-release-notes.sh \
+            --version "${{ steps.get_version.outputs.VERSION }}" \
+            --output release-notes.md
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ github.ref }}
+          name: Release ${{ steps.get_version.outputs.VERSION }}
+          body_path: release-notes.md
+          draft: false
+          prerelease: false
+          files: ./build/distributions/*.zip

--- a/TESTING.md
+++ b/TESTING.md
@@ -48,9 +48,13 @@ start it with a test project, and hit a few API endpoints.
 
 ## CI
 
-GitHub Actions runs on version tags (`v*`) via `.github/workflows/release.yml`:
+GitHub Actions runs the commit gate on pull requests and pushes to `main` via
+`.github/workflows/ci.yml`:
 
 - `./gradlew test`
 - `./gradlew :mcp-server-jvm:test`
-- `mcp-server-jvm` build
 - `./gradlew buildPlugin`
+
+Version tags (`v*`) run `.github/workflows/release.yml`, which repeats the
+commit gate before publishing to the JetBrains Marketplace and creating the
+GitHub Release.

--- a/scripts/commit-gate.sh
+++ b/scripts/commit-gate.sh
@@ -117,6 +117,7 @@ JAVA_HOME=$(resolve_java_home) || {
 
 export JAVA_HOME
 
-./gradlew test
+./gradlew :test
+./gradlew :inspection-core:test
 ./gradlew :mcp-server-jvm:test
 ./gradlew buildPlugin


### PR DESCRIPTION
## Summary
- add a CI workflow that runs `./scripts/commit-gate.sh --ci` on pull requests and pushes to `main`
- set explicit workflow permissions on the tag-based release workflow while preserving `contents: write` only for the release job
- update testing docs and repo workflow metadata to include the new CI workflow

Refs #14

## Validation
- `prettier --check .github/workflows/ci.yml .github/workflows/release.yml TESTING.md .github/github-repo-workflow.json`
- `actionlint .github/workflows/ci.yml .github/workflows/release.yml`
- `./scripts/commit-gate.sh --ci`

Note: opened with the active `cbusillo` GitHub account because the repo-local `scripts/shiny-bot-gh` helper is not present in this checkout.