### PR TITLE
Fix fresh inspection stale race

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Notes:
 - `status: "no_results"` uses the same pagination, filters, `total_problems`, `problems_shown`, and `problems` fields as result responses, with an empty problems list.
 - `status: "capture_incomplete"` means an inspection finished, but the plugin could not conclusively capture the IDE results. Re-run the inspection or open the Problems/Inspection Results view before treating the project as clean.
 - `status: "stale_results"` means project files changed after the last inspection. It is not a clean result. Cached findings are withheld by default; call `/problems?include_stale=true` only when explicitly diagnosing cached data.
+- `snapshot_change_kind` explains freshness classification when present. `snapshot_predates_current_trigger` and `unsaved_documents` are stale; `current_run_psi_churn` is a fresh-run PSI tick that the plugin attempts to reconcile before returning results.
 - `session_drift: true` means the client sent an old `session_id`; the IDE/plugin session restarted or the port was reused.
 
 ## API Reference
@@ -444,6 +445,7 @@ The status endpoint includes a `clean_inspection` field that makes the outcome e
 **Status Indicators**:
 - `is_scanning: true` → Inspection running, wait
 - `results_may_be_stale: true` → Project changed after the last inspection; trigger again before trusting results
+- `snapshot_change_kind: "current_run_psi_churn"` → The latest run's snapshot saw a PSI modification-count tick after capture; the plugin keeps waiting instead of treating the snapshot as stale cached data.
 - `clean_inspection: true` → Inspection complete. No problems found
 - `has_inspection_results: true` → Problems found, retrieve with `/problems`
 - If all three are false and `time_since_last_trigger_ms` is recent, the inspection finished but results were not captured. Re-run the inspection or open the Inspection Results tool window.
@@ -465,6 +467,7 @@ Common completion reasons:
 - The plugin saves documents and refreshes external file changes before starting a new inspection run.
 - `/api/inspection/status` and `/api/inspection/problems` refresh project state before evaluating cached snapshots.
 - If the project changed after the last inspection, `/api/inspection/status` sets `results_may_be_stale: true` and `/api/inspection/problems` returns `status: "stale_results"`. By default, the response includes cached metadata such as `cached_total_problems` and withholds `problems`; `include_stale=true` returns cached findings for diagnostics while keeping `status: "stale_results"`.
+- Fresh snapshots are tied to inspection run metadata. A PSI modification-count change immediately after the same run's capture is classified as `current_run_psi_churn` and reconciled against the live IDE problem tree instead of being reported as stale cached data.
 
 ## MCP Server Details
 

