### PR TITLE
Keep scoped empty waits behind view evidence

### DIFF
--- a/inspection-core/src/test/kotlin/com/shiny/inspectionmcp/core/InspectionRoutingTest.kt
+++ b/inspection-core/src/test/kotlin/com/shiny/inspectionmcp/core/InspectionRoutingTest.kt
@@ -35,6 +35,32 @@ class InspectionRoutingTest {
     }
 
     @Test
+    fun legacyProjectPathSelectorMatchesProjectFilePathBeforeContainingBasePath() {
+        val exactProjectFile = project(
+            projectKey = "path:/tmp/repo/app",
+            name = "app",
+            basePath = "/tmp/repo/app",
+            projectFilePath = "/tmp/repo/app/.idea/misc.xml",
+        )
+        val containingBasePath = project(
+            projectKey = "path:/tmp/repo/app/.idea",
+            name = "idea-dir",
+            basePath = "/tmp/repo/app/.idea",
+            projectFilePath = "/tmp/repo/app/.idea/.idea/misc.xml",
+        )
+        val identity = identity(exactProjectFile, containingBasePath)
+
+        val candidates = scoreInspectionRouteCandidates(
+            identities = listOf(identity),
+            selector = InspectionRouteSelector(project = "/tmp/repo/app/.idea/misc.xml"),
+            defaultCwd = null,
+        )
+
+        assertEquals("path:/tmp/repo/app", candidates.first().project.projectKey)
+        assertEquals(900, candidates.first().score)
+    }
+
+    @Test
     fun pathSelectorsDoNotMatchSiblingPrefixes() {
         val identity = identity(project("path:/tmp/repo/app", "app", "/tmp/repo/app"))
 
@@ -94,13 +120,14 @@ class InspectionRoutingTest {
         projectKey: String,
         name: String,
         basePath: String,
+        projectFilePath: String? = null,
         focused: Boolean = false,
     ): InspectionRouteProject {
         return InspectionRouteProject(
             projectKey = projectKey,
             name = name,
             basePath = basePath,
-            projectFilePath = null,
+            projectFilePath = projectFilePath,
             focused = focused,
         )
     }

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -393,6 +393,10 @@ internal fun shouldStopCapturePolling(
 
 internal fun shouldTrustStableScopedEmptyResults(
     viewReadyOk: Boolean,
+    observedInspectionView: Boolean = false,
+    inspectionViewUpdating: Boolean = false,
+    hasSettledInspectionViewEvidence: Boolean = false,
+    extractionSucceeded: Boolean = true,
     hasScopedMatcher: Boolean,
     scopedContextResultsEmpty: Boolean,
     bestResultsEmpty: Boolean,
@@ -403,6 +407,8 @@ internal fun shouldTrustStableScopedEmptyResults(
     minPollingMs: Long = 30000L,
 ): Boolean {
     return viewReadyOk &&
+        (!observedInspectionView || (!inspectionViewUpdating && hasSettledInspectionViewEvidence)) &&
+        extractionSucceeded &&
         hasScopedMatcher &&
         scopedContextResultsEmpty &&
         bestResultsEmpty &&
@@ -1598,9 +1604,12 @@ class InspectionHandler : HttpRequestHandler() {
                 ApplicationManager.getApplication().executeOnPooledThread {
                     try {
                         val extractor = enhancedTreeExtractorFactory()
+                        var extractedFromContextSucceeded = false
                         val extractedFromContext = try {
                             ApplicationManager.getApplication().runReadAction<List<Map<String, Any>>, Exception> {
                                 extractProblemsFromContext(globalContext, project)
+                            }.also {
+                                extractedFromContextSucceeded = true
                             }
                         } catch (e: Exception) {
                             rethrowIfCanceled(e)
@@ -1628,6 +1637,8 @@ class InspectionHandler : HttpRequestHandler() {
                         var nullRootChildObservationCount = 0
                         var toolWindowObservationCount = 0
                         var compatibleToolWindowObservationCount = 0
+                        var extractionFailureCount = if (extractedFromContextSucceeded) 0 else 1
+                        var successfulExtractionCount = if (extractedFromContextSucceeded) 1 else 0
 
                         fun extractFromViewSafe(view: InspectionResultsView): List<Map<String, Any>> {
                             val app = ApplicationManager.getApplication()
@@ -1758,11 +1769,17 @@ class InspectionHandler : HttpRequestHandler() {
                                         readableEmptyInspectionViewStableSince = null
                                     }
                                 }
+                                var viewExtractionSucceeded = false
                                 val attempt = try {
                                     extractFromViewSafe(view)
+                                        .also { viewExtractionSucceeded = true }
                                 } catch (e: Exception) {
                                     rethrowIfCanceled(e)
+                                    extractionFailureCount += 1
                                     emptyList()
+                                }
+                                if (viewExtractionSucceeded) {
+                                    successfulExtractionCount += 1
                                 }
                                 val scopedAttempt = filterProblemsForScope(attempt, scopeProblemMatcher)
                                 if (scopedAttempt.size > bestResults.size) {
@@ -1771,13 +1788,20 @@ class InspectionHandler : HttpRequestHandler() {
                                 }
                             }
 
+                            var toolExtractionSucceeded = false
                             val toolResults = try {
                                 ApplicationManager.getApplication().runReadAction<List<Map<String, Any>>, Exception> {
                                     extractor.extractAllProblems(project)
+                                }.also {
+                                    toolExtractionSucceeded = true
                                 }
                             } catch (e: Exception) {
                                 rethrowIfCanceled(e)
+                                extractionFailureCount += 1
                                 emptyList()
+                            }
+                            if (toolExtractionSucceeded) {
+                                successfulExtractionCount += 1
                             }
                             toolWindowObservationCount += 1
                             val compatibleToolResults = filterProblemsForScope(toolResults, scopeProblemMatcher)
@@ -1802,13 +1826,6 @@ class InspectionHandler : HttpRequestHandler() {
 
                             val stableForMs = loopNow - lastChangeMs
                             val pollingElapsedMs = loopNow - captureStartMs
-                            val hasUsableViewEvidence = hasUsableInspectionViewEvidence(
-                                inspectionViewObservationCount = inspectionViewObservationCount,
-                                nullRootChildObservationCount = nullRootChildObservationCount,
-                                observedSettledEmptyInspectionView = observedSettledEmptyInspectionView,
-                                observedStableReadableEmptyInspectionView = observedStableReadableEmptyInspectionView,
-                                observedNonEmptyInspectionTree = observedNonEmptyInspectionTree,
-                            )
                             if (
                                 !observedStableReadableEmptyInspectionView &&
                                 readableEmptyInspectionViewStableSince != null &&
@@ -1822,6 +1839,11 @@ class InspectionHandler : HttpRequestHandler() {
                                 shouldTrustStableScopedEmptyResults(
                                     viewReadyOk = viewReadyOk,
                                     hasScopedMatcher = scopeProblemMatcher != null,
+                                    observedInspectionView = observedInspectionView,
+                                    inspectionViewUpdating = inspectionViewUpdating,
+                                    hasSettledInspectionViewEvidence = observedSettledEmptyInspectionView ||
+                                        observedStableReadableEmptyInspectionView,
+                                    extractionSucceeded = successfulExtractionCount > 0 && extractionFailureCount == 0,
                                     scopedContextResultsEmpty = scopedContextResults.isEmpty(),
                                     bestResultsEmpty = bestResults.isEmpty(),
                                     observedNonEmptyInspectionTree = observedNonEmptyInspectionTree,
@@ -1860,6 +1882,11 @@ class InspectionHandler : HttpRequestHandler() {
                             shouldTrustStableScopedEmptyResults(
                                 viewReadyOk = viewReadyOk,
                                 hasScopedMatcher = scopeProblemMatcher != null,
+                                observedInspectionView = observedInspectionView,
+                                inspectionViewUpdating = inspectionViewUpdating,
+                                hasSettledInspectionViewEvidence = observedSettledEmptyInspectionView ||
+                                    observedStableReadableEmptyInspectionView,
+                                extractionSucceeded = successfulExtractionCount > 0 && extractionFailureCount == 0,
                                 scopedContextResultsEmpty = scopedContextResults.isEmpty(),
                                 bestResultsEmpty = bestResults.isEmpty(),
                                 observedNonEmptyInspectionTree = observedNonEmptyInspectionTree,
@@ -1923,6 +1950,8 @@ class InspectionHandler : HttpRequestHandler() {
                                     "nullRootChildObservationCount=$nullRootChildObservationCount, " +
                                     "toolWindowObservationCount=$toolWindowObservationCount, " +
                                     "compatibleToolWindowObservationCount=$compatibleToolWindowObservationCount, " +
+                                    "successfulExtractionCount=$successfulExtractionCount, " +
+                                    "extractionFailureCount=$extractionFailureCount, " +
                                     "readableEmptyInspectionViewStableForMs=${readableEmptyInspectionViewStableSince?.let { snapshot.timestamp - it } ?: 0L}, " +
                                     "lastViewObservation=${lastViewObservation?.let { "isUpdating=${it.isUpdating}, hasProblems=${it.hasProblems}, rootChildCount=${it.rootChildCount}, updateStateReadable=${it.updateStateReadable}, problemStateReadable=${it.problemStateReadable}" } ?: "null"}"
                             )

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
@@ -870,10 +870,93 @@ class InspectionSnapshotStateTest {
         assertFalse(
             shouldTrustStableScopedEmptyResults(
                 viewReadyOk = true,
+                extractionSucceeded = false,
                 hasScopedMatcher = true,
                 scopedContextResultsEmpty = true,
                 bestResultsEmpty = true,
                 observedNonEmptyInspectionTree = true,
+                stableForMs = 5000L,
+                pollingElapsedMs = 30000L,
+            )
+        )
+    }
+
+    @Test
+    @DisplayName("Scoped empty results do not hide extractor failures")
+    fun testStableScopedEmptyResultsRequireSuccessfulExtraction() {
+        assertFalse(
+            shouldTrustStableScopedEmptyResults(
+                viewReadyOk = true,
+                extractionSucceeded = false,
+                hasScopedMatcher = true,
+                scopedContextResultsEmpty = true,
+                bestResultsEmpty = true,
+                observedNonEmptyInspectionTree = false,
+                stableForMs = 5000L,
+                pollingElapsedMs = 30000L,
+            )
+        )
+
+        assertFalse(
+            shouldTrustStableScopedEmptyResults(
+                viewReadyOk = true,
+                observedInspectionView = true,
+                inspectionViewUpdating = false,
+                hasSettledInspectionViewEvidence = true,
+                extractionSucceeded = false,
+                hasScopedMatcher = true,
+                scopedContextResultsEmpty = true,
+                bestResultsEmpty = true,
+                observedNonEmptyInspectionTree = false,
+                stableForMs = 5000L,
+                pollingElapsedMs = 30000L,
+            )
+        )
+    }
+
+    @Test
+    @DisplayName("Scoped empty results wait for observed inspection views to settle")
+    fun testStableScopedEmptyResultsWaitForObservedInspectionViewToSettle() {
+        assertFalse(
+            shouldTrustStableScopedEmptyResults(
+                viewReadyOk = true,
+                observedInspectionView = true,
+                inspectionViewUpdating = true,
+                hasSettledInspectionViewEvidence = true,
+                hasScopedMatcher = true,
+                scopedContextResultsEmpty = true,
+                bestResultsEmpty = true,
+                observedNonEmptyInspectionTree = false,
+                stableForMs = 5000L,
+                pollingElapsedMs = 30000L,
+            )
+        )
+
+        assertFalse(
+            shouldTrustStableScopedEmptyResults(
+                viewReadyOk = true,
+                observedInspectionView = true,
+                inspectionViewUpdating = false,
+                hasSettledInspectionViewEvidence = false,
+                hasScopedMatcher = true,
+                scopedContextResultsEmpty = true,
+                bestResultsEmpty = true,
+                observedNonEmptyInspectionTree = false,
+                stableForMs = 5000L,
+                pollingElapsedMs = 30000L,
+            )
+        )
+
+        assertTrue(
+            shouldTrustStableScopedEmptyResults(
+                viewReadyOk = true,
+                observedInspectionView = true,
+                inspectionViewUpdating = false,
+                hasSettledInspectionViewEvidence = true,
+                hasScopedMatcher = true,
+                scopedContextResultsEmpty = true,
+                bestResultsEmpty = true,
+                observedNonEmptyInspectionTree = false,
                 stableForMs = 5000L,
                 pollingElapsedMs = 30000L,
             )


### PR DESCRIPTION
## Summary
- keep the scoped-empty capture shortcut behind settled usable inspection-view evidence once a view has been observed
- preserve the no-view scoped-empty fast path for tool-window-only captures
- add regression coverage for legacy path-like `project` routing selectors so stale review findings are pinned down in `inspection-core`

## Validation
- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test --tests 'com.shiny.inspectionmcp.InspectionSnapshotStateTest'\n- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :inspection-core:test --tests 'com.shiny.inspectionmcp.core.InspectionRoutingTest'\n- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew test\n- ./scripts/commit-gate.sh\n\nFollow-up to the late auto-review after v1.12.5.