### PR TITLE
Handle empty changed-files inspection scope

### DIFF
--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -1708,6 +1708,34 @@ class InspectionHandler : HttpRequestHandler() {
             
             syncProjectState(project)
 
+            val changedFilesScopeFiles = if (scopeParam?.lowercase()?.trim() == "changed_files") {
+                resolveChangedFilesScopeFiles(
+                    project = project,
+                    includeUnversioned = includeUnversioned,
+                    changedFilesMode = changedFilesMode,
+                    maxFiles = maxFiles,
+                )
+            } else {
+                null
+            }
+            if (changedFilesScopeFiles != null && changedFilesScopeFiles.isEmpty()) {
+                resultsStore.setSnapshot(
+                    key,
+                    InspectionResultsSnapshot(
+                        problems = emptyList(),
+                        timestamp = System.currentTimeMillis(),
+                        projectState = captureProjectState(project),
+                        outcome = InspectionSnapshotOutcome.CLEAN_CONFIRMED,
+                        source = "empty_changed_files",
+                        note = "No changed files matched the requested inspection scope.",
+                        captureScope = captureScope,
+                        runId = runId,
+                        triggerTimeMs = inspectionRunStatesByProject[key]?.triggerTimeMs,
+                    )
+                )
+                return
+            }
+
             val scope: AnalysisScope = buildAnalysisScope(
                 project = project,
                 scopeParam = scopeParam,
@@ -1716,7 +1744,8 @@ class InspectionHandler : HttpRequestHandler() {
                 resolvedCurrentFile = resolvedCurrentFile,
                 includeUnversioned = includeUnversioned,
                 changedFilesMode = changedFilesMode,
-                maxFiles = maxFiles
+                maxFiles = maxFiles,
+                resolvedChangedFiles = changedFilesScopeFiles,
             )
             val scopeProblemMatcher = buildScopeProblemMatcher(
                 project = project,
@@ -1727,6 +1756,7 @@ class InspectionHandler : HttpRequestHandler() {
                 includeUnversioned = includeUnversioned,
                 changedFilesMode = changedFilesMode,
                 maxFiles = maxFiles,
+                resolvedChangedFiles = changedFilesScopeFiles,
             )
             
             @Suppress("USELESS_CAST")
@@ -2387,7 +2417,8 @@ class InspectionHandler : HttpRequestHandler() {
         resolvedCurrentFile: String?,
         includeUnversioned: Boolean,
         changedFilesMode: String?,
-        maxFiles: Int?
+        maxFiles: Int?,
+        resolvedChangedFiles: List<VirtualFile>? = null,
     ): AnalysisScope {
         return try {
             val scopeLower = scopeParam?.lowercase()?.trim()
@@ -2405,49 +2436,12 @@ class InspectionHandler : HttpRequestHandler() {
             }
 
             if (scopeLower == "changed_files") {
-                val clm = com.intellij.openapi.vcs.changes.ChangeListManager.getInstance(project)
-                val baseChanges = clm.allChanges
-
-                val changeFiles = baseChanges.mapNotNull { ch ->
-                    ch.virtualFile ?: ch.afterRevision?.file?.virtualFile ?: ch.beforeRevision?.file?.virtualFile
-                }.toMutableList()
-
-                // Best-effort Git staging filter when requested
-                val mode = changedFilesMode?.lowercase()?.trim()
-                if (!mode.isNullOrBlank() && mode != "all") {
-                    val gitSets = computeGitStagingSets(project)
-                    if (gitSets != null) {
-                        val (stagedSet, unstagedSet) = gitSets
-                        val basePath = project.basePath
-                        if (!basePath.isNullOrBlank()) {
-                            fun rel(p: String): String {
-                                val rel = try {
-                                    Paths.get(basePath).relativize(Paths.get(p)).toString()
-                                } catch (_: Exception) { p }
-                                return rel.replace('\\', '/')
-                            }
-                            changeFiles.retainAll { vf ->
-                                val rp = rel(vf.path)
-                                when (mode) {
-                                    "staged" -> stagedSet.contains(rp)
-                                    "unstaged" -> unstagedSet.contains(rp)
-                                    else -> true
-                                }
-                            }
-                        }
-                    }
-                }
-                if (includeUnversioned) {
-                    try {
-                        val method = clm.javaClass.getMethod("getUnversionedFiles")
-                        @Suppress("UNCHECKED_CAST")
-                        val unversioned = method.invoke(clm) as? Collection<VirtualFile>
-                        if (unversioned != null) changeFiles.addAll(unversioned)
-                    } catch (_: Exception) {
-                    }
-                }
-                val unique = changeFiles.distinct()
-                val limited = if (maxFiles != null && maxFiles > 0) unique.take(maxFiles) else unique
+                val limited = resolvedChangedFiles ?: resolveChangedFilesScopeFiles(
+                    project = project,
+                    includeUnversioned = includeUnversioned,
+                    changedFilesMode = changedFilesMode,
+                    maxFiles = maxFiles,
+                )
                 return if (limited.isEmpty()) AnalysisScope(project) else AnalysisScope(project, limited.toSet())
             }
 
@@ -2489,6 +2483,57 @@ class InspectionHandler : HttpRequestHandler() {
         }
     }
 
+    private fun resolveChangedFilesScopeFiles(
+        project: Project,
+        includeUnversioned: Boolean,
+        changedFilesMode: String?,
+        maxFiles: Int?,
+    ): List<VirtualFile> {
+        val clm = com.intellij.openapi.vcs.changes.ChangeListManager.getInstance(project)
+        val changeFiles = clm.allChanges.mapNotNull { change ->
+            change.virtualFile ?: change.afterRevision?.file?.virtualFile ?: change.beforeRevision?.file?.virtualFile
+        }.toMutableList()
+
+        val mode = changedFilesMode?.lowercase()?.trim()
+        if (!mode.isNullOrBlank() && mode != "all") {
+            val gitSets = computeGitStagingSets(project)
+            if (gitSets != null) {
+                val (stagedSet, unstagedSet) = gitSets
+                val basePath = project.basePath
+                if (!basePath.isNullOrBlank()) {
+                    fun relativePath(path: String): String {
+                        val relative = try {
+                            Paths.get(basePath).relativize(Paths.get(path)).toString()
+                        } catch (_: Exception) {
+                            path
+                        }
+                        return relative.replace('\\', '/')
+                    }
+                    changeFiles.retainAll { vf ->
+                        when (mode) {
+                            "staged" -> stagedSet.contains(relativePath(vf.path))
+                            "unstaged" -> unstagedSet.contains(relativePath(vf.path))
+                            else -> true
+                        }
+                    }
+                }
+            }
+        }
+        if (includeUnversioned) {
+            try {
+                val method = clm.javaClass.getMethod("getUnversionedFiles")
+                @Suppress("UNCHECKED_CAST")
+                val unversioned = method.invoke(clm) as? Collection<VirtualFile>
+                if (unversioned != null) {
+                    changeFiles.addAll(unversioned)
+                }
+            } catch (_: Exception) {
+            }
+        }
+        val unique = changeFiles.distinct()
+        return if (maxFiles != null && maxFiles > 0) unique.take(maxFiles) else unique
+    }
+
     private fun buildScopeProblemMatcher(
         project: Project,
         scopeParam: String?,
@@ -2498,6 +2543,7 @@ class InspectionHandler : HttpRequestHandler() {
         includeUnversioned: Boolean,
         changedFilesMode: String?,
         maxFiles: Int?,
+        resolvedChangedFiles: List<VirtualFile>? = null,
     ): ((Map<String, Any>) -> Boolean)? {
         val scopeLower = scopeParam?.lowercase()?.trim()
 
@@ -2535,48 +2581,12 @@ class InspectionHandler : HttpRequestHandler() {
         }
 
         if (scopeLower == "changed_files") {
-            val clm = com.intellij.openapi.vcs.changes.ChangeListManager.getInstance(project)
-            val changeFiles = clm.allChanges.mapNotNull { change ->
-                change.virtualFile ?: change.afterRevision?.file?.virtualFile ?: change.beforeRevision?.file?.virtualFile
-            }.toMutableList()
-
-            val mode = changedFilesMode?.lowercase()?.trim()
-            if (!mode.isNullOrBlank() && mode != "all") {
-                val gitSets = computeGitStagingSets(project)
-                if (gitSets != null) {
-                    val (stagedSet, unstagedSet) = gitSets
-                    val basePath = project.basePath
-                    if (!basePath.isNullOrBlank()) {
-                        fun relativePath(path: String): String {
-                            val relative = try {
-                                Paths.get(basePath).relativize(Paths.get(path)).toString()
-                            } catch (_: Exception) {
-                                path
-                            }
-                            return relative.replace('\\', '/')
-                        }
-                        changeFiles.retainAll { vf ->
-                            when (mode) {
-                                "staged" -> stagedSet.contains(relativePath(vf.path))
-                                "unstaged" -> unstagedSet.contains(relativePath(vf.path))
-                                else -> true
-                            }
-                        }
-                    }
-                }
-            }
-            if (includeUnversioned) {
-                try {
-                    val method = clm.javaClass.getMethod("getUnversionedFiles")
-                    @Suppress("UNCHECKED_CAST")
-                    val unversioned = method.invoke(clm) as? Collection<VirtualFile>
-                    if (unversioned != null) changeFiles.addAll(unversioned)
-                } catch (_: Exception) {
-                }
-            }
-            val limited = changeFiles.distinct().let { unique ->
-                if (maxFiles != null && maxFiles > 0) unique.take(maxFiles) else unique
-            }
+            val limited = resolvedChangedFiles ?: resolveChangedFilesScopeFiles(
+                project = project,
+                includeUnversioned = includeUnversioned,
+                changedFilesMode = changedFilesMode,
+                maxFiles = maxFiles,
+            )
             val resolved = limited.mapNotNull { normalizeFileSystemPath(it.path) }.toSet()
             return resolved.takeIf { it.isNotEmpty() }?.let(::exactFileMatcher)
         }

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -9,8 +9,11 @@ import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.vcs.changes.ChangeListManager
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.openapi.wm.IdeFocusManager
 import com.intellij.openapi.wm.IdeFrame
@@ -23,6 +26,8 @@ import com.intellij.codeInspection.ui.InspectionResultsView
 import com.intellij.profile.codeInspection.InspectionProjectProfileManager
 import com.intellij.codeInspection.ex.InspectionProfileImpl
 import com.intellij.openapi.util.ThrowableComputable
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.util.PsiModificationTracker
 import com.intellij.ui.content.Content
 import com.intellij.ui.content.ContentManager
 import io.netty.handler.codec.http.QueryStringDecoder
@@ -114,6 +119,61 @@ class InspectionHandlerTest {
         every { InspectionProjectProfileManager.getInstance(mockProject) } returns mockProfileManager
         every { mockProfileManager.currentProfile } returns mockProfile
         every { mockProfile.name } returns "TestProfile"
+    }
+
+    @Test
+    fun `test changed files trigger with no targets publishes clean snapshot without IDE inspection`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        every { mockApplication.isDispatchThread } returns true
+        every { mockVirtualFileManager.syncRefresh() } returns 0L
+        every { mockApplication.executeOnPooledThread(any<Runnable>()) } answers {
+            firstArg<Runnable>().run()
+            mockk(relaxed = true)
+        }
+
+        val fileDocumentManager = mockk<FileDocumentManager>(relaxed = true)
+        mockkStatic(FileDocumentManager::class)
+        every { FileDocumentManager.getInstance() } returns fileDocumentManager
+        every { fileDocumentManager.unsavedDocuments } returns emptyArray()
+
+        val psiDocumentManager = mockk<PsiDocumentManager>(relaxed = true)
+        mockkStatic(PsiDocumentManager::class)
+        every { PsiDocumentManager.getInstance(mockProject) } returns psiDocumentManager
+
+        mockkStatic(ChangeListManager::class)
+        val changeListManager = mockk<ChangeListManager>(relaxed = true)
+        every { ChangeListManager.getInstance(mockProject) } returns changeListManager
+        every { changeListManager.allChanges } returns emptyList()
+
+        mockkStatic(PsiModificationTracker::class)
+        val modificationTracker = mockk<PsiModificationTracker>()
+        every { PsiModificationTracker.getInstance(mockProject) } returns modificationTracker
+        every { modificationTracker.modificationCount } returns 11L
+
+        mockkStatic(ToolWindowManager::class)
+        val toolWindowManager = mockk<ToolWindowManager>()
+        every { ToolWindowManager.getInstance(mockProject) } returns toolWindowManager
+        every { toolWindowManager.getToolWindow(any()) } returns null
+
+        mockkStatic(DumbService::class)
+        val dumbService = mockk<DumbService>()
+        every { DumbService.getInstance(mockProject) } returns dumbService
+        every { dumbService.isDumb } returns false
+
+        val response = processTriggerRequest("/api/inspection/trigger?scope=changed_files&include_unversioned=false")
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"scope\": \"changed_files\""))
+        verify(exactly = 1) { mockApplication.executeOnPooledThread(any<Runnable>()) }
+        verify(exactly = 0) { mockInspectionManager.createNewGlobalContext() }
+        val status = buildInspectionStatus()
+        assertEquals("clean_confirmed", status["snapshot_outcome"])
+        assertEquals("empty_changed_files", status["results_source"])
+        assertEquals(false, status["capture_incomplete"])
+        assertEquals(false, status["results_may_be_stale"])
+        assertEquals(0, status["total_problems"])
     }
     
     @Test
@@ -945,6 +1005,13 @@ class InspectionHandlerTest {
 
         assertTrue(result)
         return responseSlot.captured as FullHttpResponse
+    }
+
+    private fun buildInspectionStatus(): MutableMap<String, Any> {
+        val method = InspectionHandler::class.java.getDeclaredMethod("buildInspectionStatus", Project::class.java)
+        method.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        return method.invoke(handler, mockProject) as MutableMap<String, Any>
     }
 
     private fun mockProject(name: String, basePath: String, projectFilePath: String): Project {

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionScopeFallbackTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionScopeFallbackTest.kt
@@ -34,6 +34,7 @@ class InspectionScopeFallbackTest {
             Boolean::class.javaPrimitiveType,
             String::class.java,
             Int::class.javaObjectType,
+            List::class.java,
         )
         method.isAccessible = true
 
@@ -45,6 +46,7 @@ class InspectionScopeFallbackTest {
             listOf("/does/not/exist.txt"),
             null,
             true,
+            null,
             null,
             null,
         )
@@ -71,6 +73,7 @@ class InspectionScopeFallbackTest {
             Boolean::class.javaPrimitiveType,
             String::class.java,
             Int::class.javaObjectType,
+            List::class.java,
         )
         method.isAccessible = true
 
@@ -84,6 +87,7 @@ class InspectionScopeFallbackTest {
             /* includeUnversioned = */ false,
             null,
             10,
+            null,
         )
         assertNotNull(scope)
     }
@@ -108,6 +112,7 @@ class InspectionScopeFallbackTest {
             Boolean::class.javaPrimitiveType,
             String::class.java,
             Int::class.javaObjectType,
+            List::class.java,
         )
         method.isAccessible = true
 
@@ -119,6 +124,7 @@ class InspectionScopeFallbackTest {
             null,
             null,
             true,
+            null,
             null,
             null,
         )

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionScopeResolutionTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionScopeResolutionTest.kt
@@ -83,6 +83,7 @@ class InspectionScopeResolutionTest {
             Boolean::class.javaPrimitiveType,
             String::class.java,
             Int::class.javaObjectType,
+            List::class.java,
         )
         method.isAccessible = true
         val scope = method.invoke(
@@ -93,6 +94,7 @@ class InspectionScopeResolutionTest {
             null,
             null,
             true,
+            null,
             null,
             null,
         )


### PR DESCRIPTION
## Summary
- publish a clean empty snapshot when scope=changed_files resolves to no files
- reuse one changed-file resolver for analysis scope and scope problem matching
- add regression coverage proving the IDE inspection context is not created for empty changed_files runs

## Validation
- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test --tests com.shiny.inspectionmcp.InspectionHandlerTest --tests com.shiny.inspectionmcp.InspectionScopeFallbackTest --tests com.shiny.inspectionmcp.InspectionScopeResolutionTest
- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test --tests com.shiny.inspectionmcp.InspectionSnapshotStateTest
- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew buildPlugin
- pre-commit hook: plugin tests, inspection-core tests, mcp-server-jvm tests, buildPlugin

## Notes
- No codex-skills helper update needed: the public capture_incomplete/stale handling contract is unchanged.
- Rebuilt 1.12.7 plugin installed into IntelliJIdea2026.1, PyCharm2026.1, and WebStorm2026.1 plugin dirs; IDE restart is required before live dogfood uses this exact build.