### PR TITLE
Prefer exact path matches for project routing

### DIFF
--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -670,9 +670,12 @@ class InspectionHandler : HttpRequestHandler() {
         val pathSelector = firstParameter(parameters, "project_path")
             ?: firstParameter(parameters, "worktree_path")
             ?: firstParameter(parameters, "cwd")
+            ?: firstParameter(parameters, "project")
         val pathBasedSelection = normalizeProjectPath(pathSelector) != null
         val duplicateBest = if (pathBasedSelection) {
-            best.count { candidate -> routeSpecificity(candidate.project) == routeSpecificity(selected.project) } > 1
+            val selectedPathScore = routePathMatchScore(selected.project, pathSelector)
+            selectedPathScore != null &&
+                best.count { candidate -> routePathMatchScore(candidate.project, pathSelector) == selectedPathScore } > 1
         } else {
             best.size > 1
         }
@@ -688,10 +691,11 @@ class InspectionHandler : HttpRequestHandler() {
         return ResolvedInspectionRoute(project, identity, projectIdentity, selected.score)
     }
 
-    private fun routeSpecificity(project: InspectionRouteProject): Int {
-        return normalizeProjectPath(project.basePath)?.length
-            ?: normalizeProjectPath(project.projectFilePath)?.length
-            ?: 0
+    private fun routePathMatchScore(project: InspectionRouteProject, selectorPath: String?): Int? {
+        return bestPathMatchScore(
+            selectorPath,
+            listOfNotNull(project.basePath, project.projectFilePath),
+        )
     }
 
     private fun routeMetadata(project: Project): Map<String, Any?> {
@@ -2431,7 +2435,18 @@ class InspectionHandler : HttpRequestHandler() {
         }
 
         if (pathHint != null) {
-            return matches.maxWithOrNull(compareBy<Project> { normalizeProjectPath(it.basePath)?.length ?: 0 })
+            val scoredMatches = matches.mapNotNull { project ->
+                projectPathMatchScore(project, pathHint)?.let { score -> project to score }
+            }
+            val bestScore = scoredMatches.maxOfOrNull { (_, score) -> score }
+            val bestMatches = scoredMatches.filter { (_, score) -> score == bestScore }
+            if (bestMatches.size == 1) {
+                return bestMatches.single().first
+            }
+            throw BadRequestException(
+                "project",
+                "Multiple open projects matched this request. Retry with project_path or project_key.",
+            )
         }
 
         throw BadRequestException(
@@ -2454,6 +2469,33 @@ class InspectionHandler : HttpRequestHandler() {
 
         val projectFilePath = normalizeProjectPath(project.projectFilePath)
         return projectFilePath != null && pathMatchesProject(pathHint, projectFilePath)
+    }
+
+    private fun projectPathMatchScore(project: Project, selectorPath: String?): Int? {
+        return bestPathMatchScore(
+            selectorPath,
+            listOfNotNull(project.basePath, project.projectFilePath),
+        )
+    }
+
+    private fun bestPathMatchScore(selectorPath: String?, projectPaths: List<String>): Int? {
+        val normalizedSelector = normalizeProjectPath(selectorPath) ?: return null
+        return projectPaths.maxOfOrNull { projectPath ->
+            pathMatchScore(normalizedSelector, projectPath) ?: 0
+        }?.takeIf { it > 0 }
+    }
+
+    private fun pathMatchScore(selectorPath: String, projectPath: String): Int? {
+        val normalizedProjectPath = normalizeProjectPath(projectPath) ?: return null
+        return runCatching {
+            val selector = Paths.get(selectorPath).normalize().toAbsolutePath()
+            val project = Paths.get(normalizedProjectPath).normalize().toAbsolutePath()
+            when {
+                selector == project -> 2_000_000 + project.toString().length
+                selector.startsWith(project) -> 1_000_000 + project.toString().length
+                else -> null
+            }
+        }.getOrNull()
     }
 
     private fun pathMatchesProject(selectorPath: String, projectPath: String): Boolean {

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -790,6 +790,51 @@ class InspectionHandlerTest {
     }
 
     @Test
+    fun `test getCurrentProject prefers exact project file path over longer containing base path`() {
+        val exactProjectFileMatch = mockProject(
+            name = "ExactProjectFile",
+            basePath = "/repo/app",
+            projectFilePath = "/repo/app/.idea/misc.xml",
+        )
+        val longerContainingBasePath = mockProject(
+            name = "ContainingBasePath",
+            basePath = "/repo/app/.idea",
+            projectFilePath = "/repo/app/.idea/.idea/misc.xml",
+        )
+        every { mockProjectManager.openProjects } returns arrayOf(exactProjectFileMatch, longerContainingBasePath)
+
+        val method = InspectionHandler::class.java.getDeclaredMethod("getCurrentProject", String::class.java)
+        method.isAccessible = true
+
+        val result = method.invoke(handler, "/repo/app/.idea/misc.xml") as Project?
+
+        assertNotNull(result)
+        assertEquals("ExactProjectFile", result?.name)
+    }
+
+    @Test
+    fun `test route endpoint prefers exact project file path over longer containing base path`() {
+        val exactProjectFileMatch = mockProject(
+            name = "ExactProjectFile",
+            basePath = "/repo/app",
+            projectFilePath = "/repo/app/.idea/misc.xml",
+        )
+        val longerContainingBasePath = mockProject(
+            name = "ContainingBasePath",
+            basePath = "/repo/app/.idea",
+            projectFilePath = "/repo/app/.idea/.idea/misc.xml",
+        )
+        every { mockProjectManager.openProjects } returns arrayOf(exactProjectFileMatch, longerContainingBasePath)
+
+        val response = processGetRequest("/api/inspection/route?project_path=/repo/app/.idea/misc.xml")
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"project_name\": \"ExactProjectFile\""))
+        assertFalse(body.contains("Multiple open projects matched this request"))
+    }
+
+    @Test
     fun `test clearPriorInspectionResults removes all stale inspection tabs`() {
         val toolWindowManager = mockk<ToolWindowManager>()
         val toolWindow = mockk<ToolWindow>()


### PR DESCRIPTION
## Summary
- prefer exact project base/file path matches over longer containing paths when resolving path selectors
- apply the same exact-path scoring to route ambiguity checks
- add regression coverage for direct endpoint project selection and `/api/inspection/route`

## Validation
- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test --tests 'com.shiny.inspectionmcp.InspectionHandlerTest'\n- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew test\n- ./scripts/commit-gate.sh\n\nBlocks the 1.12.5 routing hotfix follow-up for issue #24.