### PR TITLE
Harden HTTP project selector routing

### DIFF
--- a/inspection-core/src/test/kotlin/com/shiny/inspectionmcp/core/InspectionRoutingTest.kt
+++ b/inspection-core/src/test/kotlin/com/shiny/inspectionmcp/core/InspectionRoutingTest.kt
@@ -35,6 +35,19 @@ class InspectionRoutingTest {
     }
 
     @Test
+    fun pathSelectorsDoNotMatchSiblingPrefixes() {
+        val identity = identity(project("path:/tmp/repo/app", "app", "/tmp/repo/app"))
+
+        val candidates = scoreInspectionRouteCandidates(
+            identities = listOf(identity),
+            selector = InspectionRouteSelector(worktreePath = "/tmp/repo/application/src"),
+            defaultCwd = null,
+        )
+
+        assertTrue(candidates.isEmpty())
+    }
+
+    @Test
     fun duplicateProjectNamesRemainAmbiguous() {
         val first = identity(project("path:/tmp/one", "shared", "/tmp/one"))
         val second = identity(project("path:/tmp/two", "shared", "/tmp/two"))

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -665,19 +665,24 @@ class InspectionHandler : HttpRequestHandler() {
         val identity = safeInspectionIdentity()
         val routeIdentity = identity.toRouteIdentity()
         val candidates = scoreInspectionRouteCandidates(listOf(routeIdentity), selector)
-        val bestScore = candidates.firstOrNull()?.score
-        val best = candidates.filter { candidate -> candidate.score == bestScore }
-        if (bestScore != null && best.size > 1) {
+        val selected = candidates.firstOrNull() ?: return null
+        val best = candidates.filter { candidate -> candidate.score == selected.score }
+        if (best.count { candidate -> routeSpecificity(candidate.project) == routeSpecificity(selected.project) } > 1) {
             throw BadRequestException(
                 "project",
                 "Multiple open projects matched this request. Retry with project_path or project_key.",
             )
         }
-        val selected = best.firstOrNull() ?: return null
         val projectKey = selected.project.projectKey ?: return null
         val project = getCurrentProject(projectKey) ?: return null
         val projectIdentity = openProjectIdentity(project)
         return ResolvedInspectionRoute(project, identity, projectIdentity, selected.score)
+    }
+
+    private fun routeSpecificity(project: InspectionRouteProject): Int {
+        return normalizeProjectPath(project.basePath)?.length
+            ?: normalizeProjectPath(project.projectFilePath)?.length
+            ?: 0
     }
 
     private fun routeMetadata(project: Project): Map<String, Any?> {
@@ -2357,7 +2362,7 @@ class InspectionHandler : HttpRequestHandler() {
     private fun getCurrentProject(projectName: String? = null): Project? {
         val resolvedProjectName = normalizeProjectSelector(projectName)
         if (resolvedProjectName != null) {
-            return runCatching { getProjectByName(resolvedProjectName) }.getOrNull()
+            return runCatching { resolveProjectSelector(resolvedProjectName) }.getOrNull()
         }
 
         val projectFromFrame = runCatching {
@@ -2400,18 +2405,34 @@ class InspectionHandler : HttpRequestHandler() {
         return project != null && !project.isDefault && !project.isDisposed && project.isInitialized
     }
     
-    private fun getProjectByName(projectName: String): Project? {
+    private fun resolveProjectSelector(projectName: String): Project? {
         val projectManager = ProjectManager.getInstance()
         val openProjects = projectManager.openProjects
         val trimmed = projectName.trim()
         val pathHint = normalizeProjectPath(trimmed)
 
-        return openProjects.firstOrNull { project ->
+        val matches = openProjects.filter { project ->
             !project.isDefault &&
             !project.isDisposed &&
             project.isInitialized &&
             projectMatches(project, trimmed, pathHint)
         }
+        if (matches.size <= 1) {
+            return matches.firstOrNull()
+        }
+
+        if (pathHint != null) {
+            return matches.maxWithOrNull(compareBy<Project> { normalizeProjectPath(it.basePath)?.length ?: 0 })
+        }
+
+        throw BadRequestException(
+            "project",
+            "Multiple open projects matched this request. Retry with project_path or project_key.",
+        )
+    }
+
+    private fun getProjectByName(projectName: String): Project? {
+        return resolveProjectSelector(projectName)
     }
 
     private fun projectMatches(project: Project, projectName: String, pathHint: String?): Boolean {
@@ -2420,10 +2441,18 @@ class InspectionHandler : HttpRequestHandler() {
         if (pathHint == null) return false
 
         val basePath = normalizeProjectPath(project.basePath)
-        if (basePath != null && basePath == pathHint) return true
+        if (basePath != null && pathMatchesProject(pathHint, basePath)) return true
 
         val projectFilePath = normalizeProjectPath(project.projectFilePath)
-        return projectFilePath == pathHint
+        return projectFilePath != null && pathMatchesProject(pathHint, projectFilePath)
+    }
+
+    private fun pathMatchesProject(selectorPath: String, projectPath: String): Boolean {
+        return runCatching {
+            val selector = Paths.get(selectorPath).normalize().toAbsolutePath()
+            val project = Paths.get(projectPath).normalize().toAbsolutePath()
+            selector == project || selector.startsWith(project)
+        }.getOrDefault(false)
     }
 
     private fun normalizeProjectPath(value: String?): String? {
@@ -2445,10 +2474,13 @@ class InspectionHandler : HttpRequestHandler() {
         urlDecoder: QueryStringDecoder,
         request: FullHttpRequest,
     ): String? {
-        for (parameterName in listOf("project", "project_key", "project_path", "worktree_path", "cwd")) {
+        for (parameterName in listOf("project_key", "project_path", "worktree_path", "cwd", "project")) {
             val parameterValues = urlDecoder.parameters()[parameterName]
             if (parameterValues != null) {
-                return if (parameterValues.isEmpty()) "" else parameterValues.firstOrNull()
+                val firstNonBlankValue = parameterValues.firstOrNull { value -> value.trim().isNotEmpty() }
+                if (firstNonBlankValue != null) {
+                    return firstNonBlankValue
+                }
             }
         }
 
@@ -2467,7 +2499,10 @@ class InspectionHandler : HttpRequestHandler() {
                 continue
             }
             val encodedValue = nameAndValue.getOrElse(1) { "" }
-            return QueryStringDecoder.decodeComponent(encodedValue)
+            val decodedValue = QueryStringDecoder.decodeComponent(encodedValue)
+            if (decodedValue.trim().isNotEmpty()) {
+                return decodedValue
+            }
         }
 
         return null

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -643,6 +643,110 @@ class InspectionHandlerTest {
     }
 
     @Test
+    fun `test extractProjectQueryParameter prefers stable selectors over project`() {
+        val method = InspectionHandler::class.java.getDeclaredMethod(
+            "extractProjectQueryParameter",
+            QueryStringDecoder::class.java,
+            FullHttpRequest::class.java,
+        )
+        method.isAccessible = true
+
+        val urlDecoder = QueryStringDecoder("/api/inspection/route?project=legacy-name&project_key=path:%2Ftmp%2Fproject")
+        val request = mockk<FullHttpRequest>()
+        every { request.uri() } returns "/api/inspection/route?project=legacy-name&project_key=path:%2Ftmp%2Fproject"
+
+        val result = method.invoke(handler, urlDecoder, request) as String?
+
+        assertEquals("path:/tmp/project", result)
+    }
+
+    @Test
+    fun `test project path selectors match nested directories but not siblings`() {
+        val method = InspectionHandler::class.java.getDeclaredMethod(
+            "projectMatches",
+            Project::class.java,
+            String::class.java,
+            String::class.java,
+        )
+        method.isAccessible = true
+
+        every { mockProject.basePath } returns "/repo/app"
+        every { mockProject.projectFilePath } returns "/repo/app/.idea/misc.xml"
+
+        val nestedSelector = method.invoke(handler, mockProject, "ignored", "/repo/app/src/module") as Boolean
+        val siblingSelector = method.invoke(handler, mockProject, "ignored", "/repo/application/src") as Boolean
+
+        assertTrue(nestedSelector)
+        assertFalse(siblingSelector)
+    }
+
+    @Test
+    fun `test route endpoint selects the most specific nested project`() {
+        val parentProject = mockProject(
+            name = "Parent",
+            basePath = "/repo",
+            projectFilePath = "/repo/.idea/misc.xml",
+        )
+        val childProject = mockProject(
+            name = "Child",
+            basePath = "/repo/packages/app",
+            projectFilePath = "/repo/packages/app/.idea/misc.xml",
+        )
+        every { mockProjectManager.openProjects } returns arrayOf(parentProject, childProject)
+
+        val response = processGetRequest("/api/inspection/route?worktree_path=/repo/packages/app/src")
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"project_name\": \"Child\""))
+        assertFalse(body.contains("Multiple open projects matched this request"))
+    }
+
+    @Test
+    fun `test route endpoint rejects ambiguous project names`() {
+        val firstProject = mockProject(
+            name = "Shared",
+            basePath = "/repo/one",
+            projectFilePath = "/repo/one/.idea/misc.xml",
+        )
+        val secondProject = mockProject(
+            name = "Shared",
+            basePath = "/repo/two",
+            projectFilePath = "/repo/two/.idea/misc.xml",
+        )
+        every { mockProjectManager.openProjects } returns arrayOf(firstProject, secondProject)
+
+        val response = processGetRequest("/api/inspection/route?project=Shared")
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.BAD_REQUEST, response.status())
+        assertTrue(body.contains("Multiple open projects matched this request"))
+    }
+
+    @Test
+    fun `test getCurrentProject uses nested path selector scoring`() {
+        val parentProject = mockProject(
+            name = "Parent",
+            basePath = "/repo",
+            projectFilePath = "/repo/.idea/misc.xml",
+        )
+        val childProject = mockProject(
+            name = "Child",
+            basePath = "/repo/packages/app",
+            projectFilePath = "/repo/packages/app/.idea/misc.xml",
+        )
+        every { mockProjectManager.openProjects } returns arrayOf(parentProject, childProject)
+
+        val method = InspectionHandler::class.java.getDeclaredMethod("getCurrentProject", String::class.java)
+        method.isAccessible = true
+
+        val result = method.invoke(handler, "/repo/packages/app/src") as Project?
+
+        assertNotNull(result)
+        assertEquals("Child", result?.name)
+    }
+
+    @Test
     fun `test clearPriorInspectionResults removes all stale inspection tabs`() {
         val toolWindowManager = mockk<ToolWindowManager>()
         val toolWindow = mockk<ToolWindow>()
@@ -752,5 +856,16 @@ class InspectionHandlerTest {
 
         assertTrue(result)
         return responseSlot.captured as FullHttpResponse
+    }
+
+    private fun mockProject(name: String, basePath: String, projectFilePath: String): Project {
+        val project = mockk<Project>()
+        every { project.isDefault } returns false
+        every { project.isDisposed } returns false
+        every { project.isInitialized } returns true
+        every { project.name } returns name
+        every { project.basePath } returns basePath
+        every { project.projectFilePath } returns projectFilePath
+        return project
     }
 }


### PR DESCRIPTION
## Summary

- Harden HTTP project selector routing after auto-review found two wrong-project risks.
- Match path selectors by real path boundaries so sibling directories with shared prefixes do not match.
- Prefer stable selectors over legacy `project`, route nested paths to the deepest containing project, and reject ambiguous duplicate project names instead of first-match routing.

## Validation

- Focused handler/core routing tests
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./scripts/commit-gate.sh --ci`
