### PR TITLE
Add capture incomplete reason diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,15 @@ Typical response (truncated):
 Notes:
 - `locationKnown=false` means the IDE did not provide a stable file/line (often stale results). Use `locationNote` and re-run inspection.
 - `status: "no_results"` uses the same pagination, filters, `total_problems`, `problems_shown`, and `problems` fields as result responses, with an empty problems list.
-- `status: "capture_incomplete"` means an inspection finished, but the plugin could not conclusively capture the IDE results. Re-run the inspection or open the Problems/Inspection Results view before treating the project as clean.
+- `status: "capture_incomplete"` means an inspection finished, but the
+  plugin could not conclusively capture the IDE results. Re-run the inspection
+  or open the Problems/Inspection Results view before treating the project as
+  clean. The response includes `capture_incomplete_reason` with a stable reason
+  such as `view_not_ready`, `view_unreadable`, `view_updating_unreadable`,
+  `extractor_failure`, `non_empty_unmapped_tree`, `capture_timeout`,
+  `capture_interrupted`, `plugin_error`, or `inconclusive_empty_results`;
+  `capture_diagnostic` carries the detailed counters behind that
+  classification when available.
 - `status: "stale_results"` means project files changed after the last inspection. It is not a clean result. Cached findings are withheld by default; call `/problems?include_stale=true` only when explicitly diagnosing cached data.
 - `snapshot_change_kind` explains freshness classification when present. `snapshot_predates_current_trigger` and `unsaved_documents` are stale; `current_run_psi_churn` is a fresh-run PSI tick that the plugin attempts to reconcile before returning results.
 - `session_drift: true` means the client sent an old `session_id`; the IDE/plugin session restarted or the port was reused.
@@ -475,6 +483,10 @@ The status endpoint includes a `clean_inspection` field that makes the outcome e
 - `results_may_be_stale: true` → Project changed after the last inspection; trigger again before trusting results
 - `snapshot_change_kind: "current_run_psi_churn"` → The latest run's snapshot saw a PSI modification-count tick after capture; the plugin keeps waiting instead of treating the snapshot as stale cached data.
 - `clean_inspection: true` → Inspection complete. No problems found
+- `capture_incomplete: true` → Inspection completed without a trustworthy
+  clean/results capture. Check `capture_incomplete_reason` and
+  `capture_diagnostic` before choosing retry, narrower scope, or plugin
+  investigation.
 - `has_inspection_results: true` → Problems found, retrieve with `/problems`
 - If all three are false and `time_since_last_trigger_ms` is recent, the inspection finished but results were not captured. Re-run the inspection or open the Inspection Results tool window.
 - If all three are false and `time_since_last_trigger_ms` is old, there was no recent inspection. Trigger one first.
@@ -486,7 +498,10 @@ Common completion reasons:
 - `results`: inspection completed and problems are ready to fetch.
 - `clean`: inspection completed and a clean empty result was confirmed.
 - `no_results`: inspection finished, but no results were captured. This can be a clean run or an unavailable/filtered IDE view.
-- `capture_incomplete`: inspection finished, but the plugin could not conclusively capture the IDE results. Re-run the inspection or open the Problems/Inspection Results view.
+- `capture_incomplete`: inspection finished, but the plugin could not
+  conclusively capture the IDE results. Re-run the inspection or open the
+  Problems/Inspection Results view. Wait responses include
+  `capture_incomplete_reason` when this happens.
 - `stale_results`: cached results exist, but project files changed after the last inspection. Trigger again before trusting findings. Wait responses expose cached counts as `cached_total_problems`, not `total_problems`.
 - `no_recent_inspection`: no inspection run is known for the selected project. Trigger one first.
 - `no_project`: no matching project was open during the wait period. This is not reported as `timed_out`; open a project or pass the exact project name.

--- a/TESTING.md
+++ b/TESTING.md
@@ -88,12 +88,14 @@ PyCharm, and WebStorm.
 
 The helper treats `capture_incomplete`, stale results, timeouts, indexing,
 session drift, route ambiguity, wrong-worktree routes, and cleanup failures as