--- a/mcp-server-jvm/src/main/kotlin/com/shiny/inspectionmcp/mcpserver/Main.kt
+++ b/mcp-server-jvm/src/main/kotlin/com/shiny/inspectionmcp/mcpserver/Main.kt
@@ -211,7 +211,7 @@ internal class ToolExecutor(
                     put(
                         "description",
                         JsonPrimitive(
-                            "Fetch problems after inspection completes. Typical flow: inspection_trigger -> inspection_wait -> inspection_get_problems. In auto mode, pass project_path or project_key when available; selector-less calls follow the last triggered project when possible. capture_incomplete means do not treat as clean; retry once, preferably with a narrower scope. stale_results withholds cached findings by default; pass include_stale only when explicitly diagnosing cached data."
+                            "Fetch problems after inspection completes. Typical flow: inspection_trigger -> inspection_wait -> inspection_get_problems. In auto mode, pass project_path or project_key when available; selector-less calls follow the last triggered project when possible. capture_incomplete means do not treat as clean; retry once, preferably with a narrower scope. stale_results withholds cached findings by default; pass include_stale only when explicitly diagnosing cached data. snapshot_change_kind explains whether stale data predates the trigger or fresh results saw reconciled IDE PSI churn."
                         )
                     )
                     put("inputSchema", getProblemsSchema())

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -83,6 +83,8 @@ internal data class InspectionResultsSnapshot(
     val source: String,
     val note: String? = null,
     val captureScope: InspectionCaptureScope? = null,
+    val runId: Long? = null,
+    val triggerTimeMs: Long? = null,
 )
 
 internal data class InspectionViewObservation(
@@ -194,6 +196,10 @@ internal object InspectionResultsStore {
 
     fun getProjectState(projectName: String): InspectionProjectStateSnapshot? {
         return snapshotsByProject[projectName]?.projectState
+    }
+
+    fun getRunId(projectName: String): Long? {
+        return snapshotsByProject[projectName]?.runId
     }
 
     fun setSnapshot(projectName: String, snapshot: InspectionResultsSnapshot) {
@@ -499,6 +505,7 @@ class InspectionHandler : HttpRequestHandler() {
     private data class SnapshotStaleness(
         val stale: Boolean,
         val reasons: List<String>,
+        val changeKind: String = "fresh",
     )
     
     override fun isSupported(request: FullHttpRequest): Boolean {
@@ -885,7 +892,7 @@ class InspectionHandler : HttpRequestHandler() {
             val key = projectKey(project)
             var snapshot = resultsStore.getSnapshot(key)
             val hasSnapshot = snapshot != null
-            val staleness = getSnapshotStaleness(project)
+            val staleness = resolveSnapshotStaleness(project, snapshot)
             if (hasSnapshot && staleness.stale) {
                 val cachedProblems = snapshot.problems
                 val currentFilePath = resolveCurrentFilePath(project, normalizedScope)
@@ -908,6 +915,7 @@ class InspectionHandler : HttpRequestHandler() {
                     "message" to "Project files changed since the last inspection. Trigger a new inspection before trusting these results.",
                     "results_may_be_stale" to true,
                     "stale_reasons" to staleness.reasons,
+                    "snapshot_change_kind" to staleness.changeKind,
                     "snapshot_outcome" to snapshot.outcome.apiValue,
                     "results_source" to snapshot.source,
                     "results_timestamp_ms" to snapshot.timestamp,
@@ -934,6 +942,9 @@ class InspectionHandler : HttpRequestHandler() {
                     staleBase["include_stale"] = false
                 }
                 return formatJsonManually(staleBase.filterValues { it != null })
+            }
+            if (staleness.changeKind == "current_run_psi_churn") {
+                snapshot = reconcileCurrentRunPsiChurn(project, snapshot)
             }
             snapshot = reconcileSnapshotWithLiveProblems(project, snapshot)
             if (snapshot != null && snapshot.outcome == InspectionSnapshotOutcome.CAPTURE_INCOMPLETE) {
@@ -990,7 +1001,7 @@ class InspectionHandler : HttpRequestHandler() {
 
                 val page = paginateProblems(filteredProblems, limit, offset)
                 
-                val response = mapOf(
+                val response = mutableMapOf<String, Any?>(
                     "status" to "results_available",
                     "project" to project.name,
                     "project_key" to key,
@@ -1014,8 +1025,11 @@ class InspectionHandler : HttpRequestHandler() {
                     ),
                     "method" to (snapshot?.source ?: "enhanced_tree")
                 )
+                snapshot?.runId?.let { response["snapshot_run_id"] = it }
+                snapshot?.triggerTimeMs?.let { response["snapshot_trigger_time_ms"] = it }
+                response["snapshot_change_kind"] = resolveSnapshotStaleness(project, snapshot).changeKind
                 
-                formatJsonManually(response)
+                formatJsonManually(response.filterValues { it != null })
             } else {
                 val response = mapOf(
                     "status" to "no_results",
@@ -1109,7 +1123,11 @@ class InspectionHandler : HttpRequestHandler() {
         // Use the same extractor as the /problems endpoint so status matches real availability
         var snapshot = resultsStore.getSnapshot(key)
         val hasInspectionSnapshot = snapshot != null
-        val staleness = getSnapshotStaleness(project)
+        var staleness = resolveSnapshotStaleness(project, snapshot)
+        if (staleness.changeKind == "current_run_psi_churn") {
+            snapshot = reconcileCurrentRunPsiChurn(project, snapshot)
+            staleness = resolveSnapshotStaleness(project, snapshot)
+        }
         if (!staleness.stale) {
             snapshot = reconcileSnapshotWithLiveProblems(project, snapshot)
         }
@@ -1144,6 +1162,7 @@ class InspectionHandler : HttpRequestHandler() {
         if (staleness.reasons.isNotEmpty()) {
             status["stale_reasons"] = staleness.reasons
         }
+        status["snapshot_change_kind"] = staleness.changeKind
 
         // Window visibility hints (best-effort)
         val problemsVisible = problemsWindow?.isVisible ?: false
@@ -1169,6 +1188,8 @@ class InspectionHandler : HttpRequestHandler() {
         }
         if (snapshot != null) {
             status["results_age_ms"] = (currentTime - snapshot.timestamp).coerceAtLeast(0L)
+            snapshot.runId?.let { status["snapshot_run_id"] = it }
+            snapshot.triggerTimeMs?.let { status["snapshot_trigger_time_ms"] = it }
         }
         status["indexing"] = isIndexing
 
@@ -1225,6 +1246,44 @@ class InspectionHandler : HttpRequestHandler() {
             outcome = InspectionSnapshotOutcome.PROBLEMS_FOUND,
             source = "tool_window",
             note = null,
+        )
+        resultsStore.setSnapshot(projectKey(project), reconciledSnapshot)
+        return reconciledSnapshot
+    }
+
+    private fun reconcileCurrentRunPsiChurn(
+        project: Project,
+        snapshot: InspectionResultsSnapshot?,
+    ): InspectionResultsSnapshot? {
+        if (snapshot == null) {
+            return null
+        }
+
+        val liveProblems = try {
+            enhancedTreeExtractorFactory().extractAllProblems(project)
+        } catch (_: Exception) {
+            return snapshot
+        }
+        val captureScopeMatcher = snapshot.captureScope?.let { captureScope ->
+            buildScopeProblemMatcher(
+                project = project,
+                scopeParam = captureScope.scopeParam,
+                directoryParam = captureScope.directoryParam,
+                files = captureScope.files,
+                resolvedCurrentFile = captureScope.resolvedCurrentFile,
+                includeUnversioned = captureScope.includeUnversioned,
+                changedFilesMode = captureScope.changedFilesMode,
+                maxFiles = captureScope.maxFiles,
+            )
+        }
+        val compatibleLiveProblems = filterProblemsForScope(liveProblems, captureScopeMatcher)
+        if (compatibleLiveProblems != snapshot.problems) {
+            return snapshot
+        }
+
+        val reconciledSnapshot = snapshot.copy(
+            timestamp = System.currentTimeMillis(),
+            projectState = captureProjectState(project),
         )
         resultsStore.setSnapshot(projectKey(project), reconciledSnapshot)
         return reconciledSnapshot
@@ -2059,6 +2118,8 @@ class InspectionHandler : HttpRequestHandler() {
                                 outcome = InspectionSnapshotOutcome.PROBLEMS_FOUND,
                                 source = bestSource,
                                 captureScope = captureScope,
+                                runId = runId,
+                                triggerTimeMs = inspectionRunStatesByProject[key]?.triggerTimeMs,
                             )
                             emptyOutcome == InspectionSnapshotOutcome.CLEAN_CONFIRMED -> InspectionResultsSnapshot(
                                 problems = emptyList(),
@@ -2067,6 +2128,8 @@ class InspectionHandler : HttpRequestHandler() {
                                 outcome = InspectionSnapshotOutcome.CLEAN_CONFIRMED,
                                 source = "inspection_view",
                                 captureScope = captureScope,
+                                runId = runId,
+                                triggerTimeMs = inspectionRunStatesByProject[key]?.triggerTimeMs,
                             )
                             else -> InspectionResultsSnapshot(
                                 problems = emptyList(),
@@ -2076,6 +2139,8 @@ class InspectionHandler : HttpRequestHandler() {
                                 source = if (viewReadyOk) "inspection_view" else "tool_window",
                                 note = emptyNote,
                                 captureScope = captureScope,
+                                runId = runId,
+                                triggerTimeMs = inspectionRunStatesByProject[key]?.triggerTimeMs,
                             )
                         }
                         if (snapshot.outcome == InspectionSnapshotOutcome.CAPTURE_INCOMPLETE && bestResults.isEmpty()) {
@@ -2121,6 +2186,8 @@ class InspectionHandler : HttpRequestHandler() {
                                         source = "inspection_view",
                                         note = "Inspection failed before results could be captured.",
                                         captureScope = captureScope,
+                                        runId = runId,
+                                        triggerTimeMs = inspectionRunStatesByProject[key]?.triggerTimeMs,
                                     )
                                 )
                             }
@@ -2198,6 +2265,8 @@ class InspectionHandler : HttpRequestHandler() {
                 source = "inspection_view",
                 note = "Inspection failed before results could be captured.",
                 captureScope = captureScope,
+                runId = runId,
+                triggerTimeMs = inspectionRunStatesByProject[key]?.triggerTimeMs,
             )
         )
     }
@@ -2262,8 +2331,8 @@ class InspectionHandler : HttpRequestHandler() {
         )
     }
 
-    private fun getSnapshotStaleness(project: Project): SnapshotStaleness {
-        val snapshotState = resultsStore.getProjectState(projectKey(project)) ?: return SnapshotStaleness(false, emptyList())
+    private fun resolveSnapshotStaleness(project: Project, snapshot: InspectionResultsSnapshot?): SnapshotStaleness {
+        val snapshotState = snapshot?.projectState ?: return SnapshotStaleness(false, emptyList())
         val currentState = captureProjectState(project)
         val reasons = mutableListOf<String>()
         if (currentState.unsavedProjectDocuments > 0) {
@@ -2272,7 +2341,25 @@ class InspectionHandler : HttpRequestHandler() {
         if (currentState.psiModificationCount != snapshotState.psiModificationCount) {
             reasons += "project_changed_since_inspection"
         }
-        return SnapshotStaleness(reasons.isNotEmpty(), reasons)
+        if (reasons.isEmpty()) {
+            return SnapshotStaleness(false, emptyList())
+        }
+
+        val currentRunState = inspectionRunStatesByProject[projectKey(project)]
+        val currentRunId = currentRunState?.runId
+        val sameRunSnapshot = snapshot.runId != null && snapshot.runId == currentRunId
+        val psiOnlyChange = reasons == listOf("project_changed_since_inspection")
+        if (sameRunSnapshot && psiOnlyChange) {
+            return SnapshotStaleness(false, reasons, "current_run_psi_churn")
+        }
+
+        val changeKind = when {
+            reasons.contains("unsaved_documents") -> "unsaved_documents"
+            snapshot.runId != null && currentRunId != null && snapshot.runId != currentRunId -> "snapshot_predates_current_trigger"
+            snapshot.runId == null -> "unknown_snapshot_run"
+            else -> "project_changed_since_inspection"
+        }
+        return SnapshotStaleness(true, reasons, changeKind)
     }
 
     private fun countProjectUnsavedDocuments(project: Project): Int {

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
@@ -571,6 +571,136 @@ class InspectionSnapshotStateTest {
     }
 
     @Test
+    @DisplayName("Wait reconciles current-run PSI churn without stale_results")
+    fun testWaitReconcilesCurrentRunPsiChurn() {
+        val extractor = mockk<EnhancedTreeExtractor>()
+        val currentRun = beginInspectionRun()
+        finishInspectionRun(snapshotKey(), currentRun.runId)
+        setLastInspectionTriggerTime(System.currentTimeMillis() - 16000L)
+        val problems = listOf(staleProblem(description = "Fresh warning"))
+        every { extractor.extractAllProblems(mockProject) } returns problems
+        enhancedTreeExtractorFactory = { extractor }
+        InspectionResultsStore.setSnapshot(
+            snapshotKey(),
+            InspectionResultsSnapshot(
+                problems = problems,
+                timestamp = System.currentTimeMillis() - 16000L,
+                projectState = InspectionProjectStateSnapshot(psiModificationCount = 7L, unsavedProjectDocuments = 0),
+                outcome = InspectionSnapshotOutcome.PROBLEMS_FOUND,
+                source = "inspection_view",
+                runId = currentRun.runId,
+                triggerTimeMs = currentRun.triggerTimeMs,
+            ),
+        )
+        every { PsiModificationTracker.getInstance(mockProject).modificationCount } returns 8L
+
+        val response = waitForInspection(timeoutMs = 7000L, pollMs = 200L)
+        val status = buildInspectionStatus()
+
+        assertTrue(response.contains("\"completion_reason\": \"results\""))
+        assertFalse(response.contains("\"completion_reason\": \"stale_results\""))
+        assertEquals(false, status["results_may_be_stale"])
+        assertEquals("fresh", status["snapshot_change_kind"])
+        assertEquals(8L, InspectionResultsStore.getProjectState(snapshotKey())?.psiModificationCount)
+        assertEquals(currentRun.runId, InspectionResultsStore.getRunId(snapshotKey()))
+    }
+
+    @Test
+    @DisplayName("Status distinguishes unreconciled current-run PSI churn")
+    fun testStatusReportsCurrentRunPsiChurnWhenReconcileCannotConfirm() {
+        val extractor = mockk<EnhancedTreeExtractor>()
+        val currentRun = beginInspectionRun()
+        finishInspectionRun(snapshotKey(), currentRun.runId)
+        every { extractor.extractAllProblems(mockProject) } returns emptyList()
+        enhancedTreeExtractorFactory = { extractor }
+        InspectionResultsStore.setSnapshot(
+            snapshotKey(),
+            InspectionResultsSnapshot(
+                problems = listOf(staleProblem(description = "Fresh warning")),
+                timestamp = System.currentTimeMillis() - 16000L,
+                projectState = InspectionProjectStateSnapshot(psiModificationCount = 7L, unsavedProjectDocuments = 0),
+                outcome = InspectionSnapshotOutcome.PROBLEMS_FOUND,
+                source = "inspection_view",
+                runId = currentRun.runId,
+                triggerTimeMs = currentRun.triggerTimeMs,
+            ),
+        )
+        every { PsiModificationTracker.getInstance(mockProject).modificationCount } returns 8L
+
+        val status = buildInspectionStatus()
+
+        assertEquals(false, status["results_may_be_stale"])
+        assertEquals("current_run_psi_churn", status["snapshot_change_kind"])
+        assertEquals(listOf("project_changed_since_inspection"), status["stale_reasons"])
+        assertEquals(currentRun.runId, status["snapshot_run_id"])
+    }
+
+    @Test
+    @DisplayName("Current-run snapshots with unsaved documents remain stale")
+    fun testCurrentRunSnapshotWithUnsavedDocumentsRemainsStale() {
+        val currentRun = beginInspectionRun()
+        finishInspectionRun(snapshotKey(), currentRun.runId)
+        setLastInspectionTriggerTime(System.currentTimeMillis() - 16000L)
+        InspectionResultsStore.setSnapshot(
+            snapshotKey(),
+            InspectionResultsSnapshot(
+                problems = listOf(staleProblem()),
+                timestamp = System.currentTimeMillis() - 16000L,
+                projectState = InspectionProjectStateSnapshot(psiModificationCount = 7L, unsavedProjectDocuments = 0),
+                outcome = InspectionSnapshotOutcome.PROBLEMS_FOUND,
+                source = "inspection_view",
+                runId = currentRun.runId,
+                triggerTimeMs = currentRun.triggerTimeMs,
+            ),
+        )
+        val unsavedDocument = mockk<Document>()
+        val unsavedFile = mockk<VirtualFile>()
+        val mockProjectFileIndex = mockk<ProjectFileIndex>()
+        mockkStatic(ProjectFileIndex::class)
+        every { ProjectFileIndex.getInstance(mockProject) } returns mockProjectFileIndex
+        every { FileDocumentManager.getInstance().unsavedDocuments } returns arrayOf(unsavedDocument)
+        every { FileDocumentManager.getInstance().getFile(unsavedDocument) } returns unsavedFile
+        every { unsavedFile.path } returns "/tmp/TestProject/src/app.js"
+        every { mockProjectFileIndex.isInContent(unsavedFile) } returns true
+        every { PsiModificationTracker.getInstance(mockProject).modificationCount } returns 8L
+
+        val response = waitForInspection(timeoutMs = 1000L, pollMs = 200L)
+
+        assertTrue(response.contains("\"completion_reason\": \"stale_results\""))
+        assertTrue(response.contains("\"snapshot_change_kind\": \"unsaved_documents\""))
+    }
+
+    @Test
+    @DisplayName("Older run snapshot remains stale after a newer trigger")
+    fun testOlderRunSnapshotRemainsStaleAfterNewerTrigger() {
+        val oldRun = beginInspectionRun()
+        finishInspectionRun(snapshotKey(), oldRun.runId)
+        val currentRun = beginInspectionRun()
+        finishInspectionRun(snapshotKey(), currentRun.runId)
+        setLastInspectionTriggerTime(System.currentTimeMillis() - 16000L)
+        InspectionResultsStore.setSnapshot(
+            snapshotKey(),
+            InspectionResultsSnapshot(
+                problems = listOf(staleProblem()),
+                timestamp = System.currentTimeMillis() - 16000L,
+                projectState = InspectionProjectStateSnapshot(psiModificationCount = 7L, unsavedProjectDocuments = 0),
+                outcome = InspectionSnapshotOutcome.PROBLEMS_FOUND,
+                source = "inspection_view",
+                runId = oldRun.runId,
+                triggerTimeMs = oldRun.triggerTimeMs,
+            ),
+        )
+        every { PsiModificationTracker.getInstance(mockProject).modificationCount } returns 8L
+
+        val response = waitForInspection(timeoutMs = 1000L, pollMs = 200L)
+
+        assertTrue(response.contains("\"completion_reason\": \"stale_results\""))
+        assertTrue(response.contains("\"snapshot_change_kind\": \"snapshot_predates_current_trigger\""))
+        assertTrue(response.contains("\"snapshot_run_id\": ${oldRun.runId}"))
+        assertTrue(response.contains("\"inspection_run_id\": ${currentRun.runId}"))
+    }
+
+    @Test
     @DisplayName("Status reports cached counts separately for stale snapshots")
     fun testStatusUsesCachedCountsForStaleSnapshots() {
         InspectionResultsStore.setSnapshot(


### PR DESCRIPTION
## Summary

Fixes #43 by making inspection snapshot freshness run-aware.

- attach `runId` and trigger time to captured snapshots
- classify snapshot freshness with `snapshot_change_kind`
- reconcile same-run PSI-only churn against live IDE problems instead of returning `stale_results`
- preserve hard stale behavior for older snapshots and unsaved documents
- document the new diagnostic field and update MCP tool wording

## Validation

- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test --tests com.shiny.inspectionmcp.InspectionSnapshotStateTest :mcp-server-jvm:test`
- commit hook ran broader Gradle tests and `buildPlugin` successfully
- installed dev plugin `1.12.7` into PyCharm, IntelliJ IDEA, and WebStorm
- dogfood matrix: 12 inspection runs across PyCharm, IntelliJ IDEA, and WebStorm returned `stale_results` count `0`
- original repro project `discord-blue` hit `snapshot_change_kind=current_run_psi_churn` and completed as `wait=results`, `stale=false`

## Notes

Dogfood still surfaced some `capture_incomplete` outcomes for empty captures. Those were non-stale and appear separate from this race; follow-up investigation is warranted.
