### PR TITLE
Trust scoped empty results from updating problem-free views

### DIFF
--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -290,6 +290,13 @@ internal fun isTransientUpdatingUnreadableEmptyCandidate(observation: Inspection
         observation.rootChildCount == 0
 }
 
+internal fun isTransientUpdatingProblemFreeCandidate(observation: InspectionViewObservation): Boolean {
+    return observation.updateStateReadable &&
+        observation.problemStateReadable &&
+        observation.isUpdating &&
+        !observation.hasProblems
+}
+
 internal fun isOpaqueSettledEmptyInspectionViewCandidate(observation: InspectionViewObservation): Boolean {
     return observation.updateStateReadable &&
         observation.problemStateReadable &&
@@ -2329,7 +2336,7 @@ class InspectionHandler : HttpRequestHandler() {
                                             readableEmptyInspectionViewStableSince = loopNow
                                         }
                                     }
-                                    isTransientUpdatingUnreadableEmptyCandidate(viewObservation) &&
+                                    isTransientUpdatingProblemFreeCandidate(viewObservation) &&
                                         !observedNonEmptyInspectionTree -> {
                                         observedTransientEmptyInspectionViewEvidence = true
                                         transientUpdatingEmptyObservationCount += 1

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
@@ -1504,6 +1504,43 @@ class InspectionSnapshotStateTest {
     }
 
     @Test
+    @DisplayName("Updating problem-free views can prove scoped empty results after deadline")
+    fun testUpdatingProblemFreeViewsCanProveScopedEmptyResults() {
+        val updatingProblemFreeView = InspectionViewObservation(
+            isUpdating = true,
+            hasProblems = false,
+            rootChildCount = null,
+            updateStateReadable = true,
+            problemStateReadable = true,
+        )
+
+        assertFalse(isTransientUpdatingUnreadableEmptyCandidate(updatingProblemFreeView))
+        assertTrue(isTransientUpdatingProblemFreeCandidate(updatingProblemFreeView))
+        assertTrue(
+            shouldTreatScopedEmptyExtractionAsSucceeded(
+                lastExtractionCycleSucceeded = false,
+                observedTransientEmptyInspectionViewEvidence = true,
+                lastToolExtractionSucceeded = true,
+            )
+        )
+        assertTrue(
+            shouldTrustStableScopedEmptyResults(
+                viewReadyOk = true,
+                observedInspectionView = true,
+                inspectionViewUpdating = true,
+                hasTransientEmptyInspectionViewEvidence = true,
+                extractionSucceeded = true,
+                hasScopedMatcher = true,
+                scopedContextResultsEmpty = true,
+                bestResultsEmpty = true,
+                observedNonEmptyInspectionTree = false,
+                stableForMs = 60000L,
+                pollingElapsedMs = 60000L,
+            )
+        )
+    }
+
+    @Test
     @DisplayName("Settled views without problems are clean even when the tree has grouping nodes")
     fun testSettledCleanInspectionViewAllowsGroupingNodes() {
         val groupedCleanView = InspectionViewObservation(


### PR DESCRIPTION
## Summary
- treat updating, problem-free Inspection Results views as guarded transient empty evidence for scoped inspections
- allow repeated successful scoped empty extraction to confirm clean after the existing deadline instead of returning capture_incomplete
- add regression coverage for the mediaforce-shaped diagnostic where the view stays updating but scoped results remain empty

## Validation
- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test --tests 'com.shiny.inspectionmcp.InspectionSnapshotStateTest'
- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :inspection-core:test :test --tests 'com.shiny.inspectionmcp.InspectionHandlerTest' :test --tests 'com.shiny.inspectionmcp.InspectionSnapshotStateTest' :mcp-server-jvm:test buildPlugin
- commit hook: ./gradlew test, :inspection-core:test, :mcp-server-jvm:test, buildPlugin
- installed patched build into PyCharm/IntelliJ/WebStorm local dogfood IDEs
- mediaforce closeout before: capture_incomplete with scoped empty diagnostics
- mediaforce closeout after: status=clean, snapshot_outcome=clean_confirmed, cleanup.status=closed
- jetbrains-inspection-api closeout after: status=clean, snapshot_outcome=clean_confirmed