### PR TITLE
Keep unreconciled churn snapshots stale

### DIFF
--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -102,6 +102,11 @@ internal data class InspectionViewObservation(
     val problemStateReadable: Boolean = true,
 )
 
+private data class CurrentRunPsiChurnReconciliation(
+    val snapshot: InspectionResultsSnapshot?,
+    val reconciled: Boolean,
+)
+
 internal fun readInspectionRootChildCount(root: Any?): Int? {
     return when (root) {
         null -> null
@@ -1224,9 +1229,19 @@ class InspectionHandler : HttpRequestHandler() {
             val key = projectKey(project)
             var snapshot = resultsStore.getSnapshot(key)
             val hasSnapshot = snapshot != null
-            val staleness = resolveSnapshotStaleness(project, snapshot)
+            var staleness = resolveSnapshotStaleness(project, snapshot)
+            if (staleness.changeKind == "current_run_psi_churn") {
+                val reconciliation = reconcileCurrentRunPsiChurn(project, snapshot)
+                snapshot = reconciliation.snapshot
+                staleness = if (reconciliation.reconciled) {
+                    resolveSnapshotStaleness(project, snapshot)
+                } else {
+                    staleness.asUnverifiedCurrentRunPsiChurn()
+                }
+            }
             if (hasSnapshot && staleness.stale) {
-                val cachedProblems = snapshot.problems
+                val staleSnapshot = snapshot ?: resultsStore.getSnapshot(key)
+                val cachedProblems = staleSnapshot?.problems ?: emptyList()
                 val currentFilePath = resolveCurrentFilePath(project, normalizedScope)
                 val filteredCachedProblems = filterProblems(
                     problems = cachedProblems,
@@ -1237,7 +1252,7 @@ class InspectionHandler : HttpRequestHandler() {
                     filePattern = filePattern,
                 )
                 val page = paginateProblems(filteredCachedProblems, limit, offset)
-                val staleBase = mutableMapOf<String, Any?>(
+                val staleBase = mutableMapOf(
                     "status" to "stale_results",
                     "project" to project.name,
                     "project_key" to key,
@@ -1248,9 +1263,9 @@ class InspectionHandler : HttpRequestHandler() {
                     "results_may_be_stale" to true,
                     "stale_reasons" to staleness.reasons,
                     "snapshot_change_kind" to staleness.changeKind,
-                    "snapshot_outcome" to snapshot.outcome.apiValue,
-                    "results_source" to snapshot.source,
-                    "results_timestamp_ms" to snapshot.timestamp,
+                    "snapshot_outcome" to staleSnapshot?.outcome?.apiValue,
+                    "results_source" to staleSnapshot?.source,
+                    "results_timestamp_ms" to staleSnapshot?.timestamp,
                     "cached_total_problems" to filteredCachedProblems.size,
                     "cached_problems_shown" to if (includeStale) page.shown else 0,
                     "filters" to mapOf(
@@ -1273,11 +1288,8 @@ class InspectionHandler : HttpRequestHandler() {
                 } else {
                     staleBase["include_stale"] = false
                 }
-                snapshot.captureDiagnostic?.let { staleBase["capture_diagnostic"] = it }
+                staleSnapshot?.captureDiagnostic?.let { staleBase["capture_diagnostic"] = it }
                 return formatJsonManually(staleBase.filterValues { it != null })
-            }
-            if (staleness.changeKind == "current_run_psi_churn") {
-                snapshot = reconcileCurrentRunPsiChurn(project, snapshot)
             }
             snapshot = reconcileSnapshotWithLiveProblems(project, snapshot)
             if (snapshot != null && snapshot.outcome == InspectionSnapshotOutcome.CAPTURE_INCOMPLETE) {
@@ -1460,8 +1472,13 @@ class InspectionHandler : HttpRequestHandler() {
         val hasInspectionSnapshot = snapshot != null
         var staleness = resolveSnapshotStaleness(project, snapshot)
         if (staleness.changeKind == "current_run_psi_churn") {
-            snapshot = reconcileCurrentRunPsiChurn(project, snapshot)
-            staleness = resolveSnapshotStaleness(project, snapshot)
+            val reconciliation = reconcileCurrentRunPsiChurn(project, snapshot)
+            snapshot = reconciliation.snapshot
+            staleness = if (reconciliation.reconciled) {
+                resolveSnapshotStaleness(project, snapshot)
+            } else {
+                staleness.asUnverifiedCurrentRunPsiChurn()
+            }
         }
         if (!staleness.stale) {
             snapshot = reconcileSnapshotWithLiveProblems(project, snapshot)
@@ -1590,15 +1607,15 @@ class InspectionHandler : HttpRequestHandler() {
     private fun reconcileCurrentRunPsiChurn(
         project: Project,
         snapshot: InspectionResultsSnapshot?,
-    ): InspectionResultsSnapshot? {
+    ): CurrentRunPsiChurnReconciliation {
         if (snapshot == null) {
-            return null
+            return CurrentRunPsiChurnReconciliation(null, false)
         }
 
         val liveProblems = try {
             enhancedTreeExtractorFactory().extractAllProblems(project)
         } catch (_: Exception) {
-            return snapshot
+            return CurrentRunPsiChurnReconciliation(snapshot, false)
         }
         val captureScopeMatcher = snapshot.captureScope?.let { captureScope ->
             buildScopeProblemMatcher(
@@ -1614,7 +1631,7 @@ class InspectionHandler : HttpRequestHandler() {
         }
         val compatibleLiveProblems = filterProblemsForScope(liveProblems, captureScopeMatcher)
         if (compatibleLiveProblems != snapshot.problems) {
-            return snapshot
+            return CurrentRunPsiChurnReconciliation(snapshot, false)
         }
 
         val reconciledSnapshot = snapshot.copy(
@@ -1622,7 +1639,16 @@ class InspectionHandler : HttpRequestHandler() {
             projectState = captureProjectState(project),
         )
         resultsStore.setSnapshot(projectKey(project), reconciledSnapshot)
-        return reconciledSnapshot
+        return CurrentRunPsiChurnReconciliation(reconciledSnapshot, true)
+    }
+
+    private fun SnapshotStaleness.asUnverifiedCurrentRunPsiChurn(): SnapshotStaleness {
+        val changeKind = when {
+            reasons.contains("unsaved_documents") -> "unsaved_documents"
+            reasons.contains("project_changed_since_inspection") -> "project_changed_since_inspection"
+            else -> changeKind
+        }
+        return SnapshotStaleness(true, reasons, changeKind)
     }
 
     private fun resolveCurrentFilePath(project: Project, normalizedScope: String): String? {

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
@@ -660,10 +660,42 @@ class InspectionSnapshotStateTest {
 
         val status = buildInspectionStatus()
 
-        assertEquals(false, status["results_may_be_stale"])
-        assertEquals("current_run_psi_churn", status["snapshot_change_kind"])
+        assertEquals(true, status["results_may_be_stale"])
+        assertEquals("project_changed_since_inspection", status["snapshot_change_kind"])
         assertEquals(listOf("project_changed_since_inspection"), status["stale_reasons"])
         assertEquals(currentRun.runId, status["snapshot_run_id"])
+    }
+
+    @Test
+    @DisplayName("Problems endpoint withholds unreconciled current-run PSI churn")
+    fun testProblemsEndpointWithholdsUnreconciledCurrentRunPsiChurn() {
+        val extractor = mockk<EnhancedTreeExtractor>()
+        val currentRun = beginInspectionRun()
+        finishInspectionRun(snapshotKey(), currentRun.runId)
+        every { extractor.extractAllProblems(mockProject) } returns emptyList()
+        enhancedTreeExtractorFactory = { extractor }
+        InspectionResultsStore.setSnapshot(
+            snapshotKey(),
+            InspectionResultsSnapshot(
+                problems = listOf(staleProblem(description = "Fresh warning")),
+                timestamp = System.currentTimeMillis() - 16000L,
+                projectState = InspectionProjectStateSnapshot(psiModificationCount = 7L, unsavedProjectDocuments = 0),
+                outcome = InspectionSnapshotOutcome.PROBLEMS_FOUND,
+                source = "inspection_view",
+                runId = currentRun.runId,
+                triggerTimeMs = currentRun.triggerTimeMs,
+            ),
+        )
+        every { PsiModificationTracker.getInstance(mockProject).modificationCount } returns 8L
+
+        val response = getInspectionProblems()
+
+        assertTrue(response.contains("\"status\": \"stale_results\""))
+        assertTrue(response.contains("\"results_may_be_stale\": true"))
+        assertTrue(response.contains("\"snapshot_change_kind\": \"project_changed_since_inspection\""))
+        assertTrue(response.contains("\"cached_total_problems\": 1"))
+        assertTrue(response.contains("\"cached_problems_shown\": 0"))
+        assertFalse(response.contains("Fresh warning"))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- require live extraction confirmation before current-run PSI churn snapshots are treated as fresh
- keep unreconciled churn snapshots behind stale_results instead of returning cached findings as current
- add status and problems endpoint coverage for unreconciled churn

## Validation
- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test --tests com.shiny.inspectionmcp.InspectionSnapshotStateTest
- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test --tests com.shiny.inspectionmcp.InspectionHandlerTest --tests com.shiny.inspectionmcp.InspectionScopeFallbackTest --tests com.shiny.inspectionmcp.InspectionScopeResolutionTest
- uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py closeout --repo "$PWD" --scope changed_files
- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test
- git commit hook: plugin/core/mcp tests and buildPlugin