### PR TITLE
Add lifecycle worktree inspection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ routing state.
     "base_url": "http://localhost:63340/api/inspection",
     "session_id": "4c171eb1-2f1f-4b0c-9b5b-0dd1d5b9e2a8",
     "project_key": "path:/Users/me/Developer/MyProject",
+    "project_instance_id": "4c171eb1-2f1f-4b0c-9b5b-0dd1d5b9e2a8:123456789",
     "project_name": "MyProject",
     "base_path": "/Users/me/Developer/MyProject",
     "focused": true,
@@ -271,7 +272,9 @@ Identity responses and registry instance files share the same schema:
 `session_id`, `started_at_ms`, `heartbeat_ms`, `pid`, `port`, `ide_name`,
 `ide_version`, `ide_product_code`, `plugin_version`, and `open_projects`.
 Each project includes `project_key`, `name`, `base_path`, `project_file_path`,
-and `focused` as a JSON boolean.
+`project_instance_id`, and `focused` as a JSON boolean. `project_instance_id` is
+opaque and only stable for the lifetime of that IDE process; clients should use
+it only to guard route/session ownership.
 
 Registry files live under the OS cache directory by default:
 `jetbrains-inspection-api/instances/<session_id>.json`. Override the directory
@@ -279,6 +282,31 @@ with `JETBRAINS_INSPECTION_REGISTRY_DIR`. Clients that cannot reach a known IDE
 port can read fresh registry files, verify `heartbeat_ms` is within about 60
 seconds, and optionally scan `JETBRAINS_INSPECTION_PORTS` such as
 `63340-63350` as a fallback.
+
+### Helper Lifecycle Endpoints
+
+The helper lifecycle endpoints are for automation that needs to open an exact
+worktree, run inspection, and clean up only the IDE project it opened. Ordinary
+clients should keep using `/route`, `/trigger`, `/wait`, `/status`, and
+`/problems`; those endpoints never open projects by themselves.
+
+- `GET /api/inspection/lifecycle/open`: accepts `project_path` or
+  `worktree_path`, returns immediately after scheduling an IDE open when the
+  exact path is not already open, and uses the worktree directory name as the
+  project frame name. Helpers must poll `/route` or `/list` until the exact
+  path appears before inspecting.
+- `GET /api/inspection/lifecycle/claim`: resolves the same selectors as
+  `/route`, verifies optional `project_instance_id`, and returns a one-use
+  `close_token` tied to the current `session_id` and project instance.
+- `GET /api/inspection/lifecycle/close`: requires `project_key`,
+  `project_instance_id`, `session_id`, and `close_token`. It closes the project
+  only when all values still match the plugin-side claim. Token mismatch,
+  session drift, or route ambiguity returns a skipped/error response and leaves
+  the project open.
+
+This contract lets script helpers preserve projects that were already open
+before automation started while cleaning up helper-opened worktrees after
+closeout.
 
 ### Problems Endpoint
 **URL**: `GET /api/inspection/problems`

--- a/TESTING.md
+++ b/TESTING.md
@@ -59,11 +59,39 @@ uv run "$HELPER" run \
   --scope changed_files
 ```
 
+For agent closeout/readiness, prefer `closeout` instead of plain `run`:
+
+```bash
+uv run "$HELPER" closeout \
+  --repo "$PWD" \
+  --scope changed_files
+```
+
+`closeout` serializes helper-owned IDE opens, requires an exact current-worktree
+route, runs inspection, and calls the plugin lifecycle close endpoint only for
+projects opened by the helper. Projects that were open before the helper started
+are left open. On macOS, lifecycle opens use `open -g` by default so the IDE should
+not take focus while a closeout is preparing a worktree. Auto-open requires a
+global trusted-root policy in
+`${CODEX_HOME:-$HOME/.code}/jetbrains-inspection.json`; test worktrees should be
+created under those roots, not random temp directories.
+
+Before it starts lifecycle auto-open, the helper adds the matching trusted root
+to the selected JetBrains product's Trusted Locations and sets project opening
+to the separate-window mode. If auto-open stalls, treat it as a blocker: check
+for an unsupported IDE config layout, settings sync overwriting the config, or a
+missing inspection plugin. The
+plugin-side lifecycle open endpoint schedules project opening asynchronously and
+uses the worktree directory name as the frame project name so cloned worktrees
+with identical checked-in `.idea` metadata can coexist in IntelliJ IDEA,
+PyCharm, and WebStorm.
+
 The helper treats `capture_incomplete`, stale results, timeouts, indexing,
-session drift, and route ambiguity as non-clean outcomes. Cached stale findings
-are returned only when the helper is run with `--include-stale` for explicit
-diagnostics. When this repo changes inspection status semantics, route metadata,
-clean/capture classification, or MCP tool response contracts, update the skill
+session drift, route ambiguity, wrong-worktree routes, and cleanup failures as
+non-clean outcomes. Cached stale findings are returned only when the helper is
+run with `--include-stale` for explicit diagnostics. When this repo changes
+inspection status semantics, route metadata, clean/capture classification,
+lifecycle cleanup contracts, or MCP tool response contracts, update the skill
 docs/tests/scripts in the `jetbrains-inspection` skill as part of the same
 workstream.
 
@@ -72,8 +100,8 @@ Before shipping changes to clean/capture classification, run the focused
 `./gradlew buildPlugin`. Smoke the installed plugin from the agent helper in the
 JetBrains IDEs that matter for the change, such as PyCharm, WebStorm, and
 IntelliJ IDEA. If plugin installation prompts about replacing an existing jar,
-handle that explicitly and rerun the smoke instead of treating the prompt as a
-validated install.
+handle that explicitly and rerun the smoke; the prompt alone is not install
+validation.
 
 ## Local cleanup
 

--- a/TESTING_INSTRUCTIONS.md
+++ b/TESTING_INSTRUCTIONS.md
@@ -49,9 +49,33 @@ Expected behavior:
   for a fresh trigger instead of silently using stale state.
 - Duplicate project names produce an ambiguity response with paths/project keys.
 
+## Helper lifecycle smoke
+
+Use this when validating worktree closeout behavior from the external helper.
+
+1. Pick a repo worktree that is not currently open in the target IDE.
+2. Run `jb-inspect.py closeout --repo <worktree> --scope changed_files`.
+3. Confirm the helper reports an exact route with `opened_by_helper=true` and a
+   cleanup status of `closed` after inspection.
+4. Confirm no Trust Project, Safe Mode, or Open Project mode prompt appears; the
+   external helper should seed JetBrains Trusted Locations and project-opening
+   policy before lifecycle auto-open.
+5. If the helper times out waiting for auto-open, treat it as a blocker. Inspect
+   the helper diagnostics for unsupported IDE config layout, settings sync
+   overwriting the config, or a missing inspection plugin.
+6. If debugging a product-specific failure, call `/api/inspection/lifecycle/open`
+   directly and confirm the endpoint returns `status=opening` quickly; the
+   helper polling loop must then prove the project appears in `/list`.
+7. Open the same worktree manually in the IDE and rerun closeout.
+8. Confirm cleanup reports `not_needed` and the manually opened project remains
+   open.
+9. For linked worktrees, confirm the route `base_path` exactly equals the linked
+   worktree, not the main checkout.
+
 ## Fast-path scopes (manual)
 
 Changed files only (fast inner loop):
+
 ```bash
 IDE_PORT=63341
 curl "http://localhost:$IDE_PORT/api/inspection/trigger?scope=changed_files&include_unversioned=true&max_files=25"
@@ -59,6 +83,7 @@ curl "http://localhost:$IDE_PORT/api/inspection/status"
 ```
 
 Explicit files list:
+
 ```bash
 IDE_PORT=63341
 curl "http://localhost:$IDE_PORT/api/inspection/trigger?scope=files&file=src/app.py&file=tests/test_app.py"
@@ -66,6 +91,7 @@ curl "http://localhost:$IDE_PORT/api/inspection/status"
 ```
 
 Light inspection profile:
+
 ```bash
 IDE_PORT=63341
 curl "http://localhost:$IDE_PORT/api/inspection/trigger?profile=LLM%20Fast%20Checks"

--- a/inspection-core/src/main/kotlin/com/shiny/inspectionmcp/core/InspectionRouting.kt
+++ b/inspection-core/src/main/kotlin/com/shiny/inspectionmcp/core/InspectionRouting.kt
@@ -8,6 +8,7 @@ data class InspectionRouteProject(
     val basePath: String?,
     val projectFilePath: String?,
     val focused: Boolean,
+    val projectInstanceId: String? = null,
 )
 
 data class InspectionRouteIdentity(

--- a/inspection-core/src/test/kotlin/com/shiny/inspectionmcp/core/InspectionRoutingTest.kt
+++ b/inspection-core/src/test/kotlin/com/shiny/inspectionmcp/core/InspectionRoutingTest.kt
@@ -129,6 +129,7 @@ class InspectionRoutingTest {
             basePath = basePath,
             projectFilePath = projectFilePath,
             focused = focused,
+            projectInstanceId = "instance:$projectKey",
         )
     }
 }

--- a/mcp-server-jvm/src/main/kotlin/com/shiny/inspectionmcp/mcpserver/AutoRouting.kt
+++ b/mcp-server-jvm/src/main/kotlin/com/shiny/inspectionmcp/mcpserver/AutoRouting.kt
@@ -284,6 +284,7 @@ private fun toRouteIdentity(identity: JsonObject): InspectionRouteIdentity {
 private fun toRouteProject(project: JsonObject): InspectionRouteProject {
     return InspectionRouteProject(
         projectKey = project.string("project_key"),
+        projectInstanceId = project.string("project_instance_id"),
         name = project.string("name"),
         basePath = project.string("base_path"),
         projectFilePath = project.string("project_file_path"),

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -5,6 +5,7 @@ import com.intellij.codeInspection.InspectionManager
 import com.intellij.codeInspection.ui.InspectionResultsView
 import com.intellij.ide.DataManager
 import com.intellij.ide.RecentProjectsManagerBase
+import com.intellij.ide.impl.OpenProjectTask
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.fileEditor.FileEditorManager
@@ -12,6 +13,7 @@ import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.project.ex.ProjectManagerEx
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
@@ -37,7 +39,9 @@ import java.awt.Component
 import java.awt.Container
 import java.io.File
 import java.nio.file.Files
+import java.nio.file.Path
 import java.nio.file.Paths
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
@@ -113,6 +117,16 @@ internal data class InspectionRunState(
     val runId: Long,
     val triggerTimeMs: Long,
     val inProgress: Boolean,
+)
+
+internal data class InspectionProjectLease(
+    val closeToken: String,
+    val leaseId: String?,
+    val projectKey: String,
+    val projectInstanceId: String,
+    val basePath: String?,
+    val sessionId: String,
+    val claimedAtMs: Long,
 )
 
 internal fun parseGitStatusPorcelainZ(output: String): Pair<Set<String>, Set<String>> {
@@ -500,6 +514,19 @@ class InspectionHandler : HttpRequestHandler() {
     
     private val runIdSequence = AtomicLong()
     private val inspectionRunStatesByProject = java.util.concurrent.ConcurrentHashMap<String, InspectionRunState>()
+    private val leasesByProjectInstance = java.util.concurrent.ConcurrentHashMap<String, InspectionProjectLease>()
+    private val openingProjectPaths = java.util.concurrent.ConcurrentHashMap.newKeySet<String>()
+    internal var forceCloseProject: (Project) -> Boolean = { project ->
+        ProjectManagerEx.getInstanceEx().forceCloseProject(project, true)
+    }
+    internal var openProjectPath: (Path) -> Project? = { path ->
+        ProjectManagerEx.getInstanceEx().openProject(
+            path,
+            OpenProjectTask.build()
+                .withForceOpenInNewFrame(true)
+                .withProjectName(path.fileName?.toString() ?: path.toString()),
+        )
+    }
 
     private val resultsStore = InspectionResultsStore
 
@@ -537,6 +564,32 @@ class InspectionHandler : HttpRequestHandler() {
                         buildRouteResponse(parameters)
                     }
                     sendJsonResponse(context, result)
+                }
+                "/api/inspection/lifecycle/claim" -> {
+                    responseHasSessionDrift(parameters)?.let {
+                        sendJsonResponse(context, it, HttpResponseStatus.CONFLICT)
+                        return true
+                    }
+                    val result = ApplicationManager.getApplication().runReadAction<String, Exception> {
+                        buildLifecycleClaimResponse(parameters)
+                    }
+                    sendJsonResponse(context, result)
+                }
+                "/api/inspection/lifecycle/open" -> {
+                    responseHasSessionDrift(parameters)?.let {
+                        sendJsonResponse(context, it, HttpResponseStatus.CONFLICT)
+                        return true
+                    }
+                    val result = openLifecycleProject(parameters)
+                    sendJsonResponse(context, formatJsonManually(result.first), result.second)
+                }
+                "/api/inspection/lifecycle/close" -> {
+                    responseHasSessionDrift(parameters)?.let {
+                        sendJsonResponse(context, it, HttpResponseStatus.CONFLICT)
+                        return true
+                    }
+                    val result = closeLifecycleProject(parameters)
+                    sendJsonResponse(context, formatJsonManually(result.first), result.second)
                 }
                 "/api/inspection/problems" -> {
                     responseHasSessionDrift(parameters)?.let {
@@ -726,7 +779,193 @@ class InspectionHandler : HttpRequestHandler() {
         )
     }
 
+    private fun buildLifecycleClaimResponse(parameters: Map<String, List<String>>): String {
+        val resolved = resolveInspectionRoute(parameters)
+            ?: return formatJsonManually(buildMissingProjectResponse(routeProjectSelector(parameters)))
+        val expectedProjectInstanceId = firstParameter(parameters, "project_instance_id")
+        val actualProjectInstanceId = resolved.projectIdentity["project_instance_id"] as? String
+            ?: projectInstanceId(resolved.project)
+        if (expectedProjectInstanceId != null && expectedProjectInstanceId != actualProjectInstanceId) {
+            throw BadRequestException(
+                "project_instance_id",
+                "Project instance changed. Resolve the route again before claiming lifecycle ownership.",
+            )
+        }
+
+        val closeToken = UUID.randomUUID().toString()
+        val lease = InspectionProjectLease(
+            closeToken = closeToken,
+            leaseId = firstParameter(parameters, "lease_id"),
+            projectKey = resolved.projectIdentity["project_key"] as? String ?: projectKey(resolved.project),
+            projectInstanceId = actualProjectInstanceId,
+            basePath = resolved.projectIdentity["base_path"] as? String,
+            sessionId = InspectionIdeSession.sessionId,
+            claimedAtMs = System.currentTimeMillis(),
+        )
+        leasesByProjectInstance[actualProjectInstanceId] = lease
+
+        return formatJsonManually(
+            mapOf(
+                "status" to "claimed",
+                "close_token" to closeToken,
+                "lease_id" to lease.leaseId,
+                "project_instance_id" to actualProjectInstanceId,
+                "project_key" to lease.projectKey,
+                "session_id" to InspectionIdeSession.sessionId,
+                "route" to routeMetadata(resolved),
+                "claimed_at_ms" to lease.claimedAtMs,
+            ).filterValues { value -> value != null }
+        )
+    }
+
+    private fun openLifecycleProject(parameters: Map<String, List<String>>): Pair<Map<String, Any?>, HttpResponseStatus> {
+        val rawPath = firstParameter(parameters, "worktree_path")
+            ?: firstParameter(parameters, "project_path")
+            ?: throw BadRequestException("worktree_path", "Parameter 'worktree_path' is required.")
+        val normalizedPath = normalizeFileSystemPath(rawPath)
+            ?: throw BadRequestException("worktree_path", "Parameter 'worktree_path' must be a valid local path.")
+        val path = Paths.get(normalizedPath)
+        findOpenProjectByPath(path.toString())?.let { project ->
+            return mapOf(
+                "status" to "already_open",
+                "opened" to false,
+                "session_id" to InspectionIdeSession.sessionId,
+                "route" to routeMetadata(ResolvedInspectionRoute(project, safeInspectionIdentity(), openProjectIdentity(project))),
+            ) to HttpResponseStatus.OK
+        }
+        if (!Files.isDirectory(path)) {
+            throw BadRequestException("worktree_path", "Parameter 'worktree_path' must point to an existing directory.")
+        }
+        if (!openingProjectPaths.add(normalizedPath)) {
+            return mapOf(
+                "status" to "opening",
+                "opened" to false,
+                "opening_scheduled" to false,
+                "reason" to "already_opening",
+                "worktree_path" to path.toString(),
+                "session_id" to InspectionIdeSession.sessionId,
+            ) to HttpResponseStatus.OK
+        }
+
+        val scheduled = runCatching {
+            ApplicationManager.getApplication().invokeLater {
+                try {
+                    openProjectPath(path)
+                } finally {
+                    openingProjectPaths.remove(normalizedPath)
+                }
+            }
+        }.isSuccess
+        if (!scheduled) {
+            openingProjectPaths.remove(normalizedPath)
+            return mapOf(
+                "status" to "failed",
+                "opened" to false,
+                "reason" to "open_schedule_failed",
+                "message" to "JetBrains IDE declined or failed to schedule opening the requested project path.",
+                "worktree_path" to path.toString(),
+                "session_id" to InspectionIdeSession.sessionId,
+            ) to HttpResponseStatus.CONFLICT
+        }
+
+        return mapOf(
+            "status" to "opening",
+            "opened" to false,
+            "opening_scheduled" to true,
+            "worktree_path" to path.toString(),
+            "session_id" to InspectionIdeSession.sessionId,
+        ) to HttpResponseStatus.OK
+    }
+
+    private fun closeLifecycleProject(parameters: Map<String, List<String>>): Pair<Map<String, Any?>, HttpResponseStatus> {
+        val closeToken = firstParameter(parameters, "close_token")
+            ?: throw BadRequestException("close_token", "Parameter 'close_token' is required.")
+        val expectedProjectInstanceId = firstParameter(parameters, "project_instance_id")
+            ?: throw BadRequestException("project_instance_id", "Parameter 'project_instance_id' is required.")
+        val lease = leasesByProjectInstance[expectedProjectInstanceId]
+            ?: return lifecycleCloseSkipped("not_claimed", "No helper lifecycle claim exists for this project instance.")
+        if (lease.closeToken != closeToken) {
+            return lifecycleCloseSkipped("token_mismatch", "Close token did not match the helper lifecycle claim.", HttpResponseStatus.FORBIDDEN)
+        }
+        if (lease.sessionId != InspectionIdeSession.sessionId) {
+            leasesByProjectInstance.remove(expectedProjectInstanceId)
+            return lifecycleCloseSkipped("session_drift", "IDE session changed before cleanup; leaving the project open.", HttpResponseStatus.CONFLICT)
+        }
+
+        val project = findOpenProjectByInstanceId(expectedProjectInstanceId)
+            ?: run {
+                leasesByProjectInstance.remove(expectedProjectInstanceId, lease)
+                return lifecycleCloseSkipped("route_missing", "Claimed project is no longer open; cleanup is already complete.")
+            }
+        if (projectKey(project) != lease.projectKey) {
+            leasesByProjectInstance.remove(expectedProjectInstanceId, lease)
+            return lifecycleCloseSkipped("project_mismatch", "Claimed project key no longer matches the lifecycle claim.", HttpResponseStatus.CONFLICT)
+        }
+
+        val closed = runCatching {
+            val application = ApplicationManager.getApplication()
+            if (application.isDispatchThread) {
+                forceCloseProject(project)
+            } else {
+                val closeResult = AtomicReference<Boolean>()
+                application.invokeAndWait {
+                    closeResult.set(forceCloseProject(project))
+                }
+                closeResult.get() == true
+            }
+        }.getOrDefault(false)
+
+        if (!closed) {
+            return lifecycleCloseSkipped("close_failed", "JetBrains IDE declined or failed to close the claimed project.", HttpResponseStatus.CONFLICT)
+        }
+        leasesByProjectInstance.remove(expectedProjectInstanceId, lease)
+        return mapOf(
+            "status" to "closed",
+            "project_instance_id" to expectedProjectInstanceId,
+            "project_key" to lease.projectKey,
+            "lease_id" to lease.leaseId,
+            "session_id" to InspectionIdeSession.sessionId,
+            "closed_at_ms" to System.currentTimeMillis(),
+        ).filterValues { value -> value != null } to HttpResponseStatus.OK
+    }
+
+    private fun lifecycleCloseSkipped(
+        reason: String,
+        message: String,
+        status: HttpResponseStatus = HttpResponseStatus.OK,
+    ): Pair<Map<String, Any?>, HttpResponseStatus> {
+        return mapOf(
+            "status" to "skipped",
+            "cleanup_skipped" to true,
+            "reason" to reason,
+            "message" to message,
+            "session_id" to InspectionIdeSession.sessionId,
+        ) to status
+    }
+
+    private fun findOpenProjectByInstanceId(projectInstanceId: String): Project? {
+        return ApplicationManager.getApplication().runReadAction<Project?, Exception> {
+            ProjectManager.getInstance().openProjects.firstOrNull { project ->
+                isUsableProject(project) && projectInstanceId(project) == projectInstanceId
+            }
+        }
+    }
+
+    private fun findOpenProjectByPath(path: String): Project? {
+        val normalized = normalizeFileSystemPath(path) ?: return null
+        return ApplicationManager.getApplication().runReadAction<Project?, Exception> {
+            ProjectManager.getInstance().openProjects.firstOrNull { project ->
+                isUsableProject(project) &&
+                    (normalizeFileSystemPath(project.basePath) == normalized ||
+                        normalizeFileSystemPath(project.projectFilePath) == normalized ||
+                        projectKey(project) == "path:$normalized" ||
+                        projectKey(project) == "file:$normalized")
+            }
+        }
+    }
+
     private fun resolveInspectionRoute(parameters: Map<String, List<String>>): ResolvedInspectionRoute? {
+        val expectedProjectInstanceId = firstParameter(parameters, "project_instance_id")?.trim()?.takeIf { it.isNotEmpty() }
         val selector = InspectionRouteSelector(
             projectKey = firstParameter(parameters, "project_key"),
             projectPath = firstParameter(parameters, "project_path"),
@@ -758,10 +997,26 @@ class InspectionHandler : HttpRequestHandler() {
                 "Multiple open projects matched this request. Retry with project_path or project_key.",
             )
         }
-        val projectKey = selected.project.projectKey ?: return null
-        val project = getCurrentProject(projectKey) ?: return null
+        val project = resolveProjectFromRouteProject(selected.project) ?: return null
         val projectIdentity = openProjectIdentity(project)
+        val actualProjectInstanceId = projectIdentity["project_instance_id"] as? String
+            ?: projectInstanceId(project)
+        if (expectedProjectInstanceId != null && expectedProjectInstanceId != actualProjectInstanceId) {
+            throw BadRequestException(
+                "project_instance_id",
+                "Requested project instance does not match the resolved route. Resolve the route again before continuing.",
+            )
+        }
         return ResolvedInspectionRoute(project, identity, projectIdentity, selected.score)
+    }
+
+    private fun resolveProjectFromRouteProject(routeProject: InspectionRouteProject): Project? {
+        routeProject.projectInstanceId?.let { selectedInstanceId ->
+            ProjectManager.getInstance().openProjects.firstOrNull { project ->
+                isUsableProject(project) && projectInstanceId(project) == selectedInstanceId
+            }?.let { return it }
+        }
+        return routeProject.projectKey?.let(::getCurrentProject)
     }
 
     private fun routePathMatchScore(project: InspectionRouteProject, selectorPath: String?): Int? {
@@ -802,6 +1057,7 @@ class InspectionHandler : HttpRequestHandler() {
             "started_at_ms" to resolved.identity["started_at_ms"],
             "heartbeat_ms" to resolved.identity["heartbeat_ms"],
             "project_key" to resolved.projectIdentity["project_key"],
+            "project_instance_id" to resolved.projectIdentity["project_instance_id"],
             "project_name" to resolved.projectIdentity["name"],
             "base_path" to resolved.projectIdentity["base_path"],
             "project_file_path" to resolved.projectIdentity["project_file_path"],
@@ -869,6 +1125,7 @@ class InspectionHandler : HttpRequestHandler() {
                 ?: openProjectIdentities()).map { identity ->
                 InspectionRouteProject(
                     projectKey = identity["project_key"] as? String,
+                    projectInstanceId = identity["project_instance_id"] as? String,
                     name = identity["name"] as? String,
                     basePath = identity["base_path"] as? String,
                     projectFilePath = identity["project_file_path"] as? String,
@@ -2179,7 +2436,6 @@ class InspectionHandler : HttpRequestHandler() {
                                 "last_extraction_cycle_succeeded" to lastExtractionCycleSucceeded,
                                 "last_tool_extraction_succeeded" to lastToolExtractionSucceeded,
                                 "scoped_context_results_empty" to scopedContextResults.isEmpty(),
-                                "best_results_empty" to bestResults.isEmpty(),
                                 "readable_empty_inspection_view_stable_for_ms" to readableStableForMs,
                                 "last_view_observation" to mapOf(
                                     "is_updating" to lastObservation?.isUpdating,
@@ -2750,6 +3006,11 @@ class InspectionHandler : HttpRequestHandler() {
         val projectManager = ProjectManager.getInstance()
         val openProjects = projectManager.openProjects
         val trimmed = projectName.trim()
+        if (trimmed.contains(':') && !looksLikePath(trimmed)) {
+            openProjects.firstOrNull { project ->
+                isUsableProject(project) && projectInstanceId(project) == trimmed
+            }?.let { return it }
+        }
         val pathHint = normalizeProjectPath(trimmed)
 
         val matches = openProjects.filter { project ->
@@ -2849,7 +3110,7 @@ class InspectionHandler : HttpRequestHandler() {
         urlDecoder: QueryStringDecoder,
         request: FullHttpRequest,
     ): String? {
-        for (parameterName in listOf("project_key", "project_path", "worktree_path", "cwd", "project")) {
+        for (parameterName in listOf("project_instance_id", "project_key", "project_path", "worktree_path", "cwd", "project")) {
             val parameterValues = urlDecoder.parameters()[parameterName]
             if (parameterValues != null) {
                 val firstNonBlankValue = parameterValues.firstOrNull { value -> value.trim().isNotEmpty() }
@@ -2870,7 +3131,7 @@ class InspectionHandler : HttpRequestHandler() {
             }
             val nameAndValue = segment.split('=', limit = 2)
             val decodedName = QueryStringDecoder.decodeComponent(nameAndValue[0])
-            if (decodedName !in setOf("project", "project_key", "project_path", "worktree_path", "cwd")) {
+            if (decodedName !in setOf("project", "project_instance_id", "project_key", "project_path", "worktree_path", "cwd")) {
                 continue
             }
             val encodedValue = nameAndValue.getOrElse(1) { "" }

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionIdeIdentity.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionIdeIdentity.kt
@@ -155,11 +155,16 @@ internal fun openProjectIdentities(): List<Map<String, Any?>> {
 internal fun openProjectIdentity(project: Project): Map<String, Any?> {
     return mapOf(
         "project_key" to projectKey(project),
+        "project_instance_id" to projectInstanceId(project),
         "name" to runCatching { project.name }.getOrDefault(""),
         "base_path" to runCatching { project.basePath }.getOrNull(),
         "project_file_path" to runCatching { project.projectFilePath }.getOrNull(),
         "focused" to isFocusedProject(project),
     )
+}
+
+internal fun projectInstanceId(project: Project): String {
+    return "${InspectionIdeSession.sessionId}:${System.identityHashCode(project)}"
 }
 
 private fun isFocusedProject(project: Project): Boolean {

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -40,6 +40,8 @@ import org.jetbrains.concurrency.Promise
 import org.jetbrains.concurrency.resolvedPromise
 import org.jetbrains.concurrency.rejectedPromise
 import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
 import javax.swing.JFrame
 import javax.swing.JPanel
 
@@ -764,6 +766,331 @@ class InspectionHandlerTest {
     }
 
     @Test
+    fun `test route endpoint includes project instance id`() {
+        every { mockProject.basePath } returns "/repo/app"
+        every { mockProject.projectFilePath } returns "/repo/app/.idea/misc.xml"
+
+        val response = processGetRequest("/api/inspection/route?worktree_path=/repo/app")
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"project_instance_id\""))
+    }
+
+    @Test
+    fun `test lifecycle claim returns close token for exact project instance`() {
+        every { mockProject.basePath } returns "/repo/app"
+        every { mockProject.projectFilePath } returns "/repo/app/.idea/misc.xml"
+        val instanceId = projectInstanceId(mockProject)
+
+        val response = processGetRequest(
+            "/api/inspection/lifecycle/claim?worktree_path=/repo/app&project_instance_id=$instanceId&lease_id=test-lease"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"status\": \"claimed\""))
+        assertTrue(body.contains("\"close_token\""))
+        assertTrue(body.contains("\"lease_id\": \"test-lease\""))
+    }
+
+    @Test
+    fun `test lifecycle claim rejects stale project instance id`() {
+        every { mockProject.basePath } returns "/repo/app"
+        every { mockProject.projectFilePath } returns "/repo/app/.idea/misc.xml"
+
+        val response = processGetRequest(
+            "/api/inspection/lifecycle/claim?worktree_path=/repo/app&project_instance_id=old-instance"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.BAD_REQUEST, response.status())
+        assertTrue(body.contains("does not match the resolved route"))
+    }
+
+    @Test
+    fun `test lifecycle open opens project path in running IDE`() {
+        val tempDir = Files.createTempDirectory("inspection-open-test")
+        val openedProject = mockProject(
+            name = "Opened",
+            basePath = tempDir.toString(),
+            projectFilePath = tempDir.resolve(".idea/misc.xml").toString(),
+        )
+        every { mockProjectManager.openProjects } returns emptyArray()
+        every { mockApplication.invokeLater(any()) } answers {
+            firstArg<Runnable>().run()
+        }
+        var openedPath: Path? = null
+        handler.openProjectPath = { path: Path ->
+            openedPath = path
+            openedProject
+        }
+
+        val response = processGetRequest(
+            "/api/inspection/lifecycle/open?worktree_path=${java.net.URLEncoder.encode(tempDir.toString(), "UTF-8") }"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"status\": \"opening\""))
+        assertTrue(body.contains("\"opened\": false"))
+        assertTrue(body.contains("\"opening_scheduled\": true"))
+        assertTrue(body.contains(tempDir.toString()))
+        assertEquals(tempDir.toAbsolutePath().normalize(), openedPath)
+    }
+
+    @Test
+    fun `test lifecycle open reports already open exact project`() {
+        val tempDir = Files.createTempDirectory("inspection-open-existing")
+        every { mockProject.basePath } returns tempDir.toString()
+        every { mockProject.projectFilePath } returns tempDir.resolve(".idea/misc.xml").toString()
+
+        val response = processGetRequest(
+            "/api/inspection/lifecycle/open?worktree_path=${java.net.URLEncoder.encode(tempDir.toString(), "UTF-8") }"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"status\": \"already_open\""))
+        assertTrue(body.contains("\"opened\": false"))
+    }
+
+    @Test
+    fun `test lifecycle open reports already open project file path`() {
+        val tempDir = Files.createTempDirectory("inspection-open-file-existing")
+        val projectFilePath = tempDir.resolve(".idea/misc.xml").toString()
+        every { mockProject.basePath } returns null
+        every { mockProject.projectFilePath } returns projectFilePath
+
+        val response = processGetRequest(
+            "/api/inspection/lifecycle/open?worktree_path=${java.net.URLEncoder.encode(projectFilePath, "UTF-8") }"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"status\": \"already_open\""))
+        assertTrue(body.contains("\"opened\": false"))
+    }
+
+    @Test
+    fun `test lifecycle open coalesces duplicate concurrent opens`() {
+        val tempDir = Files.createTempDirectory("inspection-open-duplicate")
+        every { mockProjectManager.openProjects } returns emptyArray()
+        val scheduled = mutableListOf<Runnable>()
+        every { mockApplication.invokeLater(any()) } answers {
+            scheduled += firstArg<Runnable>()
+        }
+        handler.openProjectPath = { mockProject }
+
+        val encodedPath = java.net.URLEncoder.encode(tempDir.toString(), "UTF-8")
+        val first = processGetRequest("/api/inspection/lifecycle/open?worktree_path=$encodedPath")
+        val second = processGetRequest("/api/inspection/lifecycle/open?worktree_path=$encodedPath")
+        val secondBody = second.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, first.status())
+        assertEquals(HttpResponseStatus.OK, second.status())
+        assertEquals(1, scheduled.size)
+        assertTrue(secondBody.contains("\"reason\": \"already_opening\""))
+        assertTrue(secondBody.contains("\"opening_scheduled\": false"))
+        scheduled.single().run()
+        val third = processGetRequest("/api/inspection/lifecycle/open?worktree_path=$encodedPath")
+        assertEquals(2, scheduled.size)
+        assertEquals(HttpResponseStatus.OK, third.status())
+    }
+
+    @Test
+    fun `test lifecycle open normalizes home-relative path for already open project`() {
+        val home = System.getProperty("user.home")
+        val projectPath = Paths.get(home, "repo-open-existing").toString()
+        every { mockProject.basePath } returns projectPath
+        every { mockProject.projectFilePath } returns Paths.get(projectPath, ".idea/misc.xml").toString()
+
+        val response = processGetRequest(
+            "/api/inspection/lifecycle/open?worktree_path=${java.net.URLEncoder.encode("~/repo-open-existing", "UTF-8") }"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"status\": \"already_open\""))
+        assertTrue(body.contains("\"opened\": false"))
+    }
+
+    @Test
+    fun `test route endpoint rejects missing project instance id without fallback`() {
+        every { mockProject.basePath } returns "/repo/app"
+        every { mockProject.projectFilePath } returns "/repo/app/.idea/misc.xml"
+
+        val response = processGetRequest(
+            "/api/inspection/route?worktree_path=/repo/app&project_instance_id=old-instance"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.BAD_REQUEST, response.status())
+        assertTrue(body.contains("does not match the resolved route"))
+        assertFalse(body.contains("\"status\": \"resolved\""))
+    }
+
+    @Test
+    fun `test route endpoint rejects project instance id that conflicts with path selector`() {
+        val mainProject = mockProject(
+            name = "Main",
+            basePath = "/repo/main",
+            projectFilePath = "/repo/main/.idea/misc.xml",
+        )
+        val worktreeProject = mockProject(
+            name = "Worktree",
+            basePath = "/repo/worktree",
+            projectFilePath = "/repo/worktree/.idea/misc.xml",
+        )
+        every { mockProjectManager.openProjects } returns arrayOf(mainProject, worktreeProject)
+
+        val response = processGetRequest(
+            "/api/inspection/route?worktree_path=/repo/main&project_instance_id=${projectInstanceId(worktreeProject)}"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.BAD_REQUEST, response.status())
+        assertTrue(body.contains("does not match the resolved route"))
+        assertFalse(body.contains("\"project_key\": \"path:/repo/worktree\""))
+    }
+
+    @Test
+    fun `test lifecycle close rejects mismatched close token`() {
+        every { mockProject.basePath } returns "/repo/app"
+        every { mockProject.projectFilePath } returns "/repo/app/.idea/misc.xml"
+        val instanceId = projectInstanceId(mockProject)
+        processGetRequest(
+            "/api/inspection/lifecycle/claim?worktree_path=/repo/app&project_instance_id=$instanceId&lease_id=test-lease"
+        )
+
+        val response = processGetRequest(
+            "/api/inspection/lifecycle/close?worktree_path=/repo/app&project_instance_id=$instanceId&close_token=wrong"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.FORBIDDEN, response.status())
+        assertTrue(body.contains("\"status\": \"skipped\""))
+        assertTrue(body.contains("\"reason\": \"token_mismatch\""))
+    }
+
+    @Test
+    fun `test lifecycle close uses claimed project instance even when route selectors drift`() {
+        val mainProject = mockProject(
+            name = "Main",
+            basePath = "/repo/main",
+            projectFilePath = "/repo/main/.idea/misc.xml",
+        )
+        val worktreeProject = mockProject(
+            name = "Worktree",
+            basePath = "/repo/worktree",
+            projectFilePath = "/repo/worktree/.idea/misc.xml",
+        )
+        every { mockProjectManager.openProjects } returns arrayOf(mainProject, worktreeProject)
+        val instanceId = projectInstanceId(worktreeProject)
+        val claim = processGetRequest(
+            "/api/inspection/lifecycle/claim?worktree_path=/repo/worktree&project_instance_id=$instanceId&lease_id=test-lease"
+        ).content().toString(Charsets.UTF_8)
+        val token = Regex("\"close_token\": \"([^\"]+)\"").find(claim)?.groupValues?.get(1)
+        assertNotNull(token)
+        every { mockApplication.isDispatchThread } returns true
+        var closedProject: Project? = null
+        handler.forceCloseProject = { project ->
+            closedProject = project
+            true
+        }
+
+        val response = processGetRequest(
+            "/api/inspection/lifecycle/close?project_key=${projectKey(mainProject)}&project_instance_id=$instanceId&close_token=$token"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"status\": \"closed\""))
+        assertSame(worktreeProject, closedProject)
+    }
+
+    @Test
+    fun `test lifecycle close evicts lease when claimed project is missing`() {
+        every { mockProject.basePath } returns "/repo/app"
+        every { mockProject.projectFilePath } returns "/repo/app/.idea/misc.xml"
+        val instanceId = projectInstanceId(mockProject)
+        val claim = processGetRequest(
+            "/api/inspection/lifecycle/claim?worktree_path=/repo/app&project_instance_id=$instanceId&lease_id=test-lease"
+        ).content().toString(Charsets.UTF_8)
+        val token = Regex("\"close_token\": \"([^\"]+)\"").find(claim)?.groupValues?.get(1)
+        assertNotNull(token)
+        every { mockProjectManager.openProjects } returns emptyArray()
+
+        val first = processGetRequest(
+            "/api/inspection/lifecycle/close?worktree_path=/repo/app&project_instance_id=$instanceId&close_token=$token"
+        )
+        val second = processGetRequest(
+            "/api/inspection/lifecycle/close?worktree_path=/repo/app&project_instance_id=$instanceId&close_token=$token"
+        )
+
+        assertEquals(HttpResponseStatus.OK, first.status())
+        assertTrue(first.content().toString(Charsets.UTF_8).contains("\"reason\": \"route_missing\""))
+        assertTrue(second.content().toString(Charsets.UTF_8).contains("\"reason\": \"not_claimed\""))
+    }
+
+    @Test
+    fun `test lifecycle close keeps lease when close fails`() {
+        every { mockProject.basePath } returns "/repo/app"
+        every { mockProject.projectFilePath } returns "/repo/app/.idea/misc.xml"
+        val instanceId = projectInstanceId(mockProject)
+        val claim = processGetRequest(
+            "/api/inspection/lifecycle/claim?worktree_path=/repo/app&project_instance_id=$instanceId&lease_id=test-lease"
+        ).content().toString(Charsets.UTF_8)
+        val token = Regex("\"close_token\": \"([^\"]+)\"").find(claim)?.groupValues?.get(1)
+        assertNotNull(token)
+        every { mockApplication.isDispatchThread } returns true
+        handler.forceCloseProject = { false }
+
+        val first = processGetRequest(
+            "/api/inspection/lifecycle/close?worktree_path=/repo/app&project_instance_id=$instanceId&close_token=$token"
+        )
+        val second = processGetRequest(
+            "/api/inspection/lifecycle/close?worktree_path=/repo/app&project_instance_id=$instanceId&close_token=$token"
+        )
+
+        assertEquals(HttpResponseStatus.CONFLICT, first.status())
+        assertEquals(HttpResponseStatus.CONFLICT, second.status())
+        assertTrue(first.content().toString(Charsets.UTF_8).contains("\"reason\": \"close_failed\""))
+        assertTrue(second.content().toString(Charsets.UTF_8).contains("\"reason\": \"close_failed\""))
+    }
+
+    @Test
+    fun `test trigger endpoint honors project instance id over duplicate path keys`() {
+        val mainProject = mockProject(
+            name = "Main",
+            basePath = "/repo/main",
+            projectFilePath = "/repo/main/.idea/misc.xml",
+        )
+        val worktreeProject = mockProject(
+            name = "Worktree",
+            basePath = "/repo/worktree",
+            projectFilePath = "/repo/worktree/.idea/misc.xml",
+        )
+        every { mockProjectManager.openProjects } returns arrayOf(mainProject, worktreeProject)
+        every { mockApplication.isDispatchThread } returns true
+        every { mockVirtualFileManager.syncRefresh() } returns 0L
+        every { mockApplication.executeOnPooledThread(any<Runnable>()) } answers {
+            firstArg<Runnable>().run()
+            mockk(relaxed = true)
+        }
+        mockInspectionPrerequisites(worktreeProject)
+
+        val response = processTriggerRequest(
+            "/api/inspection/trigger?project_instance_id=${projectInstanceId(worktreeProject)}&scope=changed_files&include_unversioned=false"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"project_key\": \"path:/repo/worktree\""))
+        assertFalse(body.contains("\"project_key\": \"path:/repo/main\""))
+    }
+
+    @Test
     fun `test route endpoint rejects ambiguous project names`() {
         val firstProject = mockProject(
             name = "Shared",
@@ -1023,5 +1350,36 @@ class InspectionHandlerTest {
         every { project.basePath } returns basePath
         every { project.projectFilePath } returns projectFilePath
         return project
+    }
+
+    private fun mockInspectionPrerequisites(project: Project) {
+        val fileDocumentManager = mockk<FileDocumentManager>(relaxed = true)
+        mockkStatic(FileDocumentManager::class)
+        every { FileDocumentManager.getInstance() } returns fileDocumentManager
+        every { fileDocumentManager.unsavedDocuments } returns emptyArray()
+
+        val psiDocumentManager = mockk<PsiDocumentManager>(relaxed = true)
+        mockkStatic(PsiDocumentManager::class)
+        every { PsiDocumentManager.getInstance(project) } returns psiDocumentManager
+
+        mockkStatic(ChangeListManager::class)
+        val changeListManager = mockk<ChangeListManager>(relaxed = true)
+        every { ChangeListManager.getInstance(project) } returns changeListManager
+        every { changeListManager.allChanges } returns emptyList()
+
+        mockkStatic(PsiModificationTracker::class)
+        val modificationTracker = mockk<PsiModificationTracker>()
+        every { PsiModificationTracker.getInstance(project) } returns modificationTracker
+        every { modificationTracker.modificationCount } returns 11L
+
+        mockkStatic(ToolWindowManager::class)
+        val toolWindowManager = mockk<ToolWindowManager>()
+        every { ToolWindowManager.getInstance(project) } returns toolWindowManager
+        every { toolWindowManager.getToolWindow(any()) } returns null
+
+        mockkStatic(DumbService::class)
+        val dumbService = mockk<DumbService>()
+        every { DumbService.getInstance(project) } returns dumbService
+        every { dumbService.isDumb } returns false
     }
 }


### PR DESCRIPTION
## Summary

Adds explicit lifecycle support for inspecting trusted linked worktrees that are not already open in a JetBrains IDE.

- Adds `/api/inspection/lifecycle/open`, `/claim`, and `/close` helper endpoints.
- Keeps normal inspection APIs open-project-only; only helper `closeout` owns auto-open behavior.
- Adds stable `project_instance_id` route metadata and guard semantics.
- Coalesces duplicate concurrent lifecycle-open requests by normalized path.
- Opens helper-owned worktrees in a new frame with the worktree directory as project name, which avoids WebStorm duplicate `.idea` project identity stalls.
- Updates route/worktree docs and smoke instructions.

Companion skill/helper PR: https://github.com/cbusillo/codex-skills/pull/new/task/inspection-worktree-lifecycle-helper

Closes #47.
Closes #48.
Closes #49.
Closes #51.
Related to #50.

## Validation

- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./scripts/commit-gate.sh --ci`
- `python3 -m py_compile jetbrains-inspection/scripts/jb-inspect.py && python3 jetbrains-inspection/tests/test_jb_inspect.py` in `codex-skills`: 51 tests OK
- `git diff --check` in this repo and `codex-skills`
- Final implementation closeout: `clean: true`, `problem_count: 0`
- Real-session IDE smokes:
  - IntelliJ IDEA 2026.1.2: trusted linked worktree opened, inspected clean, cleanup `closed`
  - PyCharm 2026.1.2: trusted linked worktree opened, inspected clean, cleanup `closed`
  - WebStorm 2026.1.2: trusted linked worktree opened, inspected clean, cleanup `closed`
  - WebStorm post-review rerun after duplicate-open/full-identity fixes: clean, cleanup `closed`, post-registry smoke count 0, leases clear

## Notes

This PR relies on the companion helper update for the autonomous `closeout` workflow. The plugin API is intentionally conservative: direct route/trigger/wait/problems endpoints do not open projects implicitly.
