### PR TITLE
Document inspection capture smoke validation

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -67,6 +67,14 @@ clean/capture classification, or MCP tool response contracts, update the skill
 docs/tests/scripts in the `jetbrains-inspection` skill as part of the same
 workstream.
 
+Before shipping changes to clean/capture classification, run the focused
+`InspectionSnapshotStateTest` coverage, then build the plugin with
+`./gradlew buildPlugin`. Smoke the installed plugin from the agent helper in the
+JetBrains IDEs that matter for the change, such as PyCharm, WebStorm, and
+IntelliJ IDEA. If plugin installation prompts about replacing an existing jar,
+handle that explicitly and rerun the smoke instead of treating the prompt as a
+validated install.
+
 ## Local cleanup
 
 `./scripts/clean-local.sh` removes disposable local files such as `.DS_Store`


### PR DESCRIPTION
## Summary
- document the validation path for clean/capture classification changes
- call out plugin install overwrite prompts before smoke validation

## Validation
- markdownlint-cli2 TESTING.md
- git diff --check
- commit hook: ./gradlew test, :inspection-core:test, :mcp-server-jvm:test, ./gradlew buildPlugin