### PR TITLE
Route project-file roots consistently

### DIFF
--- a/inspection-core/src/main/kotlin/com/shiny/inspectionmcp/core/InspectionRouting.kt
+++ b/inspection-core/src/main/kotlin/com/shiny/inspectionmcp/core/InspectionRouting.kt
@@ -112,6 +112,7 @@ private fun scoreProject(
     val projectKey = project.projectKey
     val projectName = project.name
     val basePath = normalizeRoutePath(project.basePath)
+        ?: projectRootFromProjectFilePath(project.projectFilePath)
     val projectFilePath = normalizeRoutePath(project.projectFilePath)
 
     if (explicitProjectKey != null) {
@@ -158,4 +159,14 @@ private fun looksLikeRoutePath(value: String): Boolean {
 
 private fun normalizedRoutePathLength(path: String?): Int {
     return normalizeRoutePath(path)?.length ?: 0
+}
+
+fun projectRootFromProjectFilePath(projectFilePath: String?): String? {
+    val normalizedProjectFilePath = normalizeRoutePath(projectFilePath) ?: return null
+    val path = runCatching { Paths.get(normalizedProjectFilePath) }.getOrNull() ?: return null
+    return when {
+        path.parent?.fileName?.toString() == ".idea" -> path.parent?.parent?.toString()
+        path.fileName?.toString()?.endsWith(".ipr") == true -> path.parent?.toString()
+        else -> null
+    }
 }

--- a/inspection-core/src/main/kotlin/com/shiny/inspectionmcp/core/InspectionRouting.kt
+++ b/inspection-core/src/main/kotlin/com/shiny/inspectionmcp/core/InspectionRouting.kt
@@ -75,7 +75,7 @@ fun scoreInspectionRouteCandidates(
 
     return candidates.sortedWith(
         compareByDescending<InspectionRouteCandidate> { it.score }
-            .thenByDescending { normalizedRoutePathLength(it.project.basePath) }
+            .thenByDescending { normalizedRoutePathLength(effectiveProjectRoot(it.project)) }
             .thenBy { it.project.name ?: "" }
     )
 }
@@ -111,8 +111,7 @@ private fun scoreProject(
 ): Int {
     val projectKey = project.projectKey
     val projectName = project.name
-    val basePath = normalizeRoutePath(project.basePath)
-        ?: projectRootFromProjectFilePath(project.projectFilePath)
+    val basePath = effectiveProjectRoot(project)
     val projectFilePath = normalizeRoutePath(project.projectFilePath)
 
     if (explicitProjectKey != null) {
@@ -159,6 +158,11 @@ private fun looksLikeRoutePath(value: String): Boolean {
 
 private fun normalizedRoutePathLength(path: String?): Int {
     return normalizeRoutePath(path)?.length ?: 0
+}
+
+fun effectiveProjectRoot(project: InspectionRouteProject): String? {
+    return normalizeRoutePath(project.basePath)
+        ?: projectRootFromProjectFilePath(project.projectFilePath)
 }
 
 fun projectRootFromProjectFilePath(projectFilePath: String?): String? {

--- a/inspection-core/src/test/kotlin/com/shiny/inspectionmcp/core/InspectionRoutingTest.kt
+++ b/inspection-core/src/test/kotlin/com/shiny/inspectionmcp/core/InspectionRoutingTest.kt
@@ -114,6 +114,32 @@ class InspectionRoutingTest {
     }
 
     @Test
+    fun nestedPathPrefersDerivedProjectFileRootOverContainingBasePath() {
+        val parent = project(
+            projectKey = "path:/tmp/repo",
+            name = "repo",
+            basePath = "/tmp/repo",
+            projectFilePath = "/tmp/repo/.idea/misc.xml",
+        )
+        val child = project(
+            projectKey = "file:/tmp/repo/packages/app/.idea/misc.xml",
+            name = "app",
+            basePath = null,
+            projectFilePath = "/tmp/repo/packages/app/.idea/misc.xml",
+        )
+        val identity = identity(parent, child)
+
+        val candidates = scoreInspectionRouteCandidates(
+            identities = listOf(identity),
+            selector = InspectionRouteSelector(worktreePath = "/tmp/repo/packages/app/src/main"),
+            defaultCwd = null,
+        )
+
+        assertEquals("file:/tmp/repo/packages/app/.idea/misc.xml", candidates.first().project.projectKey)
+        assertEquals(930, candidates.first().score)
+    }
+
+    @Test
     fun duplicateProjectNamesRemainAmbiguous() {
         val first = identity(project("path:/tmp/one", "shared", "/tmp/one"))
         val second = identity(project("path:/tmp/two", "shared", "/tmp/two"))

--- a/inspection-core/src/test/kotlin/com/shiny/inspectionmcp/core/InspectionRoutingTest.kt
+++ b/inspection-core/src/test/kotlin/com/shiny/inspectionmcp/core/InspectionRoutingTest.kt
@@ -74,6 +74,46 @@ class InspectionRoutingTest {
     }
 
     @Test
+    fun worktreePathMatchesProjectFileRootWhenBasePathIsMissing() {
+        val project = project(
+            projectKey = "file:/tmp/worktree/.idea/modules.xml",
+            name = "repo",
+            basePath = null,
+            projectFilePath = "/tmp/worktree/.idea/modules.xml",
+        )
+        val identity = identity(project)
+
+        val candidates = scoreInspectionRouteCandidates(
+            identities = listOf(identity),
+            selector = InspectionRouteSelector(worktreePath = "/tmp/worktree"),
+            defaultCwd = null,
+        )
+
+        assertEquals("file:/tmp/worktree/.idea/modules.xml", candidates.first().project.projectKey)
+        assertEquals(950, candidates.first().score)
+    }
+
+    @Test
+    fun nestedPathMatchesProjectFileRootWhenBasePathIsMissing() {
+        val project = project(
+            projectKey = "file:/tmp/worktree/.idea/misc.xml",
+            name = "repo",
+            basePath = null,
+            projectFilePath = "/tmp/worktree/.idea/misc.xml",
+        )
+        val identity = identity(project)
+
+        val candidates = scoreInspectionRouteCandidates(
+            identities = listOf(identity),
+            selector = InspectionRouteSelector(worktreePath = "/tmp/worktree/src/main"),
+            defaultCwd = null,
+        )
+
+        assertEquals("file:/tmp/worktree/.idea/misc.xml", candidates.first().project.projectKey)
+        assertEquals(930, candidates.first().score)
+    }
+
+    @Test
     fun duplicateProjectNamesRemainAmbiguous() {
         val first = identity(project("path:/tmp/one", "shared", "/tmp/one"))
         val second = identity(project("path:/tmp/two", "shared", "/tmp/two"))
@@ -119,7 +159,7 @@ class InspectionRoutingTest {
     private fun project(
         projectKey: String,
         name: String,
-        basePath: String,
+        basePath: String?,
         projectFilePath: String? = null,
         focused: Boolean = false,
     ): InspectionRouteProject {

--- a/mcp-server-jvm/src/main/kotlin/com/shiny/inspectionmcp/mcpserver/AutoRouting.kt
+++ b/mcp-server-jvm/src/main/kotlin/com/shiny/inspectionmcp/mcpserver/AutoRouting.kt
@@ -13,6 +13,8 @@ import kotlinx.serialization.json.jsonPrimitive
 import com.shiny.inspectionmcp.core.InspectionRouteIdentity
 import com.shiny.inspectionmcp.core.InspectionRouteProject
 import com.shiny.inspectionmcp.core.InspectionRouteSelector
+import com.shiny.inspectionmcp.core.effectiveProjectRoot
+import com.shiny.inspectionmcp.core.normalizeRoutePath
 import com.shiny.inspectionmcp.core.scoreInspectionRouteCandidates
 import java.net.HttpURLConnection
 import java.net.URI
@@ -99,7 +101,8 @@ internal class AutoTargetResolver(
         }
 
         val bestScore = candidates.first().score
-        val best = candidates.filter { it.score == bestScore }
+        val sameScore = candidates.filter { candidate -> candidate.score == bestScore }
+        val best = if (hasPathSelector(args)) deepestUniqueCandidates(sameScore) else sameScore
         if (best.size > 1) {
             throw RuntimeException(
                 "Multiple JetBrains projects matched this request. Retry with project_path or project_key.\n\n${formatCandidateProjects(best)}"
@@ -107,6 +110,17 @@ internal class AutoTargetResolver(
         }
 
         return best.first().target
+    }
+
+    private fun deepestUniqueCandidates(candidates: List<RouteCandidate>): List<RouteCandidate> {
+        val deepest = candidates.maxOfOrNull { candidate -> candidate.rootDepth } ?: return candidates
+        return candidates.filter { candidate -> candidate.rootDepth == deepest }
+    }
+
+    private fun hasPathSelector(args: JsonObject): Boolean {
+        return listOf("project_path", "worktree_path", "cwd", "project").any { key ->
+            normalizeRoutePath(args.string(key)) != null
+        }
     }
 
     override fun listProjects(): JsonElement {
@@ -240,6 +254,7 @@ internal class AutoTargetResolver(
                     project = project,
                 ),
                 candidate.score,
+                routeRootDepth(candidate.project),
             )
         }
     }
@@ -296,9 +311,15 @@ private fun routeProjectKey(projectKey: String?, name: String?, basePath: String
     return projectKey ?: "name:$name:base:$basePath"
 }
 
+private fun routeRootDepth(project: InspectionRouteProject): Int {
+    val root = effectiveProjectRoot(project) ?: return 0
+    return runCatching { Paths.get(root).normalize().toAbsolutePath().nameCount }.getOrDefault(0)
+}
+
 private data class RouteCandidate(
     val target: InspectionTarget,
     val score: Int,
+    val rootDepth: Int,
 )
 
 internal fun defaultRegistryDir(): Path {

--- a/mcp-server-jvm/src/test/kotlin/com/shiny/inspectionmcp/mcpserver/McpServerTest.kt
+++ b/mcp-server-jvm/src/test/kotlin/com/shiny/inspectionmcp/mcpserver/McpServerTest.kt
@@ -997,6 +997,33 @@ class McpServerTest {
     }
 
     @Test
+    fun autoRoutingPrefersNestedProjectFileRootOverContainingParent() {
+        MockIdeServer(identityProjectName = "Parent", identityBasePath = "/tmp/repo", identitySessionId = "parent").use { parent ->
+            MockIdeServer(
+                identityProjectName = "Child",
+                identityBasePath = null,
+                identityProjectFilePath = "/tmp/repo/packages/app/.idea/misc.xml",
+                identitySessionId = "child",
+            ).use { child ->
+                parent.start()
+                child.start()
+                val resolver = AutoTargetResolver(
+                    httpClientFactory = { HttpClient.newHttpClient() },
+                    registryDir = tempDir,
+                    scanPorts = listOf(parent.port, child.port),
+                )
+
+                val target = resolver.resolve(
+                    buildJsonObject { put("worktree_path", JsonPrimitive("/tmp/repo/packages/app/src/main")) },
+                )
+
+                assertEquals(child.port.toString(), target.idePort)
+                assertEquals("Child", target.project?.get("name")?.jsonPrimitive?.contentOrNull)
+            }
+        }
+    }
+
+    @Test
     fun defaultAutoRoutingSettingsUseRegistryDirAndInspectionPortRange() {
         val registryDir = defaultRegistryDir().toString()
         val ports = defaultScanPorts()
@@ -1122,7 +1149,8 @@ private data class StaticHttpResponse(
 private class MockIdeServer(
     overrides: Map<String, MockResponse> = emptyMap(),
     private val identityProjectName: String = "jetbrains-inspection-api",
-    private val identityBasePath: String = "/tmp/jetbrains-inspection-api",
+    private val identityBasePath: String? = "/tmp/jetbrains-inspection-api",
+    private val identityProjectFilePath: String? = null,
     private val identitySessionId: String = "session",
 ) : AutoCloseable {
     private val server: HttpServer = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
@@ -1167,7 +1195,9 @@ private class MockIdeServer(
     }
 
     private fun identityBody(): String {
-        val projectKey = "path:$identityBasePath"
+        val projectKey = identityBasePath?.let { "path:$it" } ?: "file:$identityProjectFilePath"
+        val basePathJson = identityBasePath?.let { "\"$it\"" } ?: "null"
+        val projectFilePathJson = identityProjectFilePath?.let { "\"$it\"" } ?: "null"
         return """
             {
               "session_id":"$identitySessionId-${port}",
@@ -1181,8 +1211,8 @@ private class MockIdeServer(
               "open_projects":[{
                 "project_key":"$projectKey",
                 "name":"$identityProjectName",
-                "base_path":"$identityBasePath",
-                "project_file_path":null,
+                "base_path":$basePathJson,
+                "project_file_path":$projectFilePathJson,
                 "focused":true
               }]
             }

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -27,6 +27,7 @@ import com.shiny.inspectionmcp.core.formatJsonManually
 import com.shiny.inspectionmcp.core.InspectionRouteIdentity
 import com.shiny.inspectionmcp.core.InspectionRouteProject
 import com.shiny.inspectionmcp.core.InspectionRouteSelector
+import com.shiny.inspectionmcp.core.effectiveProjectRoot
 import com.shiny.inspectionmcp.core.normalizeProblemsScope
 import com.shiny.inspectionmcp.core.paginateProblems
 import com.shiny.inspectionmcp.core.projectRootFromProjectFilePath
@@ -1028,7 +1029,7 @@ class InspectionHandler : HttpRequestHandler() {
     private fun routePathMatchScore(project: InspectionRouteProject, selectorPath: String?): Int? {
         return bestPathMatchScore(
             selectorPath,
-            listOfNotNull(project.basePath, project.projectFilePath),
+            listOfNotNull(effectiveProjectRoot(project), project.projectFilePath),
         )
     }
 

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -3061,17 +3061,23 @@ class InspectionHandler : HttpRequestHandler() {
         if (projectKey(project) == projectName) return true
         if (pathHint == null) return false
 
-        val basePath = normalizeProjectPath(project.basePath)
-        if (basePath != null && pathMatchesProject(pathHint, basePath)) return true
-
-        val projectFilePath = normalizeProjectPath(project.projectFilePath)
-        return projectFilePath != null && pathMatchesProject(pathHint, projectFilePath)
+        return projectCandidatePaths(project).any { candidatePath ->
+            pathMatchesProject(pathHint, candidatePath)
+        }
     }
 
     private fun projectPathMatchScore(project: Project, selectorPath: String?): Int? {
         return bestPathMatchScore(
             selectorPath,
-            listOfNotNull(project.basePath, project.projectFilePath),
+            projectCandidatePaths(project),
+        )
+    }
+
+    private fun projectCandidatePaths(project: Project): List<String> {
+        return listOfNotNull(
+            normalizeProjectPath(project.basePath)
+                ?: projectRootFromProjectFilePath(project.projectFilePath),
+            normalizeProjectPath(project.projectFilePath),
         )
     }
 

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -29,6 +29,7 @@ import com.shiny.inspectionmcp.core.InspectionRouteProject
 import com.shiny.inspectionmcp.core.InspectionRouteSelector
 import com.shiny.inspectionmcp.core.normalizeProblemsScope
 import com.shiny.inspectionmcp.core.paginateProblems
+import com.shiny.inspectionmcp.core.projectRootFromProjectFilePath
 import com.shiny.inspectionmcp.core.scoreInspectionRouteCandidates
 import io.netty.buffer.Unpooled
 import io.netty.channel.ChannelHandlerContext
@@ -969,18 +970,6 @@ class InspectionHandler : HttpRequestHandler() {
         }
     }
 
-    private fun projectRootFromProjectFilePath(projectFilePath: String?): String? {
-        val normalizedProjectFilePath = normalizeFileSystemPath(projectFilePath) ?: return null
-        val path = runCatching { Paths.get(normalizedProjectFilePath) }.getOrNull() ?: return null
-        return when {
-            path.fileName?.toString() == "misc.xml" && path.parent?.fileName?.toString() == ".idea" ->
-                path.parent?.parent?.toString()
-            path.fileName?.toString()?.endsWith(".ipr") == true ->
-                path.parent?.toString()
-            else -> null
-        }
-    }
-
     private fun resolveInspectionRoute(parameters: Map<String, List<String>>): ResolvedInspectionRoute? {
         val expectedProjectInstanceId = firstParameter(parameters, "project_instance_id")?.trim()?.takeIf { it.isNotEmpty() }
         val selector = InspectionRouteSelector(
@@ -1076,12 +1065,17 @@ class InspectionHandler : HttpRequestHandler() {
             "project_key" to resolved.projectIdentity["project_key"],
             "project_instance_id" to resolved.projectIdentity["project_instance_id"],
             "project_name" to resolved.projectIdentity["name"],
-            "base_path" to resolved.projectIdentity["base_path"],
+            "base_path" to routeBasePath(resolved.projectIdentity),
             "project_file_path" to resolved.projectIdentity["project_file_path"],
             "focused" to resolved.projectIdentity["focused"],
             "ide" to ideRouteMetadata(resolved.identity),
             "score" to resolved.score,
         )
+    }
+
+    private fun routeBasePath(projectIdentity: Map<String, Any?>): String? {
+        return (projectIdentity["base_path"] as? String)
+            ?: projectRootFromProjectFilePath(projectIdentity["project_file_path"] as? String)
     }
 
     private fun ideRouteMetadata(identity: Map<String, Any?>): Map<String, Any?> {

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -1311,6 +1311,33 @@ class InspectionHandlerTest {
     }
 
     @Test
+    fun `test route endpoint prefers nested project file root over containing parent`() {
+        val tempDir = Files.createTempDirectory("inspection-route-file-root-nested")
+        val nestedPath = tempDir.resolve("packages/app")
+        val parentProject = mockProject(
+            name = "Parent",
+            basePath = tempDir.toString(),
+            projectFilePath = tempDir.resolve(".idea/misc.xml").toString(),
+        )
+        val childProject = mockProject(
+            name = "Child",
+            basePath = null,
+            projectFilePath = nestedPath.resolve(".idea/misc.xml").toString(),
+        )
+        every { mockProjectManager.openProjects } returns arrayOf(parentProject, childProject)
+
+        val response = processGetRequest(
+            "/api/inspection/route?worktree_path=${java.net.URLEncoder.encode(nestedPath.resolve("src/main").toString(), "UTF-8") }"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"project_name\": \"Child\""))
+        assertTrue(body.contains("\"base_path\": \"$nestedPath\""))
+        assertFalse(body.contains("Multiple open projects matched this request"))
+    }
+
+    @Test
     fun `test clearPriorInspectionResults removes all stale inspection tabs`() {
         val toolWindowManager = mockk<ToolWindowManager>()
         val toolWindow = mockk<ToolWindow>()
@@ -1429,7 +1456,7 @@ class InspectionHandlerTest {
         return method.invoke(handler, mockProject) as MutableMap<String, Any>
     }
 
-    private fun mockProject(name: String, basePath: String, projectFilePath: String): Project {
+    private fun mockProject(name: String, basePath: String?, projectFilePath: String): Project {
         val project = mockk<Project>()
         every { project.isDefault } returns false
         every { project.isDisposed } returns false

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -1338,6 +1338,40 @@ class InspectionHandlerTest {
     }
 
     @Test
+    fun `test trigger endpoint prefers nested project file root over containing parent`() {
+        val tempDir = Files.createTempDirectory("inspection-trigger-file-root-nested")
+        val nestedPath = tempDir.resolve("packages/app")
+        val parentProject = mockProject(
+            name = "Parent",
+            basePath = tempDir.toString(),
+            projectFilePath = tempDir.resolve(".idea/misc.xml").toString(),
+        )
+        val childProject = mockProject(
+            name = "Child",
+            basePath = null,
+            projectFilePath = nestedPath.resolve(".idea/misc.xml").toString(),
+        )
+        every { mockProjectManager.openProjects } returns arrayOf(parentProject, childProject)
+        every { mockApplication.executeOnPooledThread(any()) } answers {
+            firstArg<Runnable>().run()
+            mockk(relaxed = true)
+        }
+        every { mockApplication.isDispatchThread } returns true
+        every { mockVirtualFileManager.syncRefresh() } returns 0L
+        mockInspectionPrerequisites(childProject)
+
+        val response = processTriggerRequest(
+            "/api/inspection/trigger?worktree_path=${java.net.URLEncoder.encode(nestedPath.resolve("src/main").toString(), "UTF-8") }"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"project_name\": \"Child\""))
+        assertTrue(body.contains("\"base_path\": \"$nestedPath\""))
+        assertFalse(body.contains("Multiple open projects matched this request"))
+    }
+
+    @Test
     fun `test clearPriorInspectionResults removes all stale inspection tabs`() {
         val toolWindowManager = mockk<ToolWindowManager>()
         val toolWindow = mockk<ToolWindow>()

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -1295,6 +1295,22 @@ class InspectionHandlerTest {
     }
 
     @Test
+    fun `test route endpoint exposes effective base path from project file when base path is missing`() {
+        val tempDir = Files.createTempDirectory("inspection-route-file-root")
+        every { mockProject.basePath } returns null
+        every { mockProject.projectFilePath } returns tempDir.resolve(".idea/modules.xml").toString()
+
+        val response = processGetRequest(
+            "/api/inspection/route?worktree_path=${java.net.URLEncoder.encode(tempDir.toString(), "UTF-8") }"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"base_path\": \"$tempDir\""))
+        assertTrue(body.contains("\"project_file_path\": \"${tempDir.resolve(".idea/modules.xml")}\""))
+    }
+
+    @Test
     fun `test clearPriorInspectionResults removes all stale inspection tabs`() {
         val toolWindowManager = mockk<ToolWindowManager>()
         val toolWindow = mockk<ToolWindow>()


### PR DESCRIPTION
## Summary

- route `basePath == null` projects by deriving an effective root from `.idea/*` and `.ipr` project files
- expose the effective root as route `base_path` so helper exact-worktree checks can pass after lifecycle/open
- share project-file-root derivation between lifecycle/open detection and route scoring

## Validation

- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :inspection-core:test --tests 'com.shiny.inspectionmcp.core.InspectionRoutingTest' :test --tests 'com.shiny.inspectionmcp.InspectionHandlerTest'`
- `./scripts/commit-gate.sh --ci`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py --json closeout --repo /Users/cbusillo/Developer/jetbrains-inspection-api --scope changed_files --timeout-ms 240000`

Note: an earlier closeout attempt with `--timeout-ms 120000` timed out while reporting zero problems; rerun with a longer timeout completed cleanly with `wait_completed: true`.
