### PR TITLE
Add capture incomplete reason taxonomy

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Typical response (truncated):
 Notes:
 - `locationKnown=false` means the IDE did not provide a stable file/line (often stale results). Use `locationNote` and re-run inspection.
 - `status: "no_results"` uses the same pagination, filters, `total_problems`, `problems_shown`, and `problems` fields as result responses, with an empty problems list.
-- `status: "capture_incomplete"` means an inspection finished, but the plugin could not conclusively capture the IDE results. Re-run the inspection or open the Problems/Inspection Results view before treating the project as clean.
+- `status: "capture_incomplete"` means an inspection finished, but the plugin could not conclusively capture the IDE results. Re-run the inspection or open the Problems/Inspection Results view before treating the project as clean. `capture_incomplete_reason` is a stable machine-readable bucket: `view_not_ready`, `view_updating_unreadable`, `unreadable_tree`, `extractor_failure`, `non_empty_unmapped_tree`, `current_run_psi_churn`, `timeout`, `helper_plugin_error`, or `unknown`. Use `capture_diagnostic` for the detailed counters and booleans behind the classification.
 - `status: "stale_results"` means project files changed after the last inspection. It is not a clean result. Cached findings are withheld by default; call `/problems?include_stale=true` only when explicitly diagnosing cached data.
 - `snapshot_change_kind` explains freshness classification when present. `snapshot_predates_current_trigger` and `unsaved_documents` are stale; `current_run_psi_churn` is a fresh-run PSI tick that the plugin attempts to reconcile before returning results.
 - `session_drift: true` means the client sent an old `session_id`; the IDE/plugin session restarted or the port was reused.
@@ -474,6 +474,7 @@ The status endpoint includes a `clean_inspection` field that makes the outcome e
 - `is_scanning: true` → Inspection running, wait
 - `results_may_be_stale: true` → Project changed after the last inspection; trigger again before trusting results
 - `snapshot_change_kind: "current_run_psi_churn"` → The latest run's snapshot saw a PSI modification-count tick after capture; the plugin keeps waiting instead of treating the snapshot as stale cached data.
+- `capture_incomplete_reason: "..."` → The subsystem bucket behind an inconclusive capture. IDE-state/retry buckets are `view_not_ready`, `view_updating_unreadable`, `unreadable_tree`, `current_run_psi_churn`, and `timeout`; plugin/helper investigation buckets are `extractor_failure`, `non_empty_unmapped_tree`, `helper_plugin_error`, and `unknown`.
 - `clean_inspection: true` → Inspection complete. No problems found
 - `has_inspection_results: true` → Problems found, retrieve with `/problems`
 - If all three are false and `time_since_last_trigger_ms` is recent, the inspection finished but results were not captured. Re-run the inspection or open the Inspection Results tool window.
@@ -486,7 +487,7 @@ Common completion reasons:
 - `results`: inspection completed and problems are ready to fetch.
 - `clean`: inspection completed and a clean empty result was confirmed.
 - `no_results`: inspection finished, but no results were captured. This can be a clean run or an unavailable/filtered IDE view.
-- `capture_incomplete`: inspection finished, but the plugin could not conclusively capture the IDE results. Re-run the inspection or open the Problems/Inspection Results view.
+- `capture_incomplete`: inspection finished, but the plugin could not conclusively capture the IDE results. The response includes `capture_incomplete_reason` when a bucket can be assigned; re-run the inspection or open the Problems/Inspection Results view.
 - `stale_results`: cached results exist, but project files changed after the last inspection. Trigger again before trusting findings. Wait responses expose cached counts as `cached_total_problems`, not `total_problems`.
 - `no_recent_inspection`: no inspection run is known for the selected project. Trigger one first.
 - `no_project`: no matching project was open during the wait period. This is not reported as `timed_out`; open a project or pass the exact project name.

--- a/TESTING.md
+++ b/TESTING.md
@@ -89,7 +89,10 @@ PyCharm, and WebStorm.
 The helper treats `capture_incomplete`, stale results, timeouts, indexing,
 session drift, route ambiguity, wrong-worktree routes, and cleanup failures as
 non-clean outcomes. Cached stale findings are returned only when the helper is