-non-clean outcomes. Cached stale findings are returned only when the helper is
-run with `--include-stale` for explicit diagnostics. When this repo changes
-inspection status semantics, route metadata, clean/capture classification,
-lifecycle cleanup contracts, or MCP tool response contracts, update the skill
-docs/tests/scripts in the `jetbrains-inspection` skill as part of the same
-workstream.
+non-clean outcomes. `capture_incomplete` responses expose
+`capture_incomplete_reason` for rollout bucketing, with detailed counters in
+`capture_diagnostic` when available. Cached stale findings are returned only
+when the helper is run with `--include-stale` for explicit diagnostics. When
+this repo changes inspection status semantics, route metadata, clean/capture
+classification, lifecycle cleanup contracts, or MCP tool response contracts,
+update the skill docs/tests/scripts in the `jetbrains-inspection` skill as part
+of the same workstream.
 
 Before shipping changes to clean/capture classification, run the focused
 `InspectionSnapshotStateTest` coverage, then build the plugin with

--- a/mcp-server-jvm/src/main/kotlin/com/shiny/inspectionmcp/mcpserver/Main.kt
+++ b/mcp-server-jvm/src/main/kotlin/com/shiny/inspectionmcp/mcpserver/Main.kt
@@ -465,6 +465,7 @@ internal class ToolExecutor(
     private fun buildProblemsGuidance(result: JsonElement): String {
         val obj = result as? JsonObject ?: return ""
         val status = obj["status"]?.jsonPrimitive?.contentOrNull
+        val captureIncompleteReason = obj["capture_incomplete_reason"]?.jsonPrimitive?.contentOrNull
         val total = obj["total_problems"]?.jsonPrimitive?.intOrNull
         val shown = obj["problems_shown"]?.jsonPrimitive?.intOrNull
         val pagination = obj["pagination"] as? JsonObject
@@ -475,7 +476,7 @@ internal class ToolExecutor(
             status == "stale_results" ->
                 "\n\nWARN: Cached inspection results are stale because the project changed after the last run. Trigger a new inspection before trusting these findings. Pass include_stale=true only for explicit cached-result diagnostics."
             status == "capture_incomplete" ->
-                "\n\nWARN: capture_incomplete - do not treat as clean. Retry once, preferably with a narrower scope; if it repeats, report it."
+                "\n\nWARN: capture_incomplete${formatCaptureIncompleteReason(captureIncompleteReason)} - do not treat as clean. Retry once, preferably with a narrower scope; if it repeats, report the reason."
             status == "no_results" ->
                 "\n\nWARN: No inspection results were captured. This can happen for clean runs or when the IDE results view was unavailable; re-run inspection if findings were expected."
             total == 0 ->
@@ -499,13 +500,14 @@ internal class ToolExecutor(
         val hasResults = obj["has_inspection_results"]?.jsonPrimitive?.booleanOrNull == true
         val stale = obj["results_may_be_stale"]?.jsonPrimitive?.booleanOrNull == true
         val captureIncomplete = obj["capture_incomplete"]?.jsonPrimitive?.booleanOrNull == true
+        val captureIncompleteReason = obj["capture_incomplete_reason"]?.jsonPrimitive?.contentOrNull
 
         val timeSince = obj["time_since_last_trigger_ms"]?.jsonPrimitive?.longOrNull
 
         return when {
             isScanning -> "\n\nSTATUS: Inspection still running - wait before getting problems."
             stale -> "\n\nSTATUS: Project changed after the last inspection - trigger inspection again before trusting cached results."
-            captureIncomplete -> "\n\nSTATUS: capture_incomplete - do not treat as clean. Retry once, preferably with a narrower scope; if it repeats, report it."
+            captureIncomplete -> "\n\nSTATUS: capture_incomplete${formatCaptureIncompleteReason(captureIncompleteReason)} - do not treat as clean. Retry once, preferably with a narrower scope; if it repeats, report the reason."
             clean -> "\n\nSTATUS: Inspection complete - codebase is clean (no problems found)."
             hasResults -> "\n\nSTATUS: Inspection complete - problems found, ready to retrieve."
             timeSince != null && timeSince < 60000 ->
@@ -519,12 +521,13 @@ internal class ToolExecutor(
         val completed = obj["wait_completed"]?.jsonPrimitive?.booleanOrNull == true
         val timedOut = obj["timed_out"]?.jsonPrimitive?.booleanOrNull == true
         val reason = obj["completion_reason"]?.jsonPrimitive?.contentOrNull
+        val captureIncompleteReason = obj["capture_incomplete_reason"]?.jsonPrimitive?.contentOrNull
 
         return when {
             completed && reason == "clean" -> "\n\nSTATUS: Inspection complete - codebase is clean."
             completed && reason == "results" -> "\n\nSTATUS: Inspection complete - problems found."
             completed && reason == "capture_incomplete" ->
-                "\n\nSTATUS: capture_incomplete - do not treat as clean. Retry once, preferably with a narrower scope; if it repeats, report it."
+                "\n\nSTATUS: capture_incomplete${formatCaptureIncompleteReason(captureIncompleteReason)} - do not treat as clean. Retry once, preferably with a narrower scope; if it repeats, report the reason."
             completed && reason == "stale_results" ->
                 "\n\nSTATUS: Cached inspection results are stale - trigger inspection again before trusting findings."
             completed && reason == "no_results" ->
@@ -535,6 +538,10 @@ internal class ToolExecutor(
             timedOut -> "\n\nSTATUS: Wait timed out - try inspection_get_status or increase timeout_ms."
             else -> ""
         }
+    }
+
+    private fun formatCaptureIncompleteReason(reason: String?): String {
+        return if (reason.isNullOrBlank()) "" else " ($reason)"
     }
 
     private fun toolText(text: String, isError: Boolean = false): JsonObject {

--- a/mcp-server-jvm/src/test/kotlin/com/shiny/inspectionmcp/mcpserver/McpServerTest.kt
+++ b/mcp-server-jvm/src/test/kotlin/com/shiny/inspectionmcp/mcpserver/McpServerTest.kt
@@ -430,13 +430,14 @@ class McpServerTest {
 
     @Test
     fun inspectionGetStatusHandlesCaptureIncomplete() {
-        val response = """{"capture_incomplete":true,"has_inspection_results":false,"clean_inspection":false}"""
+        val response = """{"capture_incomplete":true,"capture_incomplete_reason":"view_not_ready","has_inspection_results":false,"clean_inspection":false}"""
         MockIdeServer(mapOf("/api/inspection/status" to MockResponse(response))).use { server ->
             server.start()
             val executor = ToolExecutor(server.baseUrl, HttpClient.newHttpClient(), server.port.toString())
 
             val result = executor.handleToolCall(buildToolCall("inspection_get_status", buildJsonObject { }))
             val text = result.firstText()
+            assertTrue(text.contains("capture_incomplete (view_not_ready)"))
             assertTrue(text.contains("do not treat as clean"))
             assertTrue(text.contains("Retry once"))
             assertFalse(text.contains("codebase is clean"))
@@ -611,13 +612,14 @@ class McpServerTest {
 
     @Test
     fun inspectionWaitHandlesCaptureIncomplete() {
-        val response = """{"wait_completed":true,"completion_reason":"capture_incomplete"}"""
+        val response = """{"wait_completed":true,"completion_reason":"capture_incomplete","capture_incomplete_reason":"capture_timeout"}"""
         MockIdeServer(mapOf("/api/inspection/wait" to MockResponse(response))).use { server ->
             server.start()
             val executor = ToolExecutor(server.baseUrl, HttpClient.newHttpClient(), server.port.toString())
 
             val result = executor.handleToolCall(buildToolCall("inspection_wait", buildJsonObject { }))
             val text = result.firstText()
+            assertTrue(text.contains("capture_incomplete (capture_timeout)"))
             assertTrue(text.contains("do not treat as clean"))
             assertTrue(text.contains("Retry once"))
             assertFalse(text.contains("codebase is clean"))

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -67,6 +67,18 @@ internal enum class InspectionSnapshotOutcome(val apiValue: String) {
     CAPTURE_INCOMPLETE("capture_incomplete"),
 }
 
+internal enum class CaptureIncompleteReason(val apiValue: String) {
+    VIEW_NOT_READY("view_not_ready"),
+    VIEW_UNREADABLE("view_unreadable"),
+    VIEW_UPDATING_UNREADABLE("view_updating_unreadable"),
+    EXTRACTOR_FAILURE("extractor_failure"),
+    NON_EMPTY_UNMAPPED_TREE("non_empty_unmapped_tree"),
+    CAPTURE_TIMEOUT("capture_timeout"),
+    CAPTURE_INTERRUPTED("capture_interrupted"),
+    PLUGIN_ERROR("plugin_error"),
+    INCONCLUSIVE_EMPTY_RESULTS("inconclusive_empty_results"),
+}
+
 internal data class InspectionProjectStateSnapshot(
     val psiModificationCount: Long,
     val unsavedProjectDocuments: Int,
@@ -264,6 +276,47 @@ internal fun classifyEmptyInspectionCapture(
 
     return InspectionSnapshotOutcome.CAPTURE_INCOMPLETE to
         "Inspection finished, but the plugin could not conclusively confirm that the IDE results were empty. Re-run the inspection or open the Inspection Results/Problems tool window."
+}
+
+internal fun classifyCaptureIncompleteReason(captureDiagnostic: Map<String, Any?>?): CaptureIncompleteReason {
+    val diagnostic = captureDiagnostic ?: return CaptureIncompleteReason.PLUGIN_ERROR
+    val exitReason = diagnostic["exit_reason"] as? String
+    val observedInspectionView = diagnostic["observed_inspection_view"] as? Boolean ?: false
+    val observedNonEmptyInspectionTree = diagnostic["observed_non_empty_inspection_tree"] as? Boolean ?: false
+    val inspectionViewUpdating = diagnostic["inspection_view_updating"] as? Boolean ?: false
+    val inspectionViewObservationCount = (diagnostic["inspection_view_observation_count"] as? Number)?.toInt() ?: 0
+    val unreadableProblemStateObservationCount =
+        (diagnostic["unreadable_problem_state_observation_count"] as? Number)?.toInt() ?: 0
+    val nullRootChildObservationCount = (diagnostic["null_root_child_observation_count"] as? Number)?.toInt() ?: 0
+    val compatibleToolWindowObservationCount =
+        (diagnostic["compatible_tool_window_observation_count"] as? Number)?.toInt() ?: 0
+    val successfulExtractionCount = (diagnostic["successful_extraction_count"] as? Number)?.toInt() ?: 0
+    val extractionFailureCount = (diagnostic["extraction_failure_count"] as? Number)?.toInt() ?: 0
+    val viewReadyOk = diagnostic["view_ready_ok"] as? Boolean ?: false
+
+    return when {
+        exitReason == "plugin_error" -> CaptureIncompleteReason.PLUGIN_ERROR
+        exitReason == "sleep_interrupted" -> CaptureIncompleteReason.CAPTURE_INTERRUPTED
+        observedNonEmptyInspectionTree && compatibleToolWindowObservationCount == 0 ->
+            CaptureIncompleteReason.NON_EMPTY_UNMAPPED_TREE
+        successfulExtractionCount == 0 && extractionFailureCount > 0 -> CaptureIncompleteReason.EXTRACTOR_FAILURE
+        observedInspectionView &&
+            inspectionViewUpdating &&
+            (unreadableProblemStateObservationCount > 0 || nullRootChildObservationCount > 0) ->
+            CaptureIncompleteReason.VIEW_UPDATING_UNREADABLE
+        observedInspectionView &&
+            inspectionViewObservationCount > 0 &&
+            (unreadableProblemStateObservationCount >= inspectionViewObservationCount ||
+                nullRootChildObservationCount >= inspectionViewObservationCount) ->
+            CaptureIncompleteReason.VIEW_UNREADABLE
+        !viewReadyOk || !observedInspectionView -> CaptureIncompleteReason.VIEW_NOT_READY
+        exitReason == "deadline" -> CaptureIncompleteReason.CAPTURE_TIMEOUT
+        else -> CaptureIncompleteReason.INCONCLUSIVE_EMPTY_RESULTS
+    }
+}
+
+internal fun captureIncompleteReasonValue(captureDiagnostic: Map<String, Any?>?): String {
+    return classifyCaptureIncompleteReason(captureDiagnostic).apiValue
 }
 
 internal fun isSettledCleanInspectionView(observation: InspectionViewObservation): Boolean {
@@ -1328,6 +1381,7 @@ class InspectionHandler : HttpRequestHandler() {
                     "method" to snapshot.source,
                     "snapshot_outcome" to snapshot.outcome.apiValue,
                 )
+                response["capture_incomplete_reason"] = captureIncompleteReasonValue(snapshot.captureDiagnostic)
                 snapshot.captureDiagnostic?.let { response["capture_diagnostic"] = it }
                 return formatJsonManually(response)
             }
@@ -1514,6 +1568,9 @@ class InspectionHandler : HttpRequestHandler() {
             status["snapshot_outcome"] = snapshot.outcome.apiValue
             if (!snapshot.note.isNullOrBlank()) {
                 status["snapshot_note"] = snapshot.note
+            }
+            if (snapshot.outcome == InspectionSnapshotOutcome.CAPTURE_INCOMPLETE && !staleness.stale) {
+                status["capture_incomplete_reason"] = captureIncompleteReasonValue(snapshot.captureDiagnostic)
             }
             snapshot.captureDiagnostic?.let { status["capture_diagnostic"] = it }
         }
@@ -2631,6 +2688,7 @@ class InspectionHandler : HttpRequestHandler() {
                                         source = "inspection_view",
                                         note = "Inspection failed before results could be captured.",
                                         captureScope = captureScope,
+                                        captureDiagnostic = mapOf("exit_reason" to "plugin_error"),
                                         runId = runId,
                                         triggerTimeMs = inspectionRunStatesByProject[key]?.triggerTimeMs,
                                     )
@@ -2710,6 +2768,7 @@ class InspectionHandler : HttpRequestHandler() {
                 source = "inspection_view",
                 note = "Inspection failed before results could be captured.",
                 captureScope = captureScope,
+                captureDiagnostic = mapOf("exit_reason" to "plugin_error"),
                 runId = runId,
                 triggerTimeMs = inspectionRunStatesByProject[key]?.triggerTimeMs,
             )

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
@@ -108,6 +108,7 @@ class InspectionSnapshotStateTest {
         val status = buildInspectionStatus()
 
         assertEquals("capture_incomplete", status["snapshot_outcome"])
+        assertEquals("view_not_ready", status["capture_incomplete_reason"])
         assertEquals("capture note", status["snapshot_note"])
         assertEquals(
             mapOf(
@@ -438,6 +439,7 @@ class InspectionSnapshotStateTest {
         val response = getInspectionProblems()
 
         assertTrue(response.contains("\"status\": \"capture_incomplete\""))
+        assertTrue(response.contains("\"capture_incomplete_reason\": \"view_not_ready\""))
         assertTrue(response.contains("\"results_may_be_incomplete\": true"))
         assertTrue(response.contains("\"snapshot_outcome\": \"capture_incomplete\""))
         assertTrue(response.contains("\"capture_diagnostic\""))
@@ -560,6 +562,7 @@ class InspectionSnapshotStateTest {
         val response = waitForInspection()
 
         assertTrue(response.contains("\"completion_reason\": \"capture_incomplete\""))
+        assertTrue(response.contains("\"capture_incomplete_reason\": \"view_not_ready\""))
         assertTrue(response.contains("\"capture_diagnostic\""))
         assertTrue(response.contains("\"exit_reason\": \"timeout\""))
         assertTrue(response.contains("\"view_ready_ok\": false"))
@@ -1146,6 +1149,79 @@ class InspectionSnapshotStateTest {
         )
 
         assertEquals(InspectionSnapshotOutcome.CAPTURE_INCOMPLETE, stillUnreadableView.first)
+    }
+
+    @Test
+    @DisplayName("Capture incomplete diagnostics produce stable reason codes")
+    fun testClassifyCaptureIncompleteReason() {
+        assertEquals(
+            CaptureIncompleteReason.VIEW_NOT_READY,
+            classifyCaptureIncompleteReason(mapOf("exit_reason" to "deadline", "view_ready_ok" to false)),
+        )
+        assertEquals(
+            CaptureIncompleteReason.NON_EMPTY_UNMAPPED_TREE,
+            classifyCaptureIncompleteReason(
+                mapOf(
+                    "view_ready_ok" to true,
+                    "observed_inspection_view" to true,
+                    "observed_non_empty_inspection_tree" to true,
+                    "compatible_tool_window_observation_count" to 0,
+                ),
+            ),
+        )
+        assertEquals(
+            CaptureIncompleteReason.EXTRACTOR_FAILURE,
+            classifyCaptureIncompleteReason(
+                mapOf(
+                    "view_ready_ok" to true,
+                    "observed_inspection_view" to true,
+                    "successful_extraction_count" to 0,
+                    "extraction_failure_count" to 2,
+                ),
+            ),
+        )
+        assertEquals(
+            CaptureIncompleteReason.VIEW_UPDATING_UNREADABLE,
+            classifyCaptureIncompleteReason(
+                mapOf(
+                    "view_ready_ok" to true,
+                    "observed_inspection_view" to true,
+                    "inspection_view_updating" to true,
+                    "unreadable_problem_state_observation_count" to 1,
+                    "inspection_view_observation_count" to 3,
+                ),
+            ),
+        )
+        assertEquals(
+            CaptureIncompleteReason.VIEW_UNREADABLE,
+            classifyCaptureIncompleteReason(
+                mapOf(
+                    "view_ready_ok" to true,
+                    "observed_inspection_view" to true,
+                    "inspection_view_observation_count" to 3,
+                    "null_root_child_observation_count" to 3,
+                ),
+            ),
+        )
+        assertEquals(
+            CaptureIncompleteReason.CAPTURE_INTERRUPTED,
+            classifyCaptureIncompleteReason(mapOf("exit_reason" to "sleep_interrupted")),
+        )
+        assertEquals(
+            CaptureIncompleteReason.PLUGIN_ERROR,
+            classifyCaptureIncompleteReason(mapOf("exit_reason" to "plugin_error")),
+        )
+        assertEquals(
+            CaptureIncompleteReason.CAPTURE_TIMEOUT,
+            classifyCaptureIncompleteReason(
+                mapOf(
+                    "exit_reason" to "deadline",
+                    "view_ready_ok" to true,
+                    "observed_inspection_view" to true,
+                    "inspection_view_observation_count" to 3,
+                ),
+            ),
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add a stable `capture_incomplete_reason` taxonomy derived from existing capture diagnostics
- expose the reason from status, wait, and problems responses while preserving the existing `capture_incomplete` status contract
- surface the reason in MCP text guidance and document the reason field for agent/helper workflows

## Validation
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test --tests 'com.shiny.inspectionmcp.InspectionSnapshotStateTest' :mcp-server-jvm:test --tests 'com.shiny.inspectionmcp.mcpserver.McpServerTest'`
- commit hook: `./gradlew test`, `./gradlew :inspection-core:test`, `./gradlew :mcp-server-jvm:test`, `./gradlew buildPlugin`
- `git diff --check`
- JetBrains helper closeout attempted: `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py closeout --repo "$PWD" --scope changed_files --timeout-ms 180000`
  - Result was not clean: helper timed out waiting for IntelliJ IDEA to open the exact isolated worktree.
  - The failure did include the structured envelope from cbusillo/codex-skills#140: `ERROR: reason=timeout`, repo/worktree/IDE context, and a next-action hint.

Refs #65
Refs #67
