### PR TITLE
Fix clean inspection capture fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,9 @@ workflows, and cleanup policy.
 
 - Plugin: Kotlin/Gradle (JetBrains 2025.x), requires Java 21.
 - MCP server: Kotlin/JVM (bundled in plugin, built via `mcp-server-jvm`).
+- Agent inspection helper: the external `jetbrains-inspection` skill wraps this
+  plugin through `scripts/jb-inspect.py`; keep its status/clean/capture
+  contracts in mind when changing HTTP inspection behavior.
 
 ## Always-on rules
 
@@ -22,6 +25,9 @@ workflows, and cleanup policy.
   "Operation not permitted" from NativeServices, re-run with escalation.
 - Prefer descriptive names to comments/docstrings; keep commentary minimal.
 - Avoid stale docs: keep this file evergreen and link to README for specifics.
+- If API status semantics, route metadata, clean/capture classification, or
+  MCP tool contracts change, check whether the installed or checked-out
+  `jetbrains-inspection` skill docs/tests/scripts need a matching update.
 
 ## Local-only overrides
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -46,6 +46,25 @@ start it with a test project, and hit a few API endpoints.
 
 - Configure your machine in `AGENTS.local.md` (copy from `AGENTS.local.template.md`).
 
+## Agent inspection helper
+
+The external `jetbrains-inspection` skill uses `scripts/jb-inspect.py` as an
+agent-facing wrapper around this plugin's HTTP API. Run it from the installed or
+checked-out skill when validating behavior the agents rely on:
+
+```bash
+HELPER="${CODEX_HOME:-$HOME/.code}/skills/jetbrains-inspection/scripts/jb-inspect.py"
+uv run "$HELPER" run \
+  --repo "$PWD" \
+  --scope changed_files
+```
+
+The helper treats `capture_incomplete`, stale results, timeouts, indexing,
+session drift, and route ambiguity as non-clean outcomes. When this repo changes
+inspection status semantics, route metadata, clean/capture classification, or
+MCP tool response contracts, update the skill docs/tests/scripts in
+the `jetbrains-inspection` skill as part of the same workstream.
+
 ## Local cleanup
 
 `./scripts/clean-local.sh` removes disposable local files such as `.DS_Store`

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -253,6 +253,35 @@ internal fun isReadableEmptyInspectionView(observation: InspectionViewObservatio
         !observation.hasProblems
 }
 
+internal fun isTransientUpdatingUnreadableEmptyCandidate(observation: InspectionViewObservation): Boolean {
+    return observation.updateStateReadable &&
+        observation.problemStateReadable &&
+        observation.isUpdating &&
+        !observation.hasProblems &&
+        observation.rootChildCount == 0
+}
+
+internal fun shouldPromoteStableReadableEmptyInspectionView(
+    readableEmptyInspectionViewStableSince: Long?,
+    readableEmptyInspectionViewObservationCount: Int,
+    transientUpdatingEmptyObservationCount: Int = 0,
+    inspectionViewUpdating: Boolean,
+    now: Long,
+    pollingElapsedMs: Long,
+    minStableMs: Long = 5000L,
+    minPollingMs: Long = 30000L,
+    minReadableEmptyObservations: Int = 2,
+    minTransientUpdatingEmptyObservations: Int = 5,
+): Boolean {
+    val stableSince = readableEmptyInspectionViewStableSince ?: return false
+    val hasEmptyEvidence = readableEmptyInspectionViewObservationCount >= minReadableEmptyObservations ||
+        transientUpdatingEmptyObservationCount >= minTransientUpdatingEmptyObservations
+    return hasEmptyEvidence &&
+        !inspectionViewUpdating &&
+        now - stableSince >= minStableMs &&
+        pollingElapsedMs >= minPollingMs
+}
+
 internal fun hasInspectionViewProblems(observation: InspectionViewObservation): Boolean {
     return observation.hasProblems
 }
