### PR TITLE
Resolve lifecycle open idea directories

### DIFF
--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -911,7 +911,9 @@ class InspectionHandler : HttpRequestHandler() {
     }
 
     private fun lifecycleOpenProjectRoot(path: Path): Path? {
-        if (Files.isDirectory(path)) return path
+        if (Files.isDirectory(path)) {
+            return if (path.fileName?.toString() == ".idea") path.parent else path
+        }
         if (!Files.isRegularFile(path)) return null
         val fileName = path.fileName?.toString() ?: return null
         if (fileName.endsWith(".ipr")) return path.parent

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -903,6 +903,37 @@ class InspectionHandlerTest {
     }
 
     @Test
+    fun `test lifecycle open resolves idea directory to project root`() {
+        val tempDir = Files.createTempDirectory("inspection-open-idea-dir")
+        val ideaDir = tempDir.resolve(".idea")
+        Files.createDirectories(ideaDir)
+        val openedProject = mockProject(
+            name = "OpenedIdeaDir",
+            basePath = tempDir.toString(),
+            projectFilePath = ideaDir.resolve("misc.xml").toString(),
+        )
+        every { mockProjectManager.openProjects } returns emptyArray()
+        every { mockApplication.invokeLater(any()) } answers {
+            firstArg<Runnable>().run()
+        }
+        var openedPath: Path? = null
+        handler.openProjectPath = { path: Path ->
+            openedPath = path
+            openedProject
+        }
+
+        val response = processGetRequest(
+            "/api/inspection/lifecycle/open?worktree_path=${java.net.URLEncoder.encode(ideaDir.toString(), "UTF-8") }"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"status\": \"opening\""))
+        assertTrue(body.contains("\"opening_scheduled\": true"))
+        assertEquals(tempDir.toAbsolutePath().normalize(), openedPath)
+    }
+
+    @Test
     fun `test lifecycle open reports already open exact project`() {
         val tempDir = Files.createTempDirectory("inspection-open-existing")
         every { mockProject.basePath } returns tempDir.toString()


### PR DESCRIPTION
## Summary

- Resolve lifecycle-open requests that point at a `.idea` directory to the enclosing project root.
- Add regression coverage so `.idea` directories are never opened as standalone project roots.

## Validation

- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test --tests 'com.shiny.inspectionmcp.InspectionHandlerTest'`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :inspection-core:test --tests 'com.shiny.inspectionmcp.core.InspectionRoutingTest' :test --tests 'com.shiny.inspectionmcp.InspectionHandlerTest' :mcp-server-jvm:test --tests 'com.shiny.inspectionmcp.mcpserver.McpServerTest'`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py closeout --repo /Users/cbusillo/Developer/jetbrains-inspection-api --scope changed_files --timeout-ms 180000`
- Commit hook ran broader plugin tests, `:inspection-core:test`, `:mcp-server-jvm:test`, and `buildPlugin` successfully.
