### PR TITLE
Remove validatedThrough metadata

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -24,7 +24,11 @@
     "inspection": {
       "tool": "jetbrains",
       "ide": "IntelliJ IDEA",
-      "scopePreference": ["changed_files", "directory", "whole_project"]
+      "scopePreference": [
+        "changed_files",
+        "directory",
+        "whole_project"
+      ]
     },
     "manualSmoke": {
       "automatedIde": "./scripts/test-automated.sh"
@@ -39,26 +43,14 @@
       "manual smoke test flow changes"
     ]
   },
-  "importantWorkflows": ["CI", "Release"],
+  "importantWorkflows": [
+    "CI",
+    "Release"
+  ],
   "qaLabels": [],
   "deployLabels": [],
   "healthUrls": [],
   "relatedRepos": [],
-  "validatedThrough": [
-    {
-      "date": "2026-05-10",
-      "source": "cbusillo/jetbrains-inspection-api#20",
-      "checks": [
-        "jq empty .github/github.json",
-        "rg github-repo-workflow\\.json",
-        "codex-skills github-repo-snapshot.sh --json",
-        "commit-gate Gradle validation"
-      ],
-      "caveats": [
-        "Metadata contents were not otherwise changed during the config-path migration."
-      ]
-    }
-  ],
   "githubSignals": {
     "postMerge": {
       "waitForActions": true,


### PR DESCRIPTION
## Summary
- remove `validatedThrough` from `.github/github.json`
- keep repo metadata focused on current static facts and freshness triggers
- leave validation/history evidence in GitHub PRs, issues, Actions, Launchplane records, or generated reports rather than tracked config

## Validation
- `jq empty .github/github.json`
- `jq -e 'has("validatedThrough") | not' .github/github.json`
- `rg validatedThrough` over `.github`, `AGENTS.md`, `README.md`, and `docs`
- `git diff --check`

Follow-up to cbusillo/codex-skills#33.
- commit hook completed successfully
