### PR TITLE
Harden status drift and scoped empty recovery

### DIFF
--- a/mcp-server-jvm/src/main/kotlin/com/shiny/inspectionmcp/mcpserver/Main.kt
+++ b/mcp-server-jvm/src/main/kotlin/com/shiny/inspectionmcp/mcpserver/Main.kt
@@ -343,6 +343,7 @@ internal class ToolExecutor(
             val params = mutableListOf<Pair<String, String>>()
 
             val (result, target) = routeAndGet(autoPinnedArgs(args), "status", params)
+            ensurePinnedSessionStillValid("inspection_get_status", target)
 
             val text = prettyJson.encodeToString(JsonElement.serializer(), result) + buildStatusGuidance(result) + buildRouteGuidance(target)
             toolText(text)

--- a/mcp-server-jvm/src/test/kotlin/com/shiny/inspectionmcp/mcpserver/McpServerTest.kt
+++ b/mcp-server-jvm/src/test/kotlin/com/shiny/inspectionmcp/mcpserver/McpServerTest.kt
@@ -791,6 +791,31 @@ class McpServerTest {
     }
 
     @Test
+    fun autoRoutingRejectsStatusWhenPinnedSessionDrifts() {
+        MockIdeServer(identityProjectName = "project", identityBasePath = "/tmp/project", identitySessionId = "old").use { oldSession ->
+            MockIdeServer(identityProjectName = "project", identityBasePath = "/tmp/project", identitySessionId = "new").use { newSession ->
+                oldSession.start()
+                val executor = autoExecutor(oldSession, newSession)
+
+                val trigger = executor.handleToolCall(
+                    buildToolCall(
+                        "inspection_trigger",
+                        buildJsonObject { put("project_path", JsonPrimitive("/tmp/project")) },
+                    )
+                )
+                oldSession.close()
+                newSession.start()
+                val status = executor.handleToolCall(buildToolCall("inspection_get_status", buildJsonObject { }))
+
+                assertFalse(trigger.isError())
+                assertTrue(status.isError())
+                assertTrue(status.firstText().contains("restarted before inspection_get_status completed"))
+                assertTrue(status.firstText().contains("Re-trigger inspection"))
+            }
+        }
+    }
+
+    @Test
     fun excludedSessionsDoNotPoisonLaterAutoDiscovery() {
         MockIdeServer().use { server ->
             server.start()

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -1639,6 +1639,7 @@ class InspectionHandler : HttpRequestHandler() {
                         var compatibleToolWindowObservationCount = 0
                         var extractionFailureCount = if (extractedFromContextSucceeded) 0 else 1
                         var successfulExtractionCount = if (extractedFromContextSucceeded) 1 else 0
+                        var lastExtractionCycleSucceeded = extractedFromContextSucceeded
 
                         fun extractFromViewSafe(view: InspectionResultsView): List<Map<String, Any>> {
                             val app = ApplicationManager.getApplication()
@@ -1723,6 +1724,7 @@ class InspectionHandler : HttpRequestHandler() {
                                 viewReadyOk = true
                             }
 
+                            var viewExtractionSucceeded = false
                             if (viewReadyOk && view != null) {
                                 observedInspectionView = true
                                 val viewObservation = try {
@@ -1769,7 +1771,6 @@ class InspectionHandler : HttpRequestHandler() {
                                         readableEmptyInspectionViewStableSince = null
                                     }
                                 }
-                                var viewExtractionSucceeded = false
                                 val attempt = try {
                                     extractFromViewSafe(view)
                                         .also { viewExtractionSucceeded = true }
@@ -1803,6 +1804,7 @@ class InspectionHandler : HttpRequestHandler() {
                             if (toolExtractionSucceeded) {
                                 successfulExtractionCount += 1
                             }
+                            lastExtractionCycleSucceeded = (!observedInspectionView || viewExtractionSucceeded) && toolExtractionSucceeded
                             toolWindowObservationCount += 1
                             val compatibleToolResults = filterProblemsForScope(toolResults, scopeProblemMatcher)
                             if (compatibleToolResults.isNotEmpty()) {
@@ -1843,7 +1845,7 @@ class InspectionHandler : HttpRequestHandler() {
                                     inspectionViewUpdating = inspectionViewUpdating,
                                     hasSettledInspectionViewEvidence = observedSettledEmptyInspectionView ||
                                         observedStableReadableEmptyInspectionView,
-                                    extractionSucceeded = successfulExtractionCount > 0 && extractionFailureCount == 0,
+                                    extractionSucceeded = lastExtractionCycleSucceeded,
                                     scopedContextResultsEmpty = scopedContextResults.isEmpty(),
                                     bestResultsEmpty = bestResults.isEmpty(),
                                     observedNonEmptyInspectionTree = observedNonEmptyInspectionTree,
@@ -1886,7 +1888,7 @@ class InspectionHandler : HttpRequestHandler() {
                                 inspectionViewUpdating = inspectionViewUpdating,
                                 hasSettledInspectionViewEvidence = observedSettledEmptyInspectionView ||
                                     observedStableReadableEmptyInspectionView,
-                                extractionSucceeded = successfulExtractionCount > 0 && extractionFailureCount == 0,
+                                extractionSucceeded = lastExtractionCycleSucceeded,
                                 scopedContextResultsEmpty = scopedContextResults.isEmpty(),
                                 bestResultsEmpty = bestResults.isEmpty(),
                                 observedNonEmptyInspectionTree = observedNonEmptyInspectionTree,
@@ -1952,6 +1954,7 @@ class InspectionHandler : HttpRequestHandler() {
                                     "compatibleToolWindowObservationCount=$compatibleToolWindowObservationCount, " +
                                     "successfulExtractionCount=$successfulExtractionCount, " +
                                     "extractionFailureCount=$extractionFailureCount, " +
+                                    "lastExtractionCycleSucceeded=$lastExtractionCycleSucceeded, " +
                                     "readableEmptyInspectionViewStableForMs=${readableEmptyInspectionViewStableSince?.let { snapshot.timestamp - it } ?: 0L}, " +
                                     "lastViewObservation=${lastViewObservation?.let { "isUpdating=${it.isUpdating}, hasProblems=${it.hasProblems}, rootChildCount=${it.rootChildCount}, updateStateReadable=${it.updateStateReadable}, problemStateReadable=${it.problemStateReadable}" } ?: "null"}"
                             )

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
@@ -912,6 +912,19 @@ class InspectionSnapshotStateTest {
                 pollingElapsedMs = 30000L,
             )
         )
+
+        assertTrue(
+            shouldTrustStableScopedEmptyResults(
+                viewReadyOk = true,
+                extractionSucceeded = true,
+                hasScopedMatcher = true,
+                scopedContextResultsEmpty = true,
+                bestResultsEmpty = true,
+                observedNonEmptyInspectionTree = false,
+                stableForMs = 5000L,
+                pollingElapsedMs = 30000L,
+            )
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary
- make `inspection_get_status` enforce the same pinned-session drift guard as wait/problems
- allow scoped-empty clean confirmation to recover after transient extractor failures once the latest extraction cycle succeeds
- add MCP and snapshot regression tests for both paths

## Validation
- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :mcp-server-jvm:test --tests 'com.shiny.inspectionmcp.mcpserver.McpServerTest' :test --tests 'com.shiny.inspectionmcp.InspectionSnapshotStateTest'\n- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew test\n- ./scripts/commit-gate.sh\n\nPre-release hardening before v1.12.6.