### PR TITLE
Support lifecycle opening project files

### DIFF
--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -513,6 +513,13 @@ class InspectionHandler : HttpRequestHandler() {
         val projectIdentity: Map<String, Any?>,
         val score: Int? = null,
     )
+
+    private data class LifecycleOpenTarget(
+        val path: Path,
+        val openPath: Path,
+        val projectRoot: Path,
+        val key: String,
+    )
     
     private val runIdSequence = AtomicLong()
     private val inspectionRunStatesByProject = java.util.concurrent.ConcurrentHashMap<String, InspectionRunState>()
@@ -828,23 +835,24 @@ class InspectionHandler : HttpRequestHandler() {
             ?: throw BadRequestException("worktree_path", "Parameter 'worktree_path' must be a valid local path.")
         val path = Paths.get(normalizedPath)
         findOpenProjectForLifecycleOpen(path.toString())?.let { project ->
-            return mapOf(
-                "status" to "already_open",
-                "opened" to false,
-                "session_id" to InspectionIdeSession.sessionId,
-                "route" to routeMetadata(ResolvedInspectionRoute(project, safeInspectionIdentity(), openProjectIdentity(project))),
-            ) to HttpResponseStatus.OK
+            return lifecycleOpenAlreadyOpen(project)
         }
-        if (!Files.isDirectory(path)) {
-            throw BadRequestException("worktree_path", "Parameter 'worktree_path' must point to an existing directory.")
+        val target = resolveLifecycleOpenTarget(path)
+        if (target.projectRoot != target.path) {
+            findOpenProjectForLifecycleOpen(target.projectRoot.toString())?.let { project ->
+                return lifecycleOpenAlreadyOpen(project)
+            }
         }
-        if (!openingProjectPaths.add(normalizedPath)) {
+        findOpenProjectForLifecycleOpenKey(target.key)?.let { project ->
+            return lifecycleOpenAlreadyOpen(project)
+        }
+        if (!openingProjectPaths.add(target.key)) {
             return mapOf(
                 "status" to "opening",
                 "opened" to false,
                 "opening_scheduled" to false,
                 "reason" to "already_opening",
-                "worktree_path" to path.toString(),
+                "worktree_path" to target.path.toString(),
                 "session_id" to InspectionIdeSession.sessionId,
             ) to HttpResponseStatus.OK
         }
@@ -852,20 +860,20 @@ class InspectionHandler : HttpRequestHandler() {
         val scheduled = runCatching {
             ApplicationManager.getApplication().invokeLater {
                 try {
-                    openProjectPath(path)
+                    openProjectPath(target.openPath)
                 } finally {
-                    openingProjectPaths.remove(normalizedPath)
+                    openingProjectPaths.remove(target.key)
                 }
             }
         }.isSuccess
         if (!scheduled) {
-            openingProjectPaths.remove(normalizedPath)
+            openingProjectPaths.remove(target.key)
             return mapOf(
                 "status" to "failed",
                 "opened" to false,
                 "reason" to "open_schedule_failed",
                 "message" to "JetBrains IDE declined or failed to schedule opening the requested project path.",
-                "worktree_path" to path.toString(),
+                "worktree_path" to target.path.toString(),
                 "session_id" to InspectionIdeSession.sessionId,
             ) to HttpResponseStatus.CONFLICT
         }
@@ -874,13 +882,65 @@ class InspectionHandler : HttpRequestHandler() {
             "status" to "opening",
             "opened" to false,
             "opening_scheduled" to true,
-            "worktree_path" to path.toString(),
+            "worktree_path" to target.path.toString(),
             "session_id" to InspectionIdeSession.sessionId,
         ) to HttpResponseStatus.OK
     }
 
+    private fun lifecycleOpenAlreadyOpen(project: Project): Pair<Map<String, Any?>, HttpResponseStatus> {
+        return mapOf(
+            "status" to "already_open",
+            "opened" to false,
+            "session_id" to InspectionIdeSession.sessionId,
+            "route" to routeMetadata(ResolvedInspectionRoute(project, safeInspectionIdentity(), openProjectIdentity(project))),
+        ) to HttpResponseStatus.OK
+    }
+
+    private fun resolveLifecycleOpenTarget(path: Path): LifecycleOpenTarget {
+        val projectRoot = lifecycleOpenProjectRoot(path)
+            ?: throw BadRequestException(
+                "worktree_path",
+                "Parameter 'worktree_path' must point to an existing directory, .ipr project file, or file inside .idea.",
+            )
+        return LifecycleOpenTarget(
+            path = path,
+            openPath = projectRoot,
+            projectRoot = projectRoot,
+            key = canonicalLifecycleOpenKey(projectRoot),
+        )
+    }
+
+    private fun lifecycleOpenProjectRoot(path: Path): Path? {
+        if (Files.isDirectory(path)) return path
+        if (!Files.isRegularFile(path)) return null
+        val fileName = path.fileName?.toString() ?: return null
+        if (fileName.endsWith(".ipr")) return path.parent
+        return path.parent
+            ?.takeIf { it.fileName?.toString() == ".idea" }
+            ?.parent
+    }
+
+    private fun canonicalLifecycleOpenKey(path: Path): String {
+        return runCatching { path.toRealPath().toString() }
+            .getOrElse { path.normalize().toAbsolutePath().toString() }
+    }
+
     private fun findOpenProjectForLifecycleOpen(path: String): Project? {
         return findOpenProjectByPath(path)
+    }
+
+    private fun findOpenProjectForLifecycleOpenKey(key: String): Project? {
+        return ApplicationManager.getApplication().runReadAction<Project?, Exception> {
+            ProjectManager.getInstance().openProjects.firstOrNull { project ->
+                isUsableProject(project) && lifecycleOpenKeys(project).contains(key)
+            }
+        }
+    }
+
+    private fun lifecycleOpenKeys(project: Project): Set<String> {
+        return projectCandidatePaths(project)
+            .mapNotNull { path -> runCatching { canonicalLifecycleOpenKey(Paths.get(path)) }.getOrNull() }
+            .toSet()
     }
 
     private fun closeLifecycleProject(parameters: Map<String, List<String>>): Pair<Map<String, Any?>, HttpResponseStatus> {

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -840,6 +840,69 @@ class InspectionHandlerTest {
     }
 
     @Test
+    fun `test lifecycle open opens ipr project file path in running IDE`() {
+        val tempDir = Files.createTempDirectory("inspection-open-ipr-file")
+        val projectFilePath = tempDir.resolve("project.ipr")
+        Files.writeString(projectFilePath, "<project />")
+        val openedProject = mockProject(
+            name = "OpenedIpr",
+            basePath = null,
+            projectFilePath = projectFilePath.toString(),
+        )
+        every { mockProjectManager.openProjects } returns emptyArray()
+        every { mockApplication.invokeLater(any()) } answers {
+            firstArg<Runnable>().run()
+        }
+        var openedPath: Path? = null
+        handler.openProjectPath = { path: Path ->
+            openedPath = path
+            openedProject
+        }
+
+        val response = processGetRequest(
+            "/api/inspection/lifecycle/open?worktree_path=${java.net.URLEncoder.encode(projectFilePath.toString(), "UTF-8") }"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"status\": \"opening\""))
+        assertTrue(body.contains("\"opening_scheduled\": true"))
+        assertEquals(tempDir.toAbsolutePath().normalize(), openedPath)
+    }
+
+    @Test
+    fun `test lifecycle open opens idea project file path in running IDE`() {
+        val tempDir = Files.createTempDirectory("inspection-open-idea-file")
+        val projectFilePath = tempDir.resolve(".idea/misc.xml")
+        Files.createDirectories(projectFilePath.parent)
+        Files.writeString(projectFilePath, "<project />")
+        val openedProject = mockProject(
+            name = "OpenedIdeaFile",
+            basePath = tempDir.toString(),
+            projectFilePath = projectFilePath.toString(),
+        )
+        every { mockProjectManager.openProjects } returns emptyArray()
+        every { mockApplication.invokeLater(any()) } answers {
+            firstArg<Runnable>().run()
+        }
+        var openedPath: Path? = null
+        handler.openProjectPath = { path: Path ->
+            openedPath = path
+            openedProject
+        }
+
+        val response = processGetRequest(
+            "/api/inspection/lifecycle/open?worktree_path=${java.net.URLEncoder.encode(projectFilePath.toString(), "UTF-8") }"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"status\": \"opening\""))
+        assertTrue(body.contains("\"opening_scheduled\": true"))
+        assertEquals(tempDir.toAbsolutePath().normalize(), openedPath)
+    }
+
+    @Test
     fun `test lifecycle open reports already open exact project`() {
         val tempDir = Files.createTempDirectory("inspection-open-existing")
         every { mockProject.basePath } returns tempDir.toString()
@@ -968,6 +1031,67 @@ class InspectionHandlerTest {
         val third = processGetRequest("/api/inspection/lifecycle/open?worktree_path=$encodedPath")
         assertEquals(2, scheduled.size)
         assertEquals(HttpResponseStatus.OK, third.status())
+    }
+
+    @Test
+    fun `test lifecycle open coalesces symlink aliases`() {
+        val tempDir = Files.createTempDirectory("inspection-open-real")
+        val symlink = tempDir.parent.resolve("inspection-open-link-${System.nanoTime()}")
+        try {
+            Files.createSymbolicLink(symlink, tempDir)
+        } catch (_: UnsupportedOperationException) {
+            return
+        }
+        every { mockProjectManager.openProjects } returns emptyArray()
+        val scheduled = mutableListOf<Runnable>()
+        every { mockApplication.invokeLater(any()) } answers {
+            scheduled += firstArg<Runnable>()
+        }
+        handler.openProjectPath = { mockProject }
+
+        val first = processGetRequest(
+            "/api/inspection/lifecycle/open?worktree_path=${java.net.URLEncoder.encode(tempDir.toString(), "UTF-8") }"
+        )
+        val second = processGetRequest(
+            "/api/inspection/lifecycle/open?worktree_path=${java.net.URLEncoder.encode(symlink.toString(), "UTF-8") }"
+        )
+        val secondBody = second.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, first.status())
+        assertEquals(HttpResponseStatus.OK, second.status())
+        assertEquals(1, scheduled.size)
+        assertTrue(secondBody.contains("\"reason\": \"already_opening\""))
+
+        Files.deleteIfExists(symlink)
+    }
+
+    @Test
+    fun `test lifecycle open detects already open symlink alias`() {
+        val realPath = Files.createTempDirectory("inspection-open-real-existing")
+        val symlink = realPath.parent.resolve("inspection-open-existing-link-${System.nanoTime()}")
+        try {
+            Files.createSymbolicLink(symlink, realPath)
+        } catch (_: UnsupportedOperationException) {
+            return
+        }
+        every { mockProject.basePath } returns realPath.toString()
+        every { mockProject.projectFilePath } returns realPath.resolve(".idea/misc.xml").toString()
+        var scheduled = false
+        every { mockApplication.invokeLater(any()) } answers {
+            scheduled = true
+        }
+
+        val response = processGetRequest(
+            "/api/inspection/lifecycle/open?worktree_path=${java.net.URLEncoder.encode(symlink.toString(), "UTF-8") }"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"status\": \"already_open\""))
+        assertTrue(body.contains("\"opened\": false"))
+        assertFalse(scheduled)
+
+        Files.deleteIfExists(symlink)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- allow lifecycle/open to schedule valid .ipr project files and files inside .idea, not only directories
- canonicalize lifecycle-open in-flight keys so symlink aliases coalesce to one scheduled open
- keep already-open detection before unopened-path validation for reported IDE projects

## Validation
- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test --tests 'com.shiny.inspectionmcp.InspectionHandlerTest'
- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :inspection-core:test --tests 'com.shiny.inspectionmcp.core.InspectionRoutingTest' :test --tests 'com.shiny.inspectionmcp.InspectionHandlerTest' :mcp-server-jvm:test --tests 'com.shiny.inspectionmcp.mcpserver.McpServerTest'
- git diff --check
- uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py --json closeout --repo /Users/cbusillo/Developer/jetbrains-inspection-api --scope changed_files --timeout-ms 180000
- commit hook ran broad test/build gate including buildPlugin