### PR TITLE
Bump version to 1.12.10

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion=1.12.9
+pluginVersion=1.12.10
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
 kotlin.stdlib.default.dependency=false
 # Enable Gradle Configuration Cache -> https://docs.gradle.org/current/userguide/configuration_cache.html

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.shiny.inspection.api</id>
     <name>Inspection API</name>
-    <version>1.12.9</version>
+    <version>1.12.10</version>
     <vendor email="info@shinycomputers.com" url="https://github.com/cbusillo/jetbrains-inspection-api">Shiny Computers (Chris Busillo)</vendor>
     <resource-bundle>messages.InspectionApiBundle</resource-bundle>
     


### PR DESCRIPTION
## Summary
- bump pluginVersion to 1.12.10 for the lifecycle/open release
- use the release script generated version commit and tag target

## Validation
- ./scripts/release.sh --patch --yes ran local validation successfully before branch protection rejected direct main push
- PR #58 and codex-skills PR #135 were merged after local tests, JetBrains closeout, CI, CodeQL, and agent review