### PR TITLE
Derive project roots from nested idea metadata

### DIFF
--- a/inspection-core/src/main/kotlin/com/shiny/inspectionmcp/core/InspectionRouting.kt
+++ b/inspection-core/src/main/kotlin/com/shiny/inspectionmcp/core/InspectionRouting.kt
@@ -1,5 +1,6 @@
 package com.shiny.inspectionmcp.core
 
+import java.nio.file.Path
 import java.nio.file.Paths
 
 data class InspectionRouteProject(
@@ -168,9 +169,20 @@ fun effectiveProjectRoot(project: InspectionRouteProject): String? {
 fun projectRootFromProjectFilePath(projectFilePath: String?): String? {
     val normalizedProjectFilePath = normalizeRoutePath(projectFilePath) ?: return null
     val path = runCatching { Paths.get(normalizedProjectFilePath) }.getOrNull() ?: return null
+    projectRootFromIdeaMetadataPath(path)?.let { return it.toString() }
     return when {
-        path.parent?.fileName?.toString() == ".idea" -> path.parent?.parent?.toString()
         path.fileName?.toString()?.endsWith(".ipr") == true -> path.parent?.toString()
         else -> null
     }
+}
+
+fun projectRootFromIdeaMetadataPath(path: Path): Path? {
+    var cursor: Path? = path
+    while (cursor != null) {
+        if (cursor.fileName?.toString() == ".idea") {
+            return cursor.parent
+        }
+        cursor = cursor.parent
+    }
+    return null
 }

--- a/inspection-core/src/test/kotlin/com/shiny/inspectionmcp/core/InspectionRoutingTest.kt
+++ b/inspection-core/src/test/kotlin/com/shiny/inspectionmcp/core/InspectionRoutingTest.kt
@@ -94,6 +94,26 @@ class InspectionRoutingTest {
     }
 
     @Test
+    fun worktreePathMatchesNestedIdeaProjectFileRootWhenBasePathIsMissing() {
+        val project = project(
+            projectKey = "file:/tmp/worktree/.idea/runConfigurations/app.xml",
+            name = "repo",
+            basePath = null,
+            projectFilePath = "/tmp/worktree/.idea/runConfigurations/app.xml",
+        )
+        val identity = identity(project)
+
+        val candidates = scoreInspectionRouteCandidates(
+            identities = listOf(identity),
+            selector = InspectionRouteSelector(worktreePath = "/tmp/worktree"),
+            defaultCwd = null,
+        )
+
+        assertEquals("file:/tmp/worktree/.idea/runConfigurations/app.xml", candidates.first().project.projectKey)
+        assertEquals(950, candidates.first().score)
+    }
+
+    @Test
     fun nestedPathMatchesProjectFileRootWhenBasePathIsMissing() {
         val project = project(
             projectKey = "file:/tmp/worktree/.idea/misc.xml",

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -30,6 +30,7 @@ import com.shiny.inspectionmcp.core.InspectionRouteSelector
 import com.shiny.inspectionmcp.core.effectiveProjectRoot
 import com.shiny.inspectionmcp.core.normalizeProblemsScope
 import com.shiny.inspectionmcp.core.paginateProblems
+import com.shiny.inspectionmcp.core.projectRootFromIdeaMetadataPath
 import com.shiny.inspectionmcp.core.projectRootFromProjectFilePath
 import com.shiny.inspectionmcp.core.scoreInspectionRouteCandidates
 import io.netty.buffer.Unpooled
@@ -916,15 +917,12 @@ class InspectionHandler : HttpRequestHandler() {
     }
 
     private fun lifecycleOpenProjectRoot(path: Path): Path? {
-        if (Files.isDirectory(path)) {
-            return if (path.fileName?.toString() == ".idea") path.parent else path
-        }
+        projectRootFromIdeaMetadataPath(path)?.let { return it }
+        if (Files.isDirectory(path)) return path
         if (!Files.isRegularFile(path)) return null
         val fileName = path.fileName?.toString() ?: return null
         if (fileName.endsWith(".ipr")) return path.parent
-        return path.parent
-            ?.takeIf { it.fileName?.toString() == ".idea" }
-            ?.parent
+        return null
     }
 
     private fun canonicalLifecycleOpenKey(path: Path): String {

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -934,6 +934,69 @@ class InspectionHandlerTest {
     }
 
     @Test
+    fun `test lifecycle open resolves nested idea directory to project root`() {
+        val tempDir = Files.createTempDirectory("inspection-open-nested-idea-dir")
+        val nestedIdeaDir = tempDir.resolve(".idea/runConfigurations")
+        Files.createDirectories(nestedIdeaDir)
+        val openedProject = mockProject(
+            name = "OpenedNestedIdeaDir",
+            basePath = tempDir.toString(),
+            projectFilePath = tempDir.resolve(".idea/misc.xml").toString(),
+        )
+        every { mockProjectManager.openProjects } returns emptyArray()
+        every { mockApplication.invokeLater(any()) } answers {
+            firstArg<Runnable>().run()
+        }
+        var openedPath: Path? = null
+        handler.openProjectPath = { path: Path ->
+            openedPath = path
+            openedProject
+        }
+
+        val response = processGetRequest(
+            "/api/inspection/lifecycle/open?worktree_path=${java.net.URLEncoder.encode(nestedIdeaDir.toString(), "UTF-8") }"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"status\": \"opening\""))
+        assertTrue(body.contains("\"opening_scheduled\": true"))
+        assertEquals(tempDir.toAbsolutePath().normalize(), openedPath)
+    }
+
+    @Test
+    fun `test lifecycle open resolves nested idea file to project root`() {
+        val tempDir = Files.createTempDirectory("inspection-open-nested-idea-file")
+        val nestedIdeaFile = tempDir.resolve(".idea/runConfigurations/app.xml")
+        Files.createDirectories(nestedIdeaFile.parent)
+        Files.writeString(nestedIdeaFile, "<component />")
+        val openedProject = mockProject(
+            name = "OpenedNestedIdeaFile",
+            basePath = tempDir.toString(),
+            projectFilePath = tempDir.resolve(".idea/misc.xml").toString(),
+        )
+        every { mockProjectManager.openProjects } returns emptyArray()
+        every { mockApplication.invokeLater(any()) } answers {
+            firstArg<Runnable>().run()
+        }
+        var openedPath: Path? = null
+        handler.openProjectPath = { path: Path ->
+            openedPath = path
+            openedProject
+        }
+
+        val response = processGetRequest(
+            "/api/inspection/lifecycle/open?worktree_path=${java.net.URLEncoder.encode(nestedIdeaFile.toString(), "UTF-8") }"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"status\": \"opening\""))
+        assertTrue(body.contains("\"opening_scheduled\": true"))
+        assertEquals(tempDir.toAbsolutePath().normalize(), openedPath)
+    }
+
+    @Test
     fun `test lifecycle open reports already open exact project`() {
         val tempDir = Files.createTempDirectory("inspection-open-existing")
         every { mockProject.basePath } returns tempDir.toString()


### PR DESCRIPTION
## Summary

- Derive project roots from any path under `.idea`, including nested metadata files/directories such as `.idea/runConfigurations/app.xml`.
- Share that root derivation between routing fallback and lifecycle-open path normalization.
- Add regression coverage for nested `.idea` project files, nested `.idea` directories, and nested `.idea` file lifecycle-open selectors.

## Validation

- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :inspection-core:test --tests 'com.shiny.inspectionmcp.core.InspectionRoutingTest' :test --tests 'com.shiny.inspectionmcp.InspectionHandlerTest'`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :inspection-core:test :test --tests 'com.shiny.inspectionmcp.InspectionHandlerTest' :mcp-server-jvm:test --tests 'com.shiny.inspectionmcp.mcpserver.McpServerTest' buildPlugin`
- `git diff --check`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py closeout --repo /Users/cbusillo/Developer/jetbrains-inspection-api --scope changed_files --timeout-ms 180000`
- Commit hook reran plugin/core/MCP/buildPlugin validation successfully.
