### PR TITLE
Preserve ambiguous project selector errors

### DIFF
--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -667,7 +667,16 @@ class InspectionHandler : HttpRequestHandler() {
         val candidates = scoreInspectionRouteCandidates(listOf(routeIdentity), selector)
         val selected = candidates.firstOrNull() ?: return null
         val best = candidates.filter { candidate -> candidate.score == selected.score }
-        if (best.count { candidate -> routeSpecificity(candidate.project) == routeSpecificity(selected.project) } > 1) {
+        val pathSelector = firstParameter(parameters, "project_path")
+            ?: firstParameter(parameters, "worktree_path")
+            ?: firstParameter(parameters, "cwd")
+        val pathBasedSelection = normalizeProjectPath(pathSelector) != null
+        val duplicateBest = if (pathBasedSelection) {
+            best.count { candidate -> routeSpecificity(candidate.project) == routeSpecificity(selected.project) } > 1
+        } else {
+            best.size > 1
+        }
+        if (duplicateBest) {
             throw BadRequestException(
                 "project",
                 "Multiple open projects matched this request. Retry with project_path or project_key.",
@@ -2362,7 +2371,7 @@ class InspectionHandler : HttpRequestHandler() {
     private fun getCurrentProject(projectName: String? = null): Project? {
         val resolvedProjectName = normalizeProjectSelector(projectName)
         if (resolvedProjectName != null) {
-            return runCatching { resolveProjectSelector(resolvedProjectName) }.getOrNull()
+            return resolveProjectSelector(resolvedProjectName)
         }
 
         val projectFromFrame = runCatching {

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -724,6 +724,49 @@ class InspectionHandlerTest {
     }
 
     @Test
+    fun `test route endpoint rejects duplicate project names even when paths differ in specificity`() {
+        val parentProject = mockProject(
+            name = "Shared",
+            basePath = "/repo",
+            projectFilePath = "/repo/.idea/misc.xml",
+        )
+        val childProject = mockProject(
+            name = "Shared",
+            basePath = "/repo/packages/app",
+            projectFilePath = "/repo/packages/app/.idea/misc.xml",
+        )
+        every { mockProjectManager.openProjects } returns arrayOf(parentProject, childProject)
+
+        val response = processGetRequest("/api/inspection/route?project=Shared")
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.BAD_REQUEST, response.status())
+        assertTrue(body.contains("Multiple open projects matched this request"))
+    }
+
+    @Test
+    fun `test trigger endpoint reports ambiguous project names as bad request`() {
+        val firstProject = mockProject(
+            name = "Shared",
+            basePath = "/repo/one",
+            projectFilePath = "/repo/one/.idea/misc.xml",
+        )
+        val secondProject = mockProject(
+            name = "Shared",
+            basePath = "/repo/two",
+            projectFilePath = "/repo/two/.idea/misc.xml",
+        )
+        every { mockProjectManager.openProjects } returns arrayOf(firstProject, secondProject)
+
+        val response = processTriggerRequest("/api/inspection/trigger?project=Shared")
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.BAD_REQUEST, response.status())
+        assertTrue(body.contains("Multiple open projects matched this request"))
+        assertFalse(body.contains("Requested project 'Shared' is not open in the IDE"))
+    }
+
+    @Test
     fun `test getCurrentProject uses nested path selector scoring`() {
         val parentProject = mockProject(
             name = "Parent",


### PR DESCRIPTION
## Summary

- Preserve hard ambiguity errors for duplicate project-name route selectors.
- Let path-based selectors keep deepest-project routing while requiring duplicate name/key selectors to disambiguate.
- Stop swallowing ambiguous project selector errors as missing-project responses for trigger/status/wait/problems.

## Validation

- Focused ambiguity regression tests passed.
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew cleanTest :test --no-configuration-cache --rerun-tasks` passed.
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./scripts/commit-gate.sh --ci` test cases passed, but local Gradle result bookkeeping twice ended with `NoSuchFileException ... in-progress-results-generic.bin`; reran clean/no-cache plugin tests successfully. CI should be source of truth for full gate.
