### PR TITLE
Fix Windows Gradle wrapper Java error exit

### DIFF
--- a/gradlew.bat
+++ b/gradlew.bat
@@ -52,6 +52,7 @@ echo Please set the JAVA_HOME variable in your environment to match the 1>&2
 echo location of your Java installation. 1>&2
 
 "%COMSPEC%" /c exit 1
+goto exitWithErrorLevel
 
 :findJavaFromJavaHome
 set JAVA_HOME=%JAVA_HOME:"=%
@@ -66,6 +67,7 @@ echo Please set the JAVA_HOME variable in your environment to match the 1>&2
 echo location of your Java installation. 1>&2
 
 "%COMSPEC%" /c exit 1
+goto exitWithErrorLevel
 
 :execute
 @rem Setup the command line


### PR DESCRIPTION
## Summary
- stop `gradlew.bat` after reporting missing `java` on `PATH`
- stop `gradlew.bat` after reporting an invalid `JAVA_HOME`

## Validation
- `shellcheck scripts/commit-gate.sh`
- `./scripts/commit-gate.sh --ci`

Note: this is a follow-up for the Windows batch-wrapper issue found after the Dependabot Gradle wrapper update. The `.bat` path was reviewed textually on macOS; the normal repo gate passes with Gradle 9.5.0.