### PR TITLE
Bump version to 1.12.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion=1.12.3
+pluginVersion=1.12.4
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
 kotlin.stdlib.default.dependency=false
 # Enable Gradle Configuration Cache -> https://docs.gradle.org/current/userguide/configuration_cache.html

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.shiny.inspection.api</id>
     <name>Inspection API</name>
-    <version>1.12.3</version>
+    <version>1.12.4</version>
     <vendor email="info@shinycomputers.com" url="https://github.com/cbusillo/jetbrains-inspection-api">Shiny Computers (Chris Busillo)</vendor>
     <resource-bundle>messages.InspectionApiBundle</resource-bundle>
     


### PR DESCRIPTION
## Summary

- Bump plugin version to 1.12.4 after ambiguity-error routing hotfix PR #29.
- Keep plugin.xml version in sync with gradle.properties.

## Validation

- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./scripts/commit-gate.sh --ci`
- Commit hook reran plugin/core/MCP tests plus `buildPlugin` successfully.