@@ -396,6 +425,7 @@ internal fun shouldTrustStableScopedEmptyResults(
     observedInspectionView: Boolean = false,
     inspectionViewUpdating: Boolean = false,
     hasSettledInspectionViewEvidence: Boolean = false,
+    hasTransientEmptyInspectionViewEvidence: Boolean = false,
     extractionSucceeded: Boolean = true,
     hasScopedMatcher: Boolean,
     scopedContextResultsEmpty: Boolean,
@@ -405,9 +435,18 @@ internal fun shouldTrustStableScopedEmptyResults(
     pollingElapsedMs: Long,
     minStableMs: Long = 5000L,
     minPollingMs: Long = 30000L,
+    maxUpdatingInspectionViewWaitMs: Long = 60000L,
 ): Boolean {
+    val hasUsableInspectionViewEvidence = !observedInspectionView ||
+        (!inspectionViewUpdating && hasSettledInspectionViewEvidence) ||
+        (
+            inspectionViewUpdating &&
+                hasTransientEmptyInspectionViewEvidence &&
+                pollingElapsedMs >= maxUpdatingInspectionViewWaitMs
+        )
+
     return viewReadyOk &&
-        (!observedInspectionView || (!inspectionViewUpdating && hasSettledInspectionViewEvidence)) &&
+        hasUsableInspectionViewEvidence &&
         extractionSucceeded &&
         hasScopedMatcher &&
         scopedContextResultsEmpty &&
@@ -415,6 +454,15 @@ internal fun shouldTrustStableScopedEmptyResults(
         !observedNonEmptyInspectionTree &&
         stableForMs >= minStableMs &&
         pollingElapsedMs >= minPollingMs
+}
+
+internal fun shouldTreatScopedEmptyExtractionAsSucceeded(
+    lastExtractionCycleSucceeded: Boolean,
+    observedTransientEmptyInspectionViewEvidence: Boolean,
+    lastToolExtractionSucceeded: Boolean,
+): Boolean {
+    return lastExtractionCycleSucceeded ||
+        (observedTransientEmptyInspectionViewEvidence && lastToolExtractionSucceeded)
 }
 
 class InspectionHandler : HttpRequestHandler() {
@@ -1628,11 +1676,13 @@ class InspectionHandler : HttpRequestHandler() {
                         var observedStableReadableEmptyInspectionView = false
                         var observedStableEmptyResultsWithoutInspectionView = false
                         var observedNonEmptyInspectionTree = false
+                        var observedTransientEmptyInspectionViewEvidence = false
                         var inspectionViewUpdating = false
                         var lastViewObservation: InspectionViewObservation? = null
                         var readableEmptyInspectionViewStableSince: Long? = null
                         var inspectionViewObservationCount = 0
                         var readableEmptyInspectionViewObservationCount = 0
+                        var transientUpdatingEmptyObservationCount = 0
                         var unreadableProblemStateObservationCount = 0
                         var nullRootChildObservationCount = 0
                         var toolWindowObservationCount = 0
@@ -1640,6 +1690,12 @@ class InspectionHandler : HttpRequestHandler() {
                         var extractionFailureCount = if (extractedFromContextSucceeded) 0 else 1
                         var successfulExtractionCount = if (extractedFromContextSucceeded) 1 else 0
                         var lastExtractionCycleSucceeded = extractedFromContextSucceeded
+                        var lastToolExtractionSucceeded = false
+
+                        fun resetReadableEmptyInspectionViewEvidence() {
+                            readableEmptyInspectionViewStableSince = null
+                            readableEmptyInspectionViewObservationCount = 0
+                        }
 
                         fun extractFromViewSafe(view: InspectionResultsView): List<Map<String, Any>> {
                             val app = ApplicationManager.getApplication()
@@ -1754,7 +1810,8 @@ class InspectionHandler : HttpRequestHandler() {
                                 when {
                                     hasInspectionViewProblems(viewObservation) -> {
                                         observedNonEmptyInspectionTree = true
-                                        readableEmptyInspectionViewStableSince = null
+                                        resetReadableEmptyInspectionViewEvidence()
+                                        transientUpdatingEmptyObservationCount = 0
                                     }
                                     isSettledCleanInspectionView(viewObservation) -> {
                                         observedSettledEmptyInspectionView = true
@@ -1767,8 +1824,17 @@ class InspectionHandler : HttpRequestHandler() {
                                             readableEmptyInspectionViewStableSince = loopNow
                                         }
                                     }
+                                    isTransientUpdatingUnreadableEmptyCandidate(viewObservation) &&
+                                        !observedNonEmptyInspectionTree -> {
+                                        observedTransientEmptyInspectionViewEvidence = true
+                                        transientUpdatingEmptyObservationCount += 1
+                                        if (readableEmptyInspectionViewStableSince == null) {
+                                            readableEmptyInspectionViewStableSince = loopNow
+                                        }
+                                    }
                                     else -> {
-                                        readableEmptyInspectionViewStableSince = null
+                                        resetReadableEmptyInspectionViewEvidence()
+                                        transientUpdatingEmptyObservationCount = 0
                                     }
                                 }
                                 val attempt = try {
@@ -1804,6 +1870,7 @@ class InspectionHandler : HttpRequestHandler() {
                             if (toolExtractionSucceeded) {
                                 successfulExtractionCount += 1
                             }
+                            lastToolExtractionSucceeded = toolExtractionSucceeded
                             lastExtractionCycleSucceeded = (!observedInspectionView || viewExtractionSucceeded) && toolExtractionSucceeded
                             toolWindowObservationCount += 1
                             val compatibleToolResults = filterProblemsForScope(toolResults, scopeProblemMatcher)
@@ -1830,9 +1897,14 @@ class InspectionHandler : HttpRequestHandler() {
                             val pollingElapsedMs = loopNow - captureStartMs
                             if (
                                 !observedStableReadableEmptyInspectionView &&
-                                readableEmptyInspectionViewStableSince != null &&
-                                loopNow - readableEmptyInspectionViewStableSince >= 5000L &&
-                                pollingElapsedMs >= 30000L
+                                shouldPromoteStableReadableEmptyInspectionView(
+                                    readableEmptyInspectionViewStableSince = readableEmptyInspectionViewStableSince,
+                                    readableEmptyInspectionViewObservationCount = readableEmptyInspectionViewObservationCount,
+                                    transientUpdatingEmptyObservationCount = transientUpdatingEmptyObservationCount,
+                                    inspectionViewUpdating = inspectionViewUpdating,
+                                    now = loopNow,
+                                    pollingElapsedMs = pollingElapsedMs,
+                                )
                             ) {
                                 observedStableReadableEmptyInspectionView = true
                             }
@@ -1845,7 +1917,12 @@ class InspectionHandler : HttpRequestHandler() {
                                     inspectionViewUpdating = inspectionViewUpdating,
                                     hasSettledInspectionViewEvidence = observedSettledEmptyInspectionView ||
                                         observedStableReadableEmptyInspectionView,
-                                    extractionSucceeded = lastExtractionCycleSucceeded,
+                                    hasTransientEmptyInspectionViewEvidence = observedTransientEmptyInspectionViewEvidence,
+                                    extractionSucceeded = shouldTreatScopedEmptyExtractionAsSucceeded(
+                                        lastExtractionCycleSucceeded = lastExtractionCycleSucceeded,
+                                        observedTransientEmptyInspectionViewEvidence = observedTransientEmptyInspectionViewEvidence,
+                                        lastToolExtractionSucceeded = lastToolExtractionSucceeded,
+                                    ),
                                     scopedContextResultsEmpty = scopedContextResults.isEmpty(),
                                     bestResultsEmpty = bestResults.isEmpty(),
                                     observedNonEmptyInspectionTree = observedNonEmptyInspectionTree,
@@ -1888,7 +1965,12 @@ class InspectionHandler : HttpRequestHandler() {
                                 inspectionViewUpdating = inspectionViewUpdating,
                                 hasSettledInspectionViewEvidence = observedSettledEmptyInspectionView ||
                                     observedStableReadableEmptyInspectionView,
-                                extractionSucceeded = lastExtractionCycleSucceeded,
+                                hasTransientEmptyInspectionViewEvidence = observedTransientEmptyInspectionViewEvidence,
+                                extractionSucceeded = shouldTreatScopedEmptyExtractionAsSucceeded(
+                                    lastExtractionCycleSucceeded = lastExtractionCycleSucceeded,
+                                    observedTransientEmptyInspectionViewEvidence = observedTransientEmptyInspectionViewEvidence,
+                                    lastToolExtractionSucceeded = lastToolExtractionSucceeded,
+                                ),
                                 scopedContextResultsEmpty = scopedContextResults.isEmpty(),
                                 bestResultsEmpty = bestResults.isEmpty(),
                                 observedNonEmptyInspectionTree = observedNonEmptyInspectionTree,
@@ -1945,9 +2027,11 @@ class InspectionHandler : HttpRequestHandler() {
                                     "observedStableReadableEmptyInspectionView=$observedStableReadableEmptyInspectionView, " +
                                     "observedStableEmptyResultsWithoutInspectionView=$observedStableEmptyResultsWithoutInspectionView, " +
                                     "observedNonEmptyInspectionTree=$observedNonEmptyInspectionTree, " +
+                                    "observedTransientEmptyInspectionViewEvidence=$observedTransientEmptyInspectionViewEvidence, " +
                                     "inspectionViewUpdating=$inspectionViewUpdating, " +
                                     "inspectionViewObservationCount=$inspectionViewObservationCount, " +
                                     "readableEmptyInspectionViewObservationCount=$readableEmptyInspectionViewObservationCount, " +
+                                    "transientUpdatingEmptyObservationCount=$transientUpdatingEmptyObservationCount, " +
                                     "unreadableProblemStateObservationCount=$unreadableProblemStateObservationCount, " +
                                     "nullRootChildObservationCount=$nullRootChildObservationCount, " +
                                     "toolWindowObservationCount=$toolWindowObservationCount, " +
@@ -1955,6 +2039,7 @@ class InspectionHandler : HttpRequestHandler() {
                                     "successfulExtractionCount=$successfulExtractionCount, " +
                                     "extractionFailureCount=$extractionFailureCount, " +
                                     "lastExtractionCycleSucceeded=$lastExtractionCycleSucceeded, " +
+                                    "lastToolExtractionSucceeded=$lastToolExtractionSucceeded, " +
                                     "readableEmptyInspectionViewStableForMs=${readableEmptyInspectionViewStableSince?.let { snapshot.timestamp - it } ?: 0L}, " +
                                     "lastViewObservation=${lastViewObservation?.let { "isUpdating=${it.isUpdating}, hasProblems=${it.hasProblems}, rootChildCount=${it.rootChildCount}, updateStateReadable=${it.updateStateReadable}, problemStateReadable=${it.problemStateReadable}" } ?: "null"}"
                             )
@@ -2485,10 +2570,6 @@ class InspectionHandler : HttpRequestHandler() {
             "project",
             "Multiple open projects matched this request. Retry with project_path or project_key.",
         )
-    }
-
-    private fun getProjectByName(projectName: String): Project? {
-        return resolveProjectSelector(projectName)
     }
 
     private fun projectMatches(project: Project, projectName: String, pathHint: String?): Boolean {

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -902,7 +902,7 @@ class InspectionHandlerTest {
     }
     
     @Test
-    fun `test getProjectByName returns correct project`() {
+    fun `test resolveProjectSelector returns correct project`() {
         val mockProject1 = mockk<Project>()
         val mockProject2 = mockk<Project>()
         
@@ -919,7 +919,7 @@ class InspectionHandlerTest {
         every { mockProjectManager.openProjects } returns arrayOf(mockProject2, mockProject1)
         
         val handler = InspectionHandler()
-        val method = InspectionHandler::class.java.getDeclaredMethod("getProjectByName", String::class.java)
+        val method = InspectionHandler::class.java.getDeclaredMethod("resolveProjectSelector", String::class.java)
         method.isAccessible = true
         
         val result = method.invoke(handler, "TargetProject") as Project?

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
@@ -841,6 +841,108 @@ class InspectionSnapshotStateTest {
     }
 
     @Test
+    @DisplayName("Transient updating unreadable empty views provide guarded clean evidence")
+    fun testTransientUpdatingUnreadableEmptyViewEvidence() {
+        val transientUpdatingUnreadableEmpty = InspectionViewObservation(
+            isUpdating = true,
+            hasProblems = false,
+            rootChildCount = 0,
+            updateStateReadable = true,
+            problemStateReadable = true,
+        )
+
+        assertTrue(isTransientUpdatingUnreadableEmptyCandidate(transientUpdatingUnreadableEmpty))
+        assertFalse(isTransientUpdatingUnreadableEmptyCandidate(transientUpdatingUnreadableEmpty.copy(hasProblems = true)))
+        assertFalse(isTransientUpdatingUnreadableEmptyCandidate(transientUpdatingUnreadableEmpty.copy(updateStateReadable = false)))
+        assertFalse(isTransientUpdatingUnreadableEmptyCandidate(transientUpdatingUnreadableEmpty.copy(problemStateReadable = false)))
+        assertFalse(isTransientUpdatingUnreadableEmptyCandidate(transientUpdatingUnreadableEmpty.copy(isUpdating = false)))
+        assertFalse(isTransientUpdatingUnreadableEmptyCandidate(transientUpdatingUnreadableEmpty.copy(rootChildCount = null)))
+        assertFalse(isTransientUpdatingUnreadableEmptyCandidate(transientUpdatingUnreadableEmpty.copy(rootChildCount = 1)))
+    }
+
+    @Test
+    @DisplayName("Stable readable empty views require repeated positive evidence")
+    fun testStableReadableEmptyViewRequiresRepeatedPositiveEvidence() {
+        assertFalse(
+            shouldPromoteStableReadableEmptyInspectionView(
+                readableEmptyInspectionViewStableSince = 1000L,
+                readableEmptyInspectionViewObservationCount = 1,
+                inspectionViewUpdating = false,
+                now = 7000L,
+                pollingElapsedMs = 30000L,
+            )
+        )
+
+        assertTrue(
+            shouldPromoteStableReadableEmptyInspectionView(
+                readableEmptyInspectionViewStableSince = 1000L,
+                readableEmptyInspectionViewObservationCount = 2,
+                inspectionViewUpdating = false,
+                now = 7000L,
+                pollingElapsedMs = 30000L,
+            )
+        )
+
+        assertFalse(
+            shouldPromoteStableReadableEmptyInspectionView(
+                readableEmptyInspectionViewStableSince = 1000L,
+                readableEmptyInspectionViewObservationCount = 2,
+                inspectionViewUpdating = false,
+                now = 7000L,
+                pollingElapsedMs = 29999L,
+            )
+        )
+    }
+
+    @Test
+    @DisplayName("Stable transient empty views require repeated guarded evidence")
+    fun testStableTransientEmptyViewRequiresRepeatedGuardedEvidence() {
+        assertFalse(
+            shouldPromoteStableReadableEmptyInspectionView(
+                readableEmptyInspectionViewStableSince = 1000L,
+                readableEmptyInspectionViewObservationCount = 0,
+                transientUpdatingEmptyObservationCount = 4,
+                inspectionViewUpdating = false,
+                now = 7000L,
+                pollingElapsedMs = 30000L,
+            )
+        )
+
+        assertTrue(
+            shouldPromoteStableReadableEmptyInspectionView(
+                readableEmptyInspectionViewStableSince = 1000L,
+                readableEmptyInspectionViewObservationCount = 0,
+                transientUpdatingEmptyObservationCount = 5,
+                inspectionViewUpdating = false,
+                now = 7000L,
+                pollingElapsedMs = 30000L,
+            )
+        )
+
+        assertFalse(
+            shouldPromoteStableReadableEmptyInspectionView(
+                readableEmptyInspectionViewStableSince = 1000L,
+                readableEmptyInspectionViewObservationCount = 0,
+                transientUpdatingEmptyObservationCount = 5,
+                inspectionViewUpdating = false,
+                now = 7000L,
+                pollingElapsedMs = 29999L,
+            )
+        )
+
+        assertFalse(
+            shouldPromoteStableReadableEmptyInspectionView(
+                readableEmptyInspectionViewStableSince = 1000L,
+                readableEmptyInspectionViewObservationCount = 0,
+                transientUpdatingEmptyObservationCount = 5,
+                inspectionViewUpdating = true,
+                now = 7000L,
+                pollingElapsedMs = 30000L,
+            )
+        )
+    }
+
+    @Test
     @DisplayName("Stable scoped empty results can confirm clean without readable view evidence")
     fun testStableScopedEmptyResultsConfirmCleanBeforeDeadline() {
         assertFalse(
@@ -949,6 +1051,51 @@ class InspectionSnapshotStateTest {
             shouldTrustStableScopedEmptyResults(
                 viewReadyOk = true,
                 observedInspectionView = true,
+                inspectionViewUpdating = true,
+                hasTransientEmptyInspectionViewEvidence = true,
+                hasScopedMatcher = true,
+                scopedContextResultsEmpty = true,
+                bestResultsEmpty = true,
+                observedNonEmptyInspectionTree = false,
+                stableForMs = 5000L,
+                pollingElapsedMs = 59999L,
+            )
+        )
+
+        assertFalse(
+            shouldTrustStableScopedEmptyResults(
+                viewReadyOk = true,
+                observedInspectionView = true,
+                inspectionViewUpdating = true,
+                hasTransientEmptyInspectionViewEvidence = true,
+                hasScopedMatcher = true,
+                scopedContextResultsEmpty = true,
+                bestResultsEmpty = true,
+                observedNonEmptyInspectionTree = true,
+                stableForMs = 5000L,
+                pollingElapsedMs = 60000L,
+            )
+        )
+
+        assertTrue(
+            shouldTrustStableScopedEmptyResults(
+                viewReadyOk = true,
+                observedInspectionView = true,
+                inspectionViewUpdating = true,
+                hasTransientEmptyInspectionViewEvidence = true,
+                hasScopedMatcher = true,
+                scopedContextResultsEmpty = true,
+                bestResultsEmpty = true,
+                observedNonEmptyInspectionTree = false,
+                stableForMs = 5000L,
+                pollingElapsedMs = 60000L,
+            )
+        )
+
+        assertFalse(
+            shouldTrustStableScopedEmptyResults(
+                viewReadyOk = true,
+                observedInspectionView = true,
                 inspectionViewUpdating = false,
                 hasSettledInspectionViewEvidence = false,
                 hasScopedMatcher = true,
@@ -972,6 +1119,42 @@ class InspectionSnapshotStateTest {
                 observedNonEmptyInspectionTree = false,
                 stableForMs = 5000L,
                 pollingElapsedMs = 30000L,
+            )
+        )
+    }
+
+    @Test
+    @DisplayName("Safe transient empty view evidence latches for scoped empty extraction")
+    fun testTransientEmptyEvidenceCanUseSuccessfulToolExtraction() {
+        assertFalse(
+            shouldTreatScopedEmptyExtractionAsSucceeded(
+                lastExtractionCycleSucceeded = false,
+                observedTransientEmptyInspectionViewEvidence = false,
+                lastToolExtractionSucceeded = true,
+            )
+        )
+
+        assertFalse(
+            shouldTreatScopedEmptyExtractionAsSucceeded(
+                lastExtractionCycleSucceeded = false,
+                observedTransientEmptyInspectionViewEvidence = true,
+                lastToolExtractionSucceeded = false,
+            )
+        )
+
+        assertTrue(
+            shouldTreatScopedEmptyExtractionAsSucceeded(
+                lastExtractionCycleSucceeded = false,
+                observedTransientEmptyInspectionViewEvidence = true,
+                lastToolExtractionSucceeded = true,
+            )
+        )
+
+        assertTrue(
+            shouldTreatScopedEmptyExtractionAsSucceeded(
+                lastExtractionCycleSucceeded = true,
+                observedTransientEmptyInspectionViewEvidence = false,
+                lastToolExtractionSucceeded = false,
             )
         )
     }


### PR DESCRIPTION
## Summary
- Confirm clean inspection snapshots when JetBrains exposes a safe empty/updating inspection view and then only stable empty scoped extraction remains available.
- Keep clean confirmation guarded by readable empty-tree evidence, no observed non-empty inspection tree, successful extraction, and settle windows.
- Document the current agent inspection helper contract and keep helper docs/tests/scripts aligned with HTTP/MCP status changes.

## Validation
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew test`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew buildPlugin`
- Installed rebuilt plugin into IntelliJ IDEA, PyCharm, and WebStorm 2026.1; restarted IDEs.
- PyCharm smoke: `discord-blue/discord_blue/config.py` clean, `capture_incomplete=false`, `results_may_be_stale=false`, `snapshot_outcome=clean_confirmed`.
- WebStorm smoke: `verireel/scripts/ops/manage-db-helpers.mjs` clean, `capture_incomplete=false`, `results_may_be_stale=false`, `snapshot_outcome=clean_confirmed`.
- IntelliJ IDEA smoke: this repo changed files clean, `capture_incomplete=false`, `results_may_be_stale=false`, `snapshot_outcome=clean_confirmed`.
