### PR TITLE
Fix stale inspection result contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,9 +13,10 @@ workflows, and cleanup policy.
 
 - Plugin: Kotlin/Gradle (JetBrains 2025.x), requires Java 21.
 - MCP server: Kotlin/JVM (bundled in plugin, built via `mcp-server-jvm`).
-- Agent inspection helper: the external `jetbrains-inspection` skill wraps this
-  plugin through `scripts/jb-inspect.py`; keep its status/clean/capture
-  contracts in mind when changing HTTP inspection behavior.
+- Agent inspection helper: the external `jetbrains-inspection` skill's
+  `scripts/jb-inspect.py` is the primary LLM-facing path for this plugin; keep
+  its status/clean/capture contracts in mind when changing HTTP inspection
+  behavior.
 
 ## Always-on rules
 

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Notes:
 - `locationKnown=false` means the IDE did not provide a stable file/line (often stale results). Use `locationNote` and re-run inspection.
 - `status: "no_results"` uses the same pagination, filters, `total_problems`, `problems_shown`, and `problems` fields as result responses, with an empty problems list.
 - `status: "capture_incomplete"` means an inspection finished, but the plugin could not conclusively capture the IDE results. Re-run the inspection or open the Problems/Inspection Results view before treating the project as clean.
-- `status: "stale_results"` means project files changed after the last inspection. Trigger a new inspection before trusting cached findings.
+- `status: "stale_results"` means project files changed after the last inspection. It is not a clean result. Cached findings are withheld by default; call `/problems?include_stale=true` only when explicitly diagnosing cached data.
 - `session_drift: true` means the client sent an old `session_id`; the IDE/plugin session restarted or the port was reused.
 
 ## API Reference
@@ -293,6 +293,7 @@ seconds, and optionally scan `JETBRAINS_INSPECTION_PORTS` such as
   Use `all` or leave blank to disable the filter.
 - `limit` (optional): Maximum problems to return, `1..1000` (default: 100)
 - `offset` (optional): Number of problems to skip for pagination, `>=0` (default: 0)
+- `include_stale` (optional): `true` returns cached stale findings for diagnostics when `status` is `stale_results`. Defaults to `false`; stale findings must not be treated as current.
 - `project` (optional): Blank or omitted uses the focused or active open project. Nonblank values must match an open project.
 - `project_key`, `project_path`, `worktree_path`, `cwd` (optional): Route selectors for stateless clients.
 - `session_id` (optional): Expected IDE session; mismatches return HTTP 409 with `session_drift: true`.
@@ -313,6 +314,9 @@ curl "http://localhost:63340/api/inspection/problems?limit=50&offset=50"
 
 # Combine filters for precise results
 curl "http://localhost:63340/api/inspection/problems?severity=error&file_pattern=src/&problem_type=TypeScript"
+
+# Diagnose cached stale findings without treating them as current
+curl "http://localhost:63340/api/inspection/problems?include_stale=true"
 ```
 
 ### Trigger Endpoint
@@ -439,7 +443,7 @@ The status endpoint includes a `clean_inspection` field that makes the outcome e
 
 **Status Indicators**:
 - `is_scanning: true` → Inspection running, wait
-- `results_may_be_stale: true` → Project changed after the last inspection; trigger again before trusting cached results
+- `results_may_be_stale: true` → Project changed after the last inspection; trigger again before trusting results
 - `clean_inspection: true` → Inspection complete. No problems found
 - `has_inspection_results: true` → Problems found, retrieve with `/problems`
 - If all three are false and `time_since_last_trigger_ms` is recent, the inspection finished but results were not captured. Re-run the inspection or open the Inspection Results tool window.
@@ -453,14 +457,14 @@ Common completion reasons:
 - `clean`: inspection completed and a clean empty result was confirmed.
 - `no_results`: inspection finished, but no results were captured. This can be a clean run or an unavailable/filtered IDE view.
 - `capture_incomplete`: inspection finished, but the plugin could not conclusively capture the IDE results. Re-run the inspection or open the Problems/Inspection Results view.
-- `stale_results`: cached results exist, but project files changed after the last inspection. Trigger again before trusting findings.
+- `stale_results`: cached results exist, but project files changed after the last inspection. Trigger again before trusting findings. Wait responses expose cached counts as `cached_total_problems`, not `total_problems`.
 - `no_recent_inspection`: no inspection run is known for the selected project. Trigger one first.
 - `no_project`: no matching project was open during the wait period. This is not reported as `timed_out`; open a project or pass the exact project name.
 
 ### Freshness Notes
 - The plugin saves documents and refreshes external file changes before starting a new inspection run.
 - `/api/inspection/status` and `/api/inspection/problems` refresh project state before evaluating cached snapshots.
-- If the project changed after the last inspection, `/api/inspection/status` sets `results_may_be_stale: true` and `/api/inspection/problems` returns `status: "stale_results"` instead of serving stale findings.
+- If the project changed after the last inspection, `/api/inspection/status` sets `results_may_be_stale: true` and `/api/inspection/problems` returns `status: "stale_results"`. By default, the response includes cached metadata such as `cached_total_problems` and withholds `problems`; `include_stale=true` returns cached findings for diagnostics while keeping `status: "stale_results"`.
 
 ## MCP Server Details
 
@@ -472,7 +476,7 @@ The bundled JVM MCP (Model Context Protocol) server provides integration for any
   - Also supports `scope=files` with `file=...` (repeat) or `files=[...]`, and `scope=changed_files` with `include_unversioned` and `max_files`.
 - **`inspection_get_status()`** - Checks inspection status
 - **`inspection_wait(timeout_ms?, poll_ms?)`** - Long-poll until results or timeout
-- **`inspection_get_problems(scope?, severity?, problem_type?, file_pattern?, limit?, offset?)`** - Gets inspection problems with filtering and pagination
+- **`inspection_get_problems(scope?, severity?, problem_type?, file_pattern?, limit?, offset?, include_stale?)`** - Gets inspection problems with filtering and pagination. `include_stale` returns cached stale findings for diagnostics only.
 
 ### Requirements
 - **Java 21+** (or the IDE's bundled runtime)

--- a/TESTING.md
+++ b/TESTING.md
@@ -48,9 +48,9 @@ start it with a test project, and hit a few API endpoints.
 
 ## Agent inspection helper
 
-The external `jetbrains-inspection` skill uses `scripts/jb-inspect.py` as an
-agent-facing wrapper around this plugin's HTTP API. Run it from the installed or
-checked-out skill when validating behavior the agents rely on:
+The external `jetbrains-inspection` skill uses `scripts/jb-inspect.py` as the
+primary agent-facing wrapper around this plugin's HTTP API. Run it from the
+installed or checked-out skill when validating behavior the agents rely on:
 
 ```bash
 HELPER="${CODEX_HOME:-$HOME/.code}/skills/jetbrains-inspection/scripts/jb-inspect.py"
@@ -60,10 +60,12 @@ uv run "$HELPER" run \
 ```
 
 The helper treats `capture_incomplete`, stale results, timeouts, indexing,
-session drift, and route ambiguity as non-clean outcomes. When this repo changes
-inspection status semantics, route metadata, clean/capture classification, or
-MCP tool response contracts, update the skill docs/tests/scripts in
-the `jetbrains-inspection` skill as part of the same workstream.
+session drift, and route ambiguity as non-clean outcomes. Cached stale findings
+are returned only when the helper is run with `--include-stale` for explicit
+diagnostics. When this repo changes inspection status semantics, route metadata,
+clean/capture classification, or MCP tool response contracts, update the skill
+docs/tests/scripts in the `jetbrains-inspection` skill as part of the same
+workstream.
 
 ## Local cleanup
 

--- a/mcp-server-jvm/src/main/kotlin/com/shiny/inspectionmcp/mcpserver/Main.kt
+++ b/mcp-server-jvm/src/main/kotlin/com/shiny/inspectionmcp/mcpserver/Main.kt
@@ -211,7 +211,7 @@ internal class ToolExecutor(
                     put(
                         "description",
                         JsonPrimitive(
-                            "Fetch problems after inspection completes. Typical flow: inspection_trigger -> inspection_wait -> inspection_get_problems. In auto mode, pass project_path or project_key when available; selector-less calls follow the last triggered project when possible. capture_incomplete means do not treat as clean; retry once, preferably with a narrower scope."
+                            "Fetch problems after inspection completes. Typical flow: inspection_trigger -> inspection_wait -> inspection_get_problems. In auto mode, pass project_path or project_key when available; selector-less calls follow the last triggered project when possible. capture_incomplete means do not treat as clean; retry once, preferably with a narrower scope. stale_results withholds cached findings by default; pass include_stale only when explicitly diagnosing cached data."
                         )
                     )
                     put("inputSchema", getProblemsSchema())
@@ -286,6 +286,9 @@ internal class ToolExecutor(
             val offset = args.int("offset") ?: 0
             if (limit != 100) params += "limit" to limit.toString()
             if (offset != 0) params += "offset" to offset.toString()
+            if (args["include_stale"]?.jsonPrimitive?.booleanOrNull == true) {
+                params += "include_stale" to "true"
+            }
 
             val (result, target) = routeAndGet(autoPinnedArgs(args), "problems", params)
             ensurePinnedSessionStillValid("inspection_get_problems", target)
@@ -470,7 +473,7 @@ internal class ToolExecutor(
 
         val guidance = when {
             status == "stale_results" ->
-                "\n\nWARN: Cached inspection results are stale because the project changed after the last run. Trigger a new inspection before trusting these findings."
+                "\n\nWARN: Cached inspection results are stale because the project changed after the last run. Trigger a new inspection before trusting these findings. Pass include_stale=true only for explicit cached-result diagnostics."
             status == "capture_incomplete" ->
                 "\n\nWARN: capture_incomplete - do not treat as clean. Retry once, preferably with a narrower scope; if it repeats, report it."
             status == "no_results" ->
@@ -698,6 +701,10 @@ internal class ToolExecutor(
                     "offset",
                     intProp("Pagination offset", defaultValue = 0, minimum = 0)
                 )
+                put("include_stale", buildJsonObject {
+                    put("type", JsonPrimitive("boolean"))
+                    put("description", JsonPrimitive("Return cached stale findings for diagnostics. Default false; stale findings must not be treated as current."))
+                })
             })
         }
     }

--- a/mcp-server-jvm/src/test/kotlin/com/shiny/inspectionmcp/mcpserver/McpServerTest.kt
+++ b/mcp-server-jvm/src/test/kotlin/com/shiny/inspectionmcp/mcpserver/McpServerTest.kt
@@ -160,6 +160,7 @@ class McpServerTest {
             val args = buildJsonObject {
                 put("file_pattern", JsonPrimitive("my file.js"))
                 put("limit", JsonPrimitive(10))
+                put("include_stale", JsonPrimitive(true))
             }
 
             val response = executor.handleToolCall(buildToolCall("inspection_get_problems", args))
@@ -169,6 +170,7 @@ class McpServerTest {
             val query = server.lastQuery.get() ?: ""
             assertTrue(query.contains("file_pattern=my+file.js"))
             assertTrue(query.contains("limit=10"))
+            assertTrue(query.contains("include_stale=true"))
         }
     }
 
@@ -253,7 +255,10 @@ class McpServerTest {
             val executor = ToolExecutor(server.baseUrl, HttpClient.newHttpClient(), server.port.toString())
 
             val result = executor.handleToolCall(buildToolCall("inspection_get_problems", buildJsonObject { }))
-            assertTrue(result.firstText().contains("results are stale"))
+            val text = result.firstText()
+            assertTrue(text.contains("results are stale"))
+            assertTrue(text.contains("include_stale=true"))
+            assertTrue(text.contains("explicit cached-result diagnostics"))
         }
     }
 

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -261,6 +261,14 @@ internal fun isTransientUpdatingUnreadableEmptyCandidate(observation: Inspection
         observation.rootChildCount == 0
 }
 
+internal fun isOpaqueSettledEmptyInspectionViewCandidate(observation: InspectionViewObservation): Boolean {
+    return observation.updateStateReadable &&
+        observation.problemStateReadable &&
+        !observation.isUpdating &&
+        !observation.hasProblems &&
+        observation.rootChildCount == null
+}
+
 internal fun shouldPromoteStableReadableEmptyInspectionView(
     readableEmptyInspectionViewStableSince: Long?,
     readableEmptyInspectionViewObservationCount: Int,
@@ -425,6 +433,7 @@ internal fun shouldTrustStableScopedEmptyResults(
     observedInspectionView: Boolean = false,
     inspectionViewUpdating: Boolean = false,
     hasSettledInspectionViewEvidence: Boolean = false,
+    hasOpaqueSettledEmptyInspectionViewEvidence: Boolean = false,
     hasTransientEmptyInspectionViewEvidence: Boolean = false,
     extractionSucceeded: Boolean = true,
     hasScopedMatcher: Boolean,
@@ -439,6 +448,7 @@ internal fun shouldTrustStableScopedEmptyResults(
 ): Boolean {
     val hasUsableInspectionViewEvidence = !observedInspectionView ||
         (!inspectionViewUpdating && hasSettledInspectionViewEvidence) ||
+        (!inspectionViewUpdating && hasOpaqueSettledEmptyInspectionViewEvidence && extractionSucceeded) ||
         (
             inspectionViewUpdating &&
                 hasTransientEmptyInspectionViewEvidence &&
@@ -533,10 +543,11 @@ class InspectionHandler : HttpRequestHandler() {
                     val filePattern = normalizeOptionalFilter(filePatternRaw)
                     val limit = parseIntParameter(parameters, "limit", defaultValue = 100, min = 1, max = 1000)
                     val offset = parseIntParameter(parameters, "offset", defaultValue = 0, min = 0)
+                    val includeStale = parameters["include_stale"]?.firstOrNull()?.equals("true", ignoreCase = true) ?: false
                     val projectName = extractProjectSelector(urlDecoder, request)
                     withCurrentProject(context, projectName, refreshProjectState = true) { project ->
                         val result = ApplicationManager.getApplication().runReadAction<String, Exception> {
-                            getInspectionProblems(project, severity, scope, problemType, filePattern, limit, offset)
+                            getInspectionProblems(project, severity, scope, problemType, filePattern, limit, offset, includeStale)
                         }
                         sendJsonResponse(context, result)
                     }
@@ -866,7 +877,8 @@ class InspectionHandler : HttpRequestHandler() {
         problemType: String? = null,
         filePattern: String? = null,
         limit: Int = 100,
-        offset: Int = 0
+        offset: Int = 0,
+        includeStale: Boolean = false,
     ): String {
         return try {
             val normalizedScope = normalizeProblemsScope(scope)
@@ -875,7 +887,18 @@ class InspectionHandler : HttpRequestHandler() {
             val hasSnapshot = snapshot != null
             val staleness = getSnapshotStaleness(project)
             if (hasSnapshot && staleness.stale) {
-                val response = mapOf(
+                val cachedProblems = snapshot.problems
+                val currentFilePath = resolveCurrentFilePath(project, normalizedScope)
+                val filteredCachedProblems = filterProblems(
+                    problems = cachedProblems,
+                    severity = severity,
+                    scope = normalizedScope,
+                    currentFilePath = currentFilePath,
+                    problemType = problemType,
+                    filePattern = filePattern,
+                )
+                val page = paginateProblems(filteredCachedProblems, limit, offset)
+                val staleBase = mutableMapOf<String, Any?>(
                     "status" to "stale_results",
                     "project" to project.name,
                     "project_key" to key,
@@ -885,6 +908,11 @@ class InspectionHandler : HttpRequestHandler() {
                     "message" to "Project files changed since the last inspection. Trigger a new inspection before trusting these results.",
                     "results_may_be_stale" to true,
                     "stale_reasons" to staleness.reasons,
+                    "snapshot_outcome" to snapshot.outcome.apiValue,
+                    "results_source" to snapshot.source,
+                    "results_timestamp_ms" to snapshot.timestamp,
+                    "cached_total_problems" to filteredCachedProblems.size,
+                    "cached_problems_shown" to if (includeStale) page.shown else 0,
                     "filters" to mapOf(
                         "severity" to severity,
                         "scope" to normalizedScope,
@@ -892,7 +920,20 @@ class InspectionHandler : HttpRequestHandler() {
                         "file_pattern" to (filePattern ?: "all")
                     )
                 )
-                return formatJsonManually(response)
+                if (includeStale) {
+                    staleBase["message"] = "Project files changed since the last inspection. Returning cached findings because include_stale=true; trigger a new inspection before acting on them."
+                    staleBase["include_stale"] = true
+                    staleBase["problems"] = page.problems
+                    staleBase["pagination"] = mapOf(
+                        "limit" to limit,
+                        "offset" to offset,
+                        "has_more" to page.hasMore,
+                        "next_offset" to page.nextOffset,
+                    )
+                } else {
+                    staleBase["include_stale"] = false
+                }
+                return formatJsonManually(staleBase.filterValues { it != null })
             }
             snapshot = reconcileSnapshotWithLiveProblems(project, snapshot)
             if (snapshot != null && snapshot.outcome == InspectionSnapshotOutcome.CAPTURE_INCOMPLETE) {
@@ -936,19 +977,7 @@ class InspectionHandler : HttpRequestHandler() {
             }
             
             if (problems.isNotEmpty() || hasSnapshot) {
-                val currentFilePath = if (normalizedScope == "current_file") {
-                    try {
-                        FileEditorManager
-                            .getInstance(project)
-                            .selectedFiles
-                            .firstOrNull()
-                            ?.path
-                    } catch (_: Exception) {
-                        null
-                    }
-                } else {
-                    null
-                }
+                val currentFilePath = resolveCurrentFilePath(project, normalizedScope)
 
                 val filteredProblems = filterProblems(
                     problems = problems,
@@ -1098,7 +1127,11 @@ class InspectionHandler : HttpRequestHandler() {
         } else {
             problemsSnapshot.isNotEmpty()
         }
-        status["total_problems"] = problemsSnapshot.size
+        if (hasInspectionSnapshot && staleness.stale) {
+            status["cached_total_problems"] = problemsSnapshot.size
+        } else {
+            status["total_problems"] = problemsSnapshot.size
+        }
         status["results_source"] = snapshot?.source ?: "tool_window"
         status["results_may_be_stale"] = hasInspectionSnapshot && staleness.stale
         if (snapshot != null) {
@@ -1195,6 +1228,21 @@ class InspectionHandler : HttpRequestHandler() {
         )
         resultsStore.setSnapshot(projectKey(project), reconciledSnapshot)
         return reconciledSnapshot
+    }
+
+    private fun resolveCurrentFilePath(project: Project, normalizedScope: String): String? {
+        if (normalizedScope != "current_file") {
+            return null
+        }
+        return try {
+            FileEditorManager
+                .getInstance(project)
+                .selectedFiles
+                .firstOrNull()
+                ?.path
+        } catch (_: Exception) {
+            null
+        }
     }
 
     private fun waitForInspection(projectName: String?, timeoutMsRaw: Long?, pollMsRaw: Long?): String {
@@ -1365,6 +1413,12 @@ class InspectionHandler : HttpRequestHandler() {
         reason: String
     ): String {
         val response = status.toMutableMap()
+        if (reason == "stale_results") {
+            (response["total_problems"] as? Number)?.let { total ->
+                response.putIfAbsent("cached_total_problems", total.toInt())
+            }
+            response.remove("total_problems")
+        }
         val elapsed = System.currentTimeMillis() - startMs
         response["wait_completed"] = completed
         response["timed_out"] = !completed && reason == "timeout"
@@ -1675,6 +1729,7 @@ class InspectionHandler : HttpRequestHandler() {
                         var observedSettledEmptyInspectionView = false
                         var observedStableReadableEmptyInspectionView = false
                         var observedStableEmptyResultsWithoutInspectionView = false
+                        var observedOpaqueSettledEmptyInspectionView = false
                         var observedNonEmptyInspectionTree = false
                         var observedTransientEmptyInspectionViewEvidence = false
                         var inspectionViewUpdating = false
@@ -1832,6 +1887,9 @@ class InspectionHandler : HttpRequestHandler() {
                                             readableEmptyInspectionViewStableSince = loopNow
                                         }
                                     }
+                                    isOpaqueSettledEmptyInspectionViewCandidate(viewObservation) -> {
+                                        observedOpaqueSettledEmptyInspectionView = true
+                                    }
                                     else -> {
                                         resetReadableEmptyInspectionViewEvidence()
                                         transientUpdatingEmptyObservationCount = 0
@@ -1917,6 +1975,7 @@ class InspectionHandler : HttpRequestHandler() {
                                     inspectionViewUpdating = inspectionViewUpdating,
                                     hasSettledInspectionViewEvidence = observedSettledEmptyInspectionView ||
                                         observedStableReadableEmptyInspectionView,
+                                    hasOpaqueSettledEmptyInspectionViewEvidence = observedOpaqueSettledEmptyInspectionView,
                                     hasTransientEmptyInspectionViewEvidence = observedTransientEmptyInspectionViewEvidence,
                                     extractionSucceeded = shouldTreatScopedEmptyExtractionAsSucceeded(
                                         lastExtractionCycleSucceeded = lastExtractionCycleSucceeded,
@@ -1965,6 +2024,7 @@ class InspectionHandler : HttpRequestHandler() {
                                 inspectionViewUpdating = inspectionViewUpdating,
                                 hasSettledInspectionViewEvidence = observedSettledEmptyInspectionView ||
                                     observedStableReadableEmptyInspectionView,
+                                hasOpaqueSettledEmptyInspectionViewEvidence = observedOpaqueSettledEmptyInspectionView,
                                 hasTransientEmptyInspectionViewEvidence = observedTransientEmptyInspectionViewEvidence,
                                 extractionSucceeded = shouldTreatScopedEmptyExtractionAsSucceeded(
                                     lastExtractionCycleSucceeded = lastExtractionCycleSucceeded,

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -366,12 +366,13 @@ class InspectionHandlerTest {
             String::class.java,  // problemType (nullable)
             String::class.java,  // filePattern (nullable)
             Int::class.java,     // limit
-            Int::class.java      // offset
+            Int::class.java,     // offset
+            Boolean::class.java, // includeStale
         )
         
         assertNotNull(method)
         assertEquals("getInspectionProblems", method.name)
-        assertEquals(7, method.parameterCount)
+        assertEquals(8, method.parameterCount)
     }
     
     @Test

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
@@ -565,7 +565,122 @@ class InspectionSnapshotStateTest {
 
         assertTrue(response.contains("\"completion_reason\": \"stale_results\""))
         assertTrue(response.contains("\"results_may_be_stale\": true"))
+        assertTrue(response.contains("\"cached_total_problems\": 1"))
+        assertFalse(response.contains("\"total_problems\":"))
         assertFalse(response.contains("\"completion_reason\": \"results\""))
+    }
+
+    @Test
+    @DisplayName("Status reports cached counts separately for stale snapshots")
+    fun testStatusUsesCachedCountsForStaleSnapshots() {
+        InspectionResultsStore.setSnapshot(
+            snapshotKey(),
+            InspectionResultsSnapshot(
+                problems = listOf(staleProblem()),
+                timestamp = System.currentTimeMillis() - 16000L,
+                projectState = InspectionProjectStateSnapshot(psiModificationCount = 7L, unsavedProjectDocuments = 0),
+                outcome = InspectionSnapshotOutcome.PROBLEMS_FOUND,
+                source = "inspection_view",
+            ),
+        )
+        every { PsiModificationTracker.getInstance(mockProject).modificationCount } returns 8L
+
+        val status = buildInspectionStatus()
+
+        assertEquals(true, status["results_may_be_stale"])
+        assertEquals(1, status["cached_total_problems"])
+        assertFalse(status.containsKey("total_problems"))
+    }
+
+    @Test
+    @DisplayName("Problems endpoint withholds stale findings by default")
+    fun testProblemsEndpointWithholdsStaleFindingsByDefault() {
+        InspectionResultsStore.setSnapshot(
+            snapshotKey(),
+            InspectionResultsSnapshot(
+                problems = listOf(staleProblem()),
+                timestamp = System.currentTimeMillis() - 16000L,
+                projectState = InspectionProjectStateSnapshot(psiModificationCount = 7L, unsavedProjectDocuments = 0),
+                outcome = InspectionSnapshotOutcome.PROBLEMS_FOUND,
+                source = "inspection_view",
+            ),
+        )
+        every { PsiModificationTracker.getInstance(mockProject).modificationCount } returns 8L
+
+        val response = getInspectionProblems(includeStale = false)
+
+        assertTrue(response.contains("\"status\": \"stale_results\""))
+        assertTrue(response.contains("\"results_may_be_stale\": true"))
+        assertTrue(response.contains("\"stale_reasons\": [\"project_changed_since_inspection\"]"))
+        assertTrue(response.contains("\"snapshot_outcome\": \"problems_found\""))
+        assertTrue(response.contains("\"cached_total_problems\": 1"))
+        assertTrue(response.contains("\"cached_problems_shown\": 0"))
+        assertTrue(response.contains("\"include_stale\": false"))
+        assertFalse(response.contains("\"problems\":"))
+        assertFalse(response.contains("\"total_problems\":"))
+    }
+
+    @Test
+    @DisplayName("Problems endpoint returns cached stale findings when explicitly requested")
+    fun testProblemsEndpointCanIncludeStaleFindings() {
+        InspectionResultsStore.setSnapshot(
+            snapshotKey(),
+            InspectionResultsSnapshot(
+                problems = listOf(staleProblem()),
+                timestamp = System.currentTimeMillis() - 16000L,
+                projectState = InspectionProjectStateSnapshot(psiModificationCount = 7L, unsavedProjectDocuments = 0),
+                outcome = InspectionSnapshotOutcome.PROBLEMS_FOUND,
+                source = "inspection_view",
+            ),
+        )
+        every { PsiModificationTracker.getInstance(mockProject).modificationCount } returns 8L
+
+        val response = getInspectionProblems(includeStale = true)
+
+        assertTrue(response.contains("\"status\": \"stale_results\""))
+        assertTrue(response.contains("\"results_may_be_stale\": true"))
+        assertTrue(response.contains("\"include_stale\": true"))
+        assertTrue(response.contains("\"cached_total_problems\": 1"))
+        assertTrue(response.contains("\"cached_problems_shown\": 1"))
+        assertTrue(response.contains("\"problems\": ["))
+        assertTrue(response.contains("Old warning"))
+        assertTrue(response.contains("\"pagination\":"))
+        assertFalse(response.contains("\"total_problems\":"))
+    }
+
+    @Test
+    @DisplayName("Problems endpoint filters included stale findings by current file")
+    fun testProblemsEndpointFiltersIncludedStaleFindingsByCurrentFile() {
+        val mockFileEditorManager = mockk<FileEditorManager>()
+        val mockActiveFile = mockk<VirtualFile>()
+        mockkStatic(FileEditorManager::class)
+        every { FileEditorManager.getInstance(mockProject) } returns mockFileEditorManager
+        every { mockFileEditorManager.selectedFiles } returns arrayOf(mockActiveFile)
+        every { mockActiveFile.path } returns "/tmp/TestProject/src/app.js"
+
+        InspectionResultsStore.setSnapshot(
+            snapshotKey(),
+            InspectionResultsSnapshot(
+                problems = listOf(
+                    staleProblem(),
+                    staleProblem(description = "Other warning", file = "/tmp/TestProject/src/other.js"),
+                ),
+                timestamp = System.currentTimeMillis() - 16000L,
+                projectState = InspectionProjectStateSnapshot(psiModificationCount = 7L, unsavedProjectDocuments = 0),
+                outcome = InspectionSnapshotOutcome.PROBLEMS_FOUND,
+                source = "inspection_view",
+            ),
+        )
+        every { PsiModificationTracker.getInstance(mockProject).modificationCount } returns 8L
+
+        val response = getInspectionProblems(scope = "current_file", includeStale = true)
+
+        assertTrue(response.contains("\"status\": \"stale_results\""))
+        assertTrue(response.contains("\"cached_total_problems\": 1"))
+        assertTrue(response.contains("\"cached_problems_shown\": 1"))
+        assertTrue(response.contains("Old warning"))
+        assertFalse(response.contains("Other warning"))
+        assertFalse(response.contains("\"total_problems\":"))
     }
 
     @Test
@@ -861,6 +976,25 @@ class InspectionSnapshotStateTest {
     }
 
     @Test
+    @DisplayName("Opaque settled empty views provide guarded clean evidence")
+    fun testOpaqueSettledEmptyViewEvidence() {
+        val opaqueSettledEmpty = InspectionViewObservation(
+            isUpdating = false,
+            hasProblems = false,
+            rootChildCount = null,
+            updateStateReadable = true,
+            problemStateReadable = true,
+        )
+
+        assertTrue(isOpaqueSettledEmptyInspectionViewCandidate(opaqueSettledEmpty))
+        assertFalse(isOpaqueSettledEmptyInspectionViewCandidate(opaqueSettledEmpty.copy(hasProblems = true)))
+        assertFalse(isOpaqueSettledEmptyInspectionViewCandidate(opaqueSettledEmpty.copy(isUpdating = true)))
+        assertFalse(isOpaqueSettledEmptyInspectionViewCandidate(opaqueSettledEmpty.copy(updateStateReadable = false)))
+        assertFalse(isOpaqueSettledEmptyInspectionViewCandidate(opaqueSettledEmpty.copy(problemStateReadable = false)))
+        assertFalse(isOpaqueSettledEmptyInspectionViewCandidate(opaqueSettledEmpty.copy(rootChildCount = 0)))
+    }
+
+    @Test
     @DisplayName("Stable readable empty views require repeated positive evidence")
     fun testStableReadableEmptyViewRequiresRepeatedPositiveEvidence() {
         assertFalse(
@@ -960,6 +1094,23 @@ class InspectionSnapshotStateTest {
         assertTrue(
             shouldTrustStableScopedEmptyResults(
                 viewReadyOk = true,
+                hasScopedMatcher = true,
+                scopedContextResultsEmpty = true,
+                bestResultsEmpty = true,
+                observedNonEmptyInspectionTree = false,
+                stableForMs = 5000L,
+                pollingElapsedMs = 30000L,
+            )
+        )
+
+        assertTrue(
+            shouldTrustStableScopedEmptyResults(
+                viewReadyOk = true,
+                observedInspectionView = true,
+                inspectionViewUpdating = false,
+                hasSettledInspectionViewEvidence = false,
+                hasOpaqueSettledEmptyInspectionViewEvidence = true,
+                extractionSucceeded = true,
                 hasScopedMatcher = true,
                 scopedContextResultsEmpty = true,
                 bestResultsEmpty = true,
@@ -1605,6 +1756,10 @@ class InspectionSnapshotStateTest {
     }
 
     private fun getInspectionProblems(): String {
+        return getInspectionProblems(includeStale = false)
+    }
+
+    private fun getInspectionProblems(scope: String = "whole_project", includeStale: Boolean): String {
         val method = InspectionHandler::class.java.getDeclaredMethod(
             "getInspectionProblems",
             Project::class.java,
@@ -1614,9 +1769,24 @@ class InspectionSnapshotStateTest {
             String::class.java,
             Int::class.javaPrimitiveType,
             Int::class.javaPrimitiveType,
+            Boolean::class.javaPrimitiveType,
         )
         method.isAccessible = true
-        return method.invoke(handler, mockProject, "all", "whole_project", null, null, 100, 0) as String
+        return method.invoke(handler, mockProject, "all", scope, null, null, 100, 0, includeStale) as String
+    }
+
+    private fun staleProblem(
+        description: String = "Old warning",
+        file: String = "/tmp/TestProject/src/app.js",
+    ): Map<String, Any> {
+        return mapOf(
+            "description" to description,
+            "file" to file,
+            "line" to 12,
+            "column" to 4,
+            "severity" to "weak_warning",
+            "inspectionType" to "JSUnresolvedReference",
+        )
     }
 
     private fun waitForInspection(timeoutMs: Long = 1000L, pollMs: Long = 200L): String {


### PR DESCRIPTION
## Summary
- tighten stale inspection result responses so cached findings/counts use cached_* fields
- add include_stale plumbing for HTTP and MCP diagnostics while keeping stale non-clean
- update script-first docs and add a guarded clean-capture path for opaque settled IDE views

## Validation
- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test --tests 'com.shiny.inspectionmcp.InspectionSnapshotStateTest' :mcp-server-jvm:test
- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew test buildPlugin
- live PyCharm 2026.1.2 discord-blue file smoke: clean
- live WebStorm 2026.1.2 verireel file smoke: clean
- live IntelliJ IDEA 2026.1.2 changed-files smoke: clean
