### PR TITLE
Clarify README inspection API port examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ path and rerun the command.
 1. **Open IDE Settings**: `File` → `Settings` (or `IntelliJ IDEA` → `Preferences` on macOS)
 2. **Navigate to**: `Tools` → `Web Browsers and Preview`
 3. In the **Built-in Server** section:
-   - Set the **Port** (example: `63341`)
+   - Set the **Port** (example: `63340`)
+   - The HTTP examples below use this same port.
    - **✅ Check**: "Can accept external connections"
    - **✅ Check**: "Allow unsigned requests"
 4. **Apply** settings
@@ -113,6 +114,9 @@ inspection_get_problems(project="odoo-ai", severity="error")
 Note: in MCP auto mode, the router prefers `project_key`, `project_path`, the MCP process working directory, then a unique `project` name. Blank or omitted selectors fall back to the focused/active open project only when unambiguous.
 
 ### Direct HTTP API
+These examples use the `63340` port from the setup example above. If you
+configured a different IDE built-in server port, use that port in each URL.
+
 ```bash
 # Trigger inspection
 curl "http://localhost:63340/api/inspection/trigger"
@@ -141,8 +145,6 @@ curl "http://localhost:63340/api/inspection/trigger?project=odoo-ai"
 # Inspect IDE/plugin identity and open project metadata
 curl "http://localhost:63340/api/inspection/identity"
 ```
-
-Replace `63340` with your IDE's configured port.
 
 ## Result Schema
 


### PR DESCRIPTION
## Summary
- Align the IDE built-in server setup example with the README HTTP API examples on port `63340`
- Move the replacement-port note above the Direct HTTP API commands so the examples are clearly placeholders for the configured IDE port

Closes #18

## Validation
- `git diff --check`
- Commit hook ran Gradle validation successfully (`test`, `:inspection-core:test`, `:mcp-server-jvm:test`, `buildPlugin`)

Launchplane request: every-code-cbusillo-jetbrains-inspection-api-18-9903a0eccb3eb99e
