### PR TITLE
Avoid duplicate lifecycle opens for nested selectors

### DIFF
--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -825,7 +825,7 @@ class InspectionHandler : HttpRequestHandler() {
         val normalizedPath = normalizeFileSystemPath(rawPath)
             ?: throw BadRequestException("worktree_path", "Parameter 'worktree_path' must be a valid local path.")
         val path = Paths.get(normalizedPath)
-        findOpenProjectByPath(path.toString())?.let { project ->
+        findOpenProjectForLifecycleOpen(path.toString())?.let { project ->
             return mapOf(
                 "status" to "already_open",
                 "opened" to false,
@@ -875,6 +875,11 @@ class InspectionHandler : HttpRequestHandler() {
             "worktree_path" to path.toString(),
             "session_id" to InspectionIdeSession.sessionId,
         ) to HttpResponseStatus.OK
+    }
+
+    private fun findOpenProjectForLifecycleOpen(path: String): Project? {
+        return findOpenProjectByPath(path)
+            ?: resolveInspectionRoute(mapOf("worktree_path" to listOf(path)))?.project
     }
 
     private fun closeLifecycleProject(parameters: Map<String, List<String>>): Pair<Map<String, Any?>, HttpResponseStatus> {

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -856,6 +856,29 @@ class InspectionHandlerTest {
     }
 
     @Test
+    fun `test lifecycle open reports already open containing project selector`() {
+        val tempDir = Files.createTempDirectory("inspection-open-containing")
+        val nestedPath = tempDir.resolve("packages/app")
+        Files.createDirectories(nestedPath)
+        every { mockProject.basePath } returns tempDir.toString()
+        every { mockProject.projectFilePath } returns tempDir.resolve(".idea/misc.xml").toString()
+        var scheduled = false
+        every { mockApplication.invokeLater(any()) } answers {
+            scheduled = true
+        }
+
+        val response = processGetRequest(
+            "/api/inspection/lifecycle/open?worktree_path=${java.net.URLEncoder.encode(nestedPath.toString(), "UTF-8") }"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"status\": \"already_open\""))
+        assertTrue(body.contains("\"opened\": false"))
+        assertFalse(scheduled)
+    }
+
+    @Test
     fun `test lifecycle open reports already open project file path`() {
         val tempDir = Files.createTempDirectory("inspection-open-file-existing")
         val projectFilePath = tempDir.resolve(".idea/misc.xml").toString()


### PR DESCRIPTION
## Summary
- Resolve lifecycle/open selectors through the existing route matcher before scheduling an IDE open.
- Prevent nested/equivalent path selectors from opening another IDE frame when they already map to an open project.
- Add regression coverage that a nested selector returns already_open and does not schedule invokeLater.

## Validation
- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test --tests 'com.shiny.inspectionmcp.InspectionHandlerTest'
- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./scripts/commit-gate.sh --ci
- uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py --json closeout --repo /Users/cbusillo/Developer/jetbrains-inspection-api --scope changed_files --timeout-ms 120000