### PR TITLE
Detect lifecycle open roots from project files

### DIFF
--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -961,10 +961,23 @@ class InspectionHandler : HttpRequestHandler() {
             ProjectManager.getInstance().openProjects.firstOrNull { project ->
                 isUsableProject(project) &&
                     (normalizeFileSystemPath(project.basePath) == normalized ||
+                        projectRootFromProjectFilePath(project.projectFilePath) == normalized ||
                         normalizeFileSystemPath(project.projectFilePath) == normalized ||
                         projectKey(project) == "path:$normalized" ||
                         projectKey(project) == "file:$normalized")
             }
+        }
+    }
+
+    private fun projectRootFromProjectFilePath(projectFilePath: String?): String? {
+        val normalizedProjectFilePath = normalizeFileSystemPath(projectFilePath) ?: return null
+        val path = runCatching { Paths.get(normalizedProjectFilePath) }.getOrNull() ?: return null
+        return when {
+            path.fileName?.toString() == "misc.xml" && path.parent?.fileName?.toString() == ".idea" ->
+                path.parent?.parent?.toString()
+            path.fileName?.toString()?.endsWith(".ipr") == true ->
+                path.parent?.toString()
+            else -> null
         }
     }
 

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -901,6 +901,50 @@ class InspectionHandlerTest {
     }
 
     @Test
+    fun `test lifecycle open detects already open project root from project file path`() {
+        val tempDir = Files.createTempDirectory("inspection-open-file-root-existing")
+        val projectFilePath = tempDir.resolve(".idea/misc.xml").toString()
+        every { mockProject.basePath } returns null
+        every { mockProject.projectFilePath } returns projectFilePath
+        var scheduled = false
+        every { mockApplication.invokeLater(any()) } answers {
+            scheduled = true
+        }
+
+        val response = processGetRequest(
+            "/api/inspection/lifecycle/open?worktree_path=${java.net.URLEncoder.encode(tempDir.toString(), "UTF-8") }"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"status\": \"already_open\""))
+        assertTrue(body.contains("\"opened\": false"))
+        assertFalse(scheduled)
+    }
+
+    @Test
+    fun `test lifecycle open detects already open ipr project root`() {
+        val tempDir = Files.createTempDirectory("inspection-open-ipr-root-existing")
+        val projectFilePath = tempDir.resolve("project.ipr").toString()
+        every { mockProject.basePath } returns null
+        every { mockProject.projectFilePath } returns projectFilePath
+        var scheduled = false
+        every { mockApplication.invokeLater(any()) } answers {
+            scheduled = true
+        }
+
+        val response = processGetRequest(
+            "/api/inspection/lifecycle/open?worktree_path=${java.net.URLEncoder.encode(tempDir.toString(), "UTF-8") }"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"status\": \"already_open\""))
+        assertTrue(body.contains("\"opened\": false"))
+        assertFalse(scheduled)
+    }
+
+    @Test
     fun `test lifecycle open coalesces duplicate concurrent opens`() {
         val tempDir = Files.createTempDirectory("inspection-open-duplicate")
         every { mockProjectManager.openProjects } returns emptyArray()


### PR DESCRIPTION
## Summary

- detect already-open lifecycle projects from `.idea/misc.xml` when `basePath` is missing
- detect legacy `.ipr` project roots as already open
- keep nested worktree lifecycle/open behavior exact so containing projects do not suppress distinct worktree opens

## Validation

- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test --tests 'com.shiny.inspectionmcp.InspectionHandlerTest'`
- `./scripts/commit-gate.sh --ci`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py --json closeout --repo /Users/cbusillo/Developer/jetbrains-inspection-api --scope changed_files --timeout-ms 120000`