-run with `--include-stale` for explicit diagnostics. When this repo changes
+run with `--include-stale` for explicit diagnostics. `capture_incomplete`
+responses expose `capture_incomplete_reason` plus `capture_diagnostic`; use the
+reason bucket for triage and the diagnostic payload for counters and state
+evidence. When this repo changes
 inspection status semantics, route metadata, clean/capture classification,
 lifecycle cleanup contracts, or MCP tool response contracts, update the skill
 docs/tests/scripts in the `jetbrains-inspection` skill as part of the same

--- a/mcp-server-jvm/src/main/kotlin/com/shiny/inspectionmcp/mcpserver/Main.kt
+++ b/mcp-server-jvm/src/main/kotlin/com/shiny/inspectionmcp/mcpserver/Main.kt
@@ -465,6 +465,7 @@ internal class ToolExecutor(
     private fun buildProblemsGuidance(result: JsonElement): String {
         val obj = result as? JsonObject ?: return ""
         val status = obj["status"]?.jsonPrimitive?.contentOrNull
+        val captureReason = obj["capture_incomplete_reason"]?.jsonPrimitive?.contentOrNull
         val total = obj["total_problems"]?.jsonPrimitive?.intOrNull
         val shown = obj["problems_shown"]?.jsonPrimitive?.intOrNull
         val pagination = obj["pagination"] as? JsonObject
@@ -475,7 +476,7 @@ internal class ToolExecutor(
             status == "stale_results" ->
                 "\n\nWARN: Cached inspection results are stale because the project changed after the last run. Trigger a new inspection before trusting these findings. Pass include_stale=true only for explicit cached-result diagnostics."
             status == "capture_incomplete" ->
-                "\n\nWARN: capture_incomplete - do not treat as clean. Retry once, preferably with a narrower scope; if it repeats, report it."
+                captureIncompleteGuidance("WARN", captureReason)
             status == "no_results" ->
                 "\n\nWARN: No inspection results were captured. This can happen for clean runs or when the IDE results view was unavailable; re-run inspection if findings were expected."
             total == 0 ->
@@ -499,13 +500,14 @@ internal class ToolExecutor(
         val hasResults = obj["has_inspection_results"]?.jsonPrimitive?.booleanOrNull == true
         val stale = obj["results_may_be_stale"]?.jsonPrimitive?.booleanOrNull == true
         val captureIncomplete = obj["capture_incomplete"]?.jsonPrimitive?.booleanOrNull == true
+        val captureReason = obj["capture_incomplete_reason"]?.jsonPrimitive?.contentOrNull
 
         val timeSince = obj["time_since_last_trigger_ms"]?.jsonPrimitive?.longOrNull
 
         return when {
             isScanning -> "\n\nSTATUS: Inspection still running - wait before getting problems."
             stale -> "\n\nSTATUS: Project changed after the last inspection - trigger inspection again before trusting cached results."
-            captureIncomplete -> "\n\nSTATUS: capture_incomplete - do not treat as clean. Retry once, preferably with a narrower scope; if it repeats, report it."
+            captureIncomplete -> captureIncompleteGuidance("STATUS", captureReason)
             clean -> "\n\nSTATUS: Inspection complete - codebase is clean (no problems found)."
             hasResults -> "\n\nSTATUS: Inspection complete - problems found, ready to retrieve."
             timeSince != null && timeSince < 60000 ->
@@ -519,12 +521,13 @@ internal class ToolExecutor(
         val completed = obj["wait_completed"]?.jsonPrimitive?.booleanOrNull == true
         val timedOut = obj["timed_out"]?.jsonPrimitive?.booleanOrNull == true
         val reason = obj["completion_reason"]?.jsonPrimitive?.contentOrNull
+        val captureReason = obj["capture_incomplete_reason"]?.jsonPrimitive?.contentOrNull
 
         return when {
             completed && reason == "clean" -> "\n\nSTATUS: Inspection complete - codebase is clean."
             completed && reason == "results" -> "\n\nSTATUS: Inspection complete - problems found."
             completed && reason == "capture_incomplete" ->
-                "\n\nSTATUS: capture_incomplete - do not treat as clean. Retry once, preferably with a narrower scope; if it repeats, report it."
+                captureIncompleteGuidance("STATUS", captureReason)
             completed && reason == "stale_results" ->
                 "\n\nSTATUS: Cached inspection results are stale - trigger inspection again before trusting findings."
             completed && reason == "no_results" ->
@@ -535,6 +538,11 @@ internal class ToolExecutor(
             timedOut -> "\n\nSTATUS: Wait timed out - try inspection_get_status or increase timeout_ms."
             else -> ""
         }
+    }
+
+    private fun captureIncompleteGuidance(prefix: String, reason: String?): String {
+        val reasonText = if (reason.isNullOrBlank()) "" else " reason=$reason."
+        return "\n\n$prefix: capture_incomplete$reasonText do not treat as clean. Retry once, preferably with a narrower scope; if it repeats, report the reason and capture_diagnostic."
     }
 
     private fun toolText(text: String, isError: Boolean = false): JsonObject {

--- a/mcp-server-jvm/src/test/kotlin/com/shiny/inspectionmcp/mcpserver/McpServerTest.kt
+++ b/mcp-server-jvm/src/test/kotlin/com/shiny/inspectionmcp/mcpserver/McpServerTest.kt
@@ -234,7 +234,7 @@ class McpServerTest {
 
     @Test
     fun inspectionGetProblemsWarnsWhenCaptureIncomplete() {
-        val response = """{"status":"capture_incomplete","total_problems":0,"problems_shown":0,"problems":[]}"""
+        val response = """{"status":"capture_incomplete","capture_incomplete_reason":"extractor_failure","capture_diagnostic":{"exit_reason":"deadline"},"total_problems":0,"problems_shown":0,"problems":[]}"""
         MockIdeServer(mapOf("/api/inspection/problems" to MockResponse(response))).use { server ->
             server.start()
             val executor = ToolExecutor(server.baseUrl, HttpClient.newHttpClient(), server.port.toString())
@@ -243,6 +243,8 @@ class McpServerTest {
             val text = result.firstText()
             assertTrue(text.contains("do not treat as clean"))
             assertTrue(text.contains("Retry once"))
+            assertTrue(text.contains("reason=extractor_failure"))
+            assertTrue(text.contains("capture_diagnostic"))
             assertFalse(text.contains("OK: No problems found matching filters"))
         }
     }
@@ -430,7 +432,7 @@ class McpServerTest {
 
     @Test
     fun inspectionGetStatusHandlesCaptureIncomplete() {
-        val response = """{"capture_incomplete":true,"has_inspection_results":false,"clean_inspection":false}"""
+        val response = """{"capture_incomplete":true,"capture_incomplete_reason":"view_not_ready","has_inspection_results":false,"clean_inspection":false}"""
         MockIdeServer(mapOf("/api/inspection/status" to MockResponse(response))).use { server ->
             server.start()
             val executor = ToolExecutor(server.baseUrl, HttpClient.newHttpClient(), server.port.toString())
@@ -439,6 +441,7 @@ class McpServerTest {
             val text = result.firstText()
             assertTrue(text.contains("do not treat as clean"))
             assertTrue(text.contains("Retry once"))
+            assertTrue(text.contains("reason=view_not_ready"))
             assertFalse(text.contains("codebase is clean"))
         }
     }
@@ -611,7 +614,7 @@ class McpServerTest {
 
     @Test
     fun inspectionWaitHandlesCaptureIncomplete() {
-        val response = """{"wait_completed":true,"completion_reason":"capture_incomplete"}"""
+        val response = """{"wait_completed":true,"completion_reason":"capture_incomplete","capture_incomplete_reason":"timeout"}"""
         MockIdeServer(mapOf("/api/inspection/wait" to MockResponse(response))).use { server ->
             server.start()
             val executor = ToolExecutor(server.baseUrl, HttpClient.newHttpClient(), server.port.toString())
@@ -620,6 +623,7 @@ class McpServerTest {
             val text = result.firstText()
             assertTrue(text.contains("do not treat as clean"))
             assertTrue(text.contains("Retry once"))
+            assertTrue(text.contains("reason=timeout"))
             assertFalse(text.contains("codebase is clean"))
         }
     }

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -67,6 +67,18 @@ internal enum class InspectionSnapshotOutcome(val apiValue: String) {
     CAPTURE_INCOMPLETE("capture_incomplete"),
 }
 
+internal enum class CaptureIncompleteReason(val apiValue: String) {
+    VIEW_NOT_READY("view_not_ready"),
+    VIEW_UPDATING_UNREADABLE("view_updating_unreadable"),
+    UNREADABLE_TREE("unreadable_tree"),
+    EXTRACTOR_FAILURE("extractor_failure"),
+    NON_EMPTY_UNMAPPED_TREE("non_empty_unmapped_tree"),
+    CURRENT_RUN_PSI_CHURN("current_run_psi_churn"),
+    TIMEOUT("timeout"),
+    HELPER_PLUGIN_ERROR("helper_plugin_error"),
+    UNKNOWN("unknown"),
+}
+
 internal data class InspectionProjectStateSnapshot(
     val psiModificationCount: Long,
     val unsavedProjectDocuments: Int,
@@ -91,6 +103,7 @@ internal data class InspectionResultsSnapshot(
     val note: String? = null,
     val captureScope: InspectionCaptureScope? = null,
     val captureDiagnostic: Map<String, Any?>? = null,
+    val captureIncompleteReason: CaptureIncompleteReason? = null,
     val runId: Long? = null,
     val triggerTimeMs: Long? = null,
 )
@@ -511,6 +524,47 @@ internal fun shouldTreatScopedEmptyExtractionAsSucceeded(
         (observedTransientEmptyInspectionViewEvidence && lastToolExtractionSucceeded)
 }
 
+internal fun classifyCaptureIncompleteReason(
+    captureDiagnostic: Map<String, Any?>?,
+    snapshotChangeKind: String? = null,
+    fallbackReason: CaptureIncompleteReason = CaptureIncompleteReason.UNKNOWN,
+): CaptureIncompleteReason {
+    if (snapshotChangeKind == CaptureIncompleteReason.CURRENT_RUN_PSI_CHURN.apiValue) {
+        return CaptureIncompleteReason.CURRENT_RUN_PSI_CHURN
+    }
+
+    val diagnostic = captureDiagnostic ?: return fallbackReason
+    val exitReason = diagnostic["exit_reason"] as? String
+    val viewReadyOk = diagnostic["view_ready_ok"] as? Boolean
+    val observedInspectionView = diagnostic["observed_inspection_view"] as? Boolean
+    val inspectionViewUpdating = diagnostic["inspection_view_updating"] as? Boolean
+    val observedNonEmptyInspectionTree = diagnostic["observed_non_empty_inspection_tree"] as? Boolean
+    val extractionFailureCount = (diagnostic["extraction_failure_count"] as? Number)?.toInt() ?: 0
+    val successfulExtractionCount = (diagnostic["successful_extraction_count"] as? Number)?.toInt() ?: 0
+    val lastExtractionCycleSucceeded = diagnostic["last_extraction_cycle_succeeded"] as? Boolean
+    val unreadableProblemStateObservationCount =
+        (diagnostic["unreadable_problem_state_observation_count"] as? Number)?.toInt() ?: 0
+    val nullRootChildObservationCount = (diagnostic["null_root_child_observation_count"] as? Number)?.toInt() ?: 0
+    val inspectionViewObservationCount = (diagnostic["inspection_view_observation_count"] as? Number)?.toInt() ?: 0
+
+    return when {
+        exitReason == "helper_plugin_error" -> CaptureIncompleteReason.HELPER_PLUGIN_ERROR
+        viewReadyOk == false || observedInspectionView == false -> CaptureIncompleteReason.VIEW_NOT_READY
+        observedNonEmptyInspectionTree == true -> CaptureIncompleteReason.NON_EMPTY_UNMAPPED_TREE
+        inspectionViewUpdating == true &&
+            (unreadableProblemStateObservationCount > 0 || nullRootChildObservationCount > 0) ->
+            CaptureIncompleteReason.VIEW_UPDATING_UNREADABLE
+        unreadableProblemStateObservationCount > 0 ||
+            (inspectionViewObservationCount > 0 && nullRootChildObservationCount >= inspectionViewObservationCount) ->
+            CaptureIncompleteReason.UNREADABLE_TREE
+        extractionFailureCount > 0 &&
+            (successfulExtractionCount == 0 || lastExtractionCycleSucceeded == false) ->
+            CaptureIncompleteReason.EXTRACTOR_FAILURE
+        exitReason == "deadline" || exitReason == "timeout" -> CaptureIncompleteReason.TIMEOUT
+        else -> fallbackReason
+    }
+}
+
 class InspectionHandler : HttpRequestHandler() {
     private val logger = Logger.getInstance(InspectionHandler::class.java)
 
@@ -557,7 +611,33 @@ class InspectionHandler : HttpRequestHandler() {
         val reasons: List<String>,
         val changeKind: String = "fresh",
     )
-    
+
+    private fun captureIncompleteReason(
+        snapshot: InspectionResultsSnapshot?,
+        staleness: SnapshotStaleness = SnapshotStaleness(false, emptyList()),
+    ): CaptureIncompleteReason? {
+        if (snapshot?.outcome != InspectionSnapshotOutcome.CAPTURE_INCOMPLETE) {
+            return null
+        }
+        if (staleness.changeKind == CaptureIncompleteReason.CURRENT_RUN_PSI_CHURN.apiValue) {
+            return CaptureIncompleteReason.CURRENT_RUN_PSI_CHURN
+        }
+        return snapshot.captureIncompleteReason ?: classifyCaptureIncompleteReason(
+            captureDiagnostic = snapshot.captureDiagnostic,
+            snapshotChangeKind = staleness.changeKind,
+        )
+    }
+
+    private fun addCaptureIncompleteReason(
+        target: MutableMap<String, Any?>,
+        snapshot: InspectionResultsSnapshot?,
+        staleness: SnapshotStaleness = SnapshotStaleness(false, emptyList()),
+    ) {
+        captureIncompleteReason(snapshot, staleness)?.let { reason ->
+            target["capture_incomplete_reason"] = reason.apiValue
+        }
+    }
+
     override fun isSupported(request: FullHttpRequest): Boolean {
         return request.uri().startsWith("/api/inspection") && request.method() == HttpMethod.GET
     }
@@ -1257,7 +1337,7 @@ class InspectionHandler : HttpRequestHandler() {
                     filePattern = filePattern,
                 )
                 val page = paginateProblems(filteredCachedProblems, limit, offset)
-                val staleBase = mutableMapOf(
+                val staleBase = mutableMapOf<String, Any?>(
                     "status" to "stale_results",
                     "project" to project.name,
                     "project_key" to key,
@@ -1280,6 +1360,7 @@ class InspectionHandler : HttpRequestHandler() {
                         "file_pattern" to (filePattern ?: "all")
                     )
                 )
+                addCaptureIncompleteReason(staleBase, staleSnapshot, staleness)
                 if (includeStale) {
                     staleBase["message"] = "Project files changed since the last inspection. Returning cached findings because include_stale=true; trigger a new inspection before acting on them."
                     staleBase["include_stale"] = true
@@ -1298,7 +1379,7 @@ class InspectionHandler : HttpRequestHandler() {
             }
             snapshot = reconcileSnapshotWithLiveProblems(project, snapshot)
             if (snapshot != null && snapshot.outcome == InspectionSnapshotOutcome.CAPTURE_INCOMPLETE) {
-                val response = mutableMapOf(
+                val response = mutableMapOf<String, Any?>(
                     "status" to "capture_incomplete",
                     "project" to project.name,
                     "project_key" to key,
@@ -1328,6 +1409,7 @@ class InspectionHandler : HttpRequestHandler() {
                     "method" to snapshot.source,
                     "snapshot_outcome" to snapshot.outcome.apiValue,
                 )
+                addCaptureIncompleteReason(response, snapshot, staleness)
                 snapshot.captureDiagnostic?.let { response["capture_diagnostic"] = it }
                 return formatJsonManually(response)
             }
@@ -1516,6 +1598,9 @@ class InspectionHandler : HttpRequestHandler() {
                 status["snapshot_note"] = snapshot.note
             }
             snapshot.captureDiagnostic?.let { status["capture_diagnostic"] = it }
+        }
+        captureIncompleteReason(snapshot, staleness)?.let { reason ->
+            status["capture_incomplete_reason"] = reason.apiValue
         }
         if (staleness.reasons.isNotEmpty()) {
             status["stale_reasons"] = staleness.reasons
@@ -2553,6 +2638,7 @@ class InspectionHandler : HttpRequestHandler() {
                         } else {
                             null
                         }
+                        val captureIncompleteReason = classifyCaptureIncompleteReason(captureDiagnostic)
                         val snapshot = when {
                             bestResults.isNotEmpty() -> InspectionResultsSnapshot(
                                 problems = bestResults,
@@ -2631,6 +2717,8 @@ class InspectionHandler : HttpRequestHandler() {
                                         source = "inspection_view",
                                         note = "Inspection failed before results could be captured.",
                                         captureScope = captureScope,
+                                        captureDiagnostic = mapOf("exit_reason" to "helper_plugin_error"),
+                                        captureIncompleteReason = CaptureIncompleteReason.HELPER_PLUGIN_ERROR,
                                         runId = runId,
                                         triggerTimeMs = inspectionRunStatesByProject[key]?.triggerTimeMs,
                                     )
@@ -2710,6 +2798,8 @@ class InspectionHandler : HttpRequestHandler() {
                 source = "inspection_view",
                 note = "Inspection failed before results could be captured.",
                 captureScope = captureScope,
+                captureDiagnostic = mapOf("exit_reason" to "helper_plugin_error"),
+                captureIncompleteReason = CaptureIncompleteReason.HELPER_PLUGIN_ERROR,
                 runId = runId,
                 triggerTimeMs = inspectionRunStatesByProject[key]?.triggerTimeMs,
             )

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
@@ -117,6 +117,7 @@ class InspectionSnapshotStateTest {
             ),
             status["capture_diagnostic"],
         )
+        assertEquals("view_not_ready", status["capture_incomplete_reason"])
         assertEquals(true, status["capture_incomplete"])
         assertFalse(status["clean_inspection"] as Boolean)
         assertFalse(status["has_inspection_results"] as Boolean)
@@ -440,6 +441,7 @@ class InspectionSnapshotStateTest {
         assertTrue(response.contains("\"status\": \"capture_incomplete\""))
         assertTrue(response.contains("\"results_may_be_incomplete\": true"))
         assertTrue(response.contains("\"snapshot_outcome\": \"capture_incomplete\""))
+        assertTrue(response.contains("\"capture_incomplete_reason\": \"view_not_ready\""))
         assertTrue(response.contains("\"capture_diagnostic\""))
         assertTrue(response.contains("\"exit_reason\": \"timeout\""))
         assertTrue(response.contains("\"view_ready_ok\": false"))
@@ -560,6 +562,7 @@ class InspectionSnapshotStateTest {
         val response = waitForInspection()
 
         assertTrue(response.contains("\"completion_reason\": \"capture_incomplete\""))
+        assertTrue(response.contains("\"capture_incomplete_reason\": \"view_not_ready\""))
         assertTrue(response.contains("\"capture_diagnostic\""))
         assertTrue(response.contains("\"exit_reason\": \"timeout\""))
         assertTrue(response.contains("\"view_ready_ok\": false"))
@@ -1146,6 +1149,85 @@ class InspectionSnapshotStateTest {
         )
 
         assertEquals(InspectionSnapshotOutcome.CAPTURE_INCOMPLETE, stillUnreadableView.first)
+    }
+
+    @Test
+    @DisplayName("Capture incomplete diagnostics map to stable reason taxonomy")
+    fun testCaptureIncompleteReasonTaxonomy() {
+        assertEquals(
+            CaptureIncompleteReason.VIEW_NOT_READY,
+            classifyCaptureIncompleteReason(
+                mapOf(
+                    "exit_reason" to "deadline",
+                    "view_ready_ok" to false,
+                ),
+            ),
+        )
+        assertEquals(
+            CaptureIncompleteReason.VIEW_UPDATING_UNREADABLE,
+            classifyCaptureIncompleteReason(
+                mapOf(
+                    "exit_reason" to "deadline",
+                    "view_ready_ok" to true,
+                    "observed_inspection_view" to true,
+                    "inspection_view_updating" to true,
+                    "null_root_child_observation_count" to 2,
+                ),
+            ),
+        )
+        assertEquals(
+            CaptureIncompleteReason.UNREADABLE_TREE,
+            classifyCaptureIncompleteReason(
+                mapOf(
+                    "exit_reason" to "deadline",
+                    "view_ready_ok" to true,
+                    "observed_inspection_view" to true,
+                    "inspection_view_observation_count" to 2,
+                    "null_root_child_observation_count" to 2,
+                ),
+            ),
+        )
+        assertEquals(
+            CaptureIncompleteReason.EXTRACTOR_FAILURE,
+            classifyCaptureIncompleteReason(
+                mapOf(
+                    "exit_reason" to "deadline",
+                    "view_ready_ok" to true,
+                    "observed_inspection_view" to true,
+                    "extraction_failure_count" to 3,
+                    "successful_extraction_count" to 0,
+                ),
+            ),
+        )
+        assertEquals(
+            CaptureIncompleteReason.NON_EMPTY_UNMAPPED_TREE,
+            classifyCaptureIncompleteReason(
+                mapOf(
+                    "exit_reason" to "deadline",
+                    "view_ready_ok" to true,
+                    "observed_inspection_view" to true,
+                    "observed_non_empty_inspection_tree" to true,
+                ),
+            ),
+        )
+        assertEquals(
+            CaptureIncompleteReason.CURRENT_RUN_PSI_CHURN,
+            classifyCaptureIncompleteReason(emptyMap(), snapshotChangeKind = "current_run_psi_churn"),
+        )
+        assertEquals(
+            CaptureIncompleteReason.TIMEOUT,
+            classifyCaptureIncompleteReason(
+                mapOf(
+                    "exit_reason" to "deadline",
+                    "view_ready_ok" to true,
+                    "observed_inspection_view" to true,
+                ),
+            ),
+        )
+        assertEquals(
+            CaptureIncompleteReason.HELPER_PLUGIN_ERROR,
+            classifyCaptureIncompleteReason(mapOf("exit_reason" to "helper_plugin_error")),
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add a stable `capture_incomplete_reason` taxonomy alongside existing `status: "capture_incomplete"`
- classify incomplete captures from existing diagnostics into IDE readiness, unreadable/updating views, extractor failures, unmapped non-empty trees, PSI churn, timeout, helper/plugin error, and unknown buckets
- surface reasons through status/problems/wait responses and MCP helper text, with docs and tests for interpretation

## Validation
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test --tests 'com.shiny.inspectionmcp.InspectionSnapshotStateTest' --tests 'com.shiny.inspectionmcp.mcpserver.McpServerTest'`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :mcp-server-jvm:test --tests 'com.shiny.inspectionmcp.mcpserver.McpServerTest'`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :inspection-core:test :test --tests 'com.shiny.inspectionmcp.InspectionSnapshotStateTest' :mcp-server-jvm:test`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test --tests 'com.shiny.inspectionmcp.InspectionSnapshotStateTest' :mcp-server-jvm:test --tests 'com.shiny.inspectionmcp.mcpserver.McpServerTest'`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew buildPlugin`
- commit hook: `./gradlew test`, `:inspection-core:test`, `:mcp-server-jvm:test`, `buildPlugin`

## IDE inspection
- Attempted `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py closeout --repo "$PWD" --scope changed_files`; initially blocked by `untrusted_auto_open_root`.
- Added the Launchplane worktree parent to local trusted auto-open roots and retried with normal and `--foreground-open`; both timed out waiting for IntelliJ IDEA to register the exact isolated worktree, so IDE closeout did not complete.

Closes #67
