### PR TITLE
Require exact matches for lifecycle open

### DIFF
--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -879,7 +879,6 @@ class InspectionHandler : HttpRequestHandler() {
 
     private fun findOpenProjectForLifecycleOpen(path: String): Project? {
         return findOpenProjectByPath(path)
-            ?: resolveInspectionRoute(mapOf("worktree_path" to listOf(path)))?.project
     }
 
     private fun closeLifecycleProject(parameters: Map<String, List<String>>): Pair<Map<String, Any?>, HttpResponseStatus> {

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -856,15 +856,19 @@ class InspectionHandlerTest {
     }
 
     @Test
-    fun `test lifecycle open reports already open containing project selector`() {
+    fun `test lifecycle open schedules nested worktree when containing project is open`() {
         val tempDir = Files.createTempDirectory("inspection-open-containing")
         val nestedPath = tempDir.resolve("packages/app")
         Files.createDirectories(nestedPath)
         every { mockProject.basePath } returns tempDir.toString()
         every { mockProject.projectFilePath } returns tempDir.resolve(".idea/misc.xml").toString()
-        var scheduled = false
+        var openedPath: Path? = null
         every { mockApplication.invokeLater(any()) } answers {
-            scheduled = true
+            firstArg<Runnable>().run()
+        }
+        handler.openProjectPath = { path: Path ->
+            openedPath = path
+            mockProject
         }
 
         val response = processGetRequest(
@@ -873,9 +877,10 @@ class InspectionHandlerTest {
         val body = response.content().toString(Charsets.UTF_8)
 
         assertEquals(HttpResponseStatus.OK, response.status())
-        assertTrue(body.contains("\"status\": \"already_open\""))
+        assertTrue(body.contains("\"status\": \"opening\""))
         assertTrue(body.contains("\"opened\": false"))
-        assertFalse(scheduled)
+        assertTrue(body.contains("\"opening_scheduled\": true"))
+        assertEquals(nestedPath.toAbsolutePath().normalize(), openedPath)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- require lifecycle/open to short-circuit only on exact open project identity/path matches
- schedule nested worktree opens even when an already-open containing project could route the selector
- update the lifecycle-open regression test to prove nested worktrees are opened separately

## Validation

- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test --tests 'com.shiny.inspectionmcp.InspectionHandlerTest'`
- `./scripts/commit-gate.sh --ci`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py --json closeout --repo /Users/cbusillo/Developer/jetbrains-inspection-api --scope changed_files --timeout-ms 120000`
