### PR TITLE
Stabilize capture incomplete reasons

### DIFF
--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -303,13 +303,6 @@ internal fun isTransientUpdatingUnreadableEmptyCandidate(observation: Inspection
         observation.rootChildCount == 0
 }
 
-internal fun isTransientUpdatingProblemFreeCandidate(observation: InspectionViewObservation): Boolean {
-    return observation.updateStateReadable &&
-        observation.problemStateReadable &&
-        observation.isUpdating &&
-        !observation.hasProblems
-}
-
 internal fun isOpaqueSettledEmptyInspectionViewCandidate(observation: InspectionViewObservation): Boolean {
     return observation.updateStateReadable &&
         observation.problemStateReadable &&
@@ -549,18 +542,21 @@ internal fun classifyCaptureIncompleteReason(
 
     return when {
         exitReason == "helper_plugin_error" -> CaptureIncompleteReason.HELPER_PLUGIN_ERROR
-        viewReadyOk == false || observedInspectionView == false -> CaptureIncompleteReason.VIEW_NOT_READY
         observedNonEmptyInspectionTree == true -> CaptureIncompleteReason.NON_EMPTY_UNMAPPED_TREE
         inspectionViewUpdating == true &&
             (unreadableProblemStateObservationCount > 0 || nullRootChildObservationCount > 0) ->
             CaptureIncompleteReason.VIEW_UPDATING_UNREADABLE
         unreadableProblemStateObservationCount > 0 ||
-            (inspectionViewObservationCount > 0 && nullRootChildObservationCount >= inspectionViewObservationCount) ->
+            (
+                inspectionViewObservationCount > 0 &&
+                    nullRootChildObservationCount in inspectionViewObservationCount..Int.MAX_VALUE
+                ) ->
             CaptureIncompleteReason.UNREADABLE_TREE
         extractionFailureCount > 0 &&
             (successfulExtractionCount == 0 || lastExtractionCycleSucceeded == false) ->
             CaptureIncompleteReason.EXTRACTOR_FAILURE
         exitReason == "deadline" || exitReason == "timeout" -> CaptureIncompleteReason.TIMEOUT
+        viewReadyOk == false || observedInspectionView == false -> CaptureIncompleteReason.VIEW_NOT_READY
         else -> fallbackReason
     }
 }
@@ -619,10 +615,11 @@ class InspectionHandler : HttpRequestHandler() {
         if (snapshot?.outcome != InspectionSnapshotOutcome.CAPTURE_INCOMPLETE) {
             return null
         }
+        snapshot.captureIncompleteReason?.let { return it }
         if (staleness.changeKind == CaptureIncompleteReason.CURRENT_RUN_PSI_CHURN.apiValue) {
             return CaptureIncompleteReason.CURRENT_RUN_PSI_CHURN
         }
-        return snapshot.captureIncompleteReason ?: classifyCaptureIncompleteReason(
+        return classifyCaptureIncompleteReason(
             captureDiagnostic = snapshot.captureDiagnostic,
             snapshotChangeKind = staleness.changeKind,
         )
@@ -2421,7 +2418,7 @@ class InspectionHandler : HttpRequestHandler() {
                                             readableEmptyInspectionViewStableSince = loopNow
                                         }
                                     }
-                                    isTransientUpdatingProblemFreeCandidate(viewObservation) &&
+                                    isTransientUpdatingUnreadableEmptyCandidate(viewObservation) &&
                                         !observedNonEmptyInspectionTree -> {
                                         observedTransientEmptyInspectionViewEvidence = true
                                         transientUpdatingEmptyObservationCount += 1
@@ -2670,6 +2667,7 @@ class InspectionHandler : HttpRequestHandler() {
                                 note = emptyNote,
                                 captureScope = captureScope,
                                 captureDiagnostic = captureDiagnostic,
+                                captureIncompleteReason = captureIncompleteReason,
                                 runId = runId,
                                 triggerTimeMs = inspectionRunStatesByProject[key]?.triggerTimeMs,
                             )

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
@@ -670,10 +670,13 @@ class InspectionSnapshotStateTest {
     }
 
     @Test
-    @DisplayName("Stored capture incomplete reason survives later PSI churn")
-    fun testStoredCaptureIncompleteReasonSurvivesPsiChurn() {
+    @DisplayName("Status preserves stored capture reason during unreconciled PSI churn")
+    fun testStatusPreservesStoredCaptureReasonDuringUnreconciledPsiChurn() {
+        val extractor = mockk<EnhancedTreeExtractor>()
         val currentRun = beginInspectionRun()
         finishInspectionRun(snapshotKey(), currentRun.runId)
+        every { extractor.extractAllProblems(mockProject) } returns listOf(staleProblem(description = "Unexpected live warning"))
+        enhancedTreeExtractorFactory = { extractor }
         InspectionResultsStore.setSnapshot(
             snapshotKey(),
             InspectionResultsSnapshot(
@@ -682,12 +685,14 @@ class InspectionSnapshotStateTest {
                 projectState = InspectionProjectStateSnapshot(psiModificationCount = 7L, unsavedProjectDocuments = 0),
                 outcome = InspectionSnapshotOutcome.CAPTURE_INCOMPLETE,
                 source = "inspection_view",
-                note = "capture note",
                 captureDiagnostic = mapOf(
-                    "exit_reason" to "timeout",
-                    "view_ready_ok" to false,
+                    "exit_reason" to "deadline",
+                    "view_ready_ok" to true,
+                    "observed_inspection_view" to true,
+                    "extraction_failure_count" to 2,
+                    "successful_extraction_count" to 0,
                 ),
-                captureIncompleteReason = CaptureIncompleteReason.TIMEOUT,
+                captureIncompleteReason = CaptureIncompleteReason.EXTRACTOR_FAILURE,
                 runId = currentRun.runId,
                 triggerTimeMs = currentRun.triggerTimeMs,
             ),
@@ -696,9 +701,9 @@ class InspectionSnapshotStateTest {
 
         val status = buildInspectionStatus()
 
-        assertEquals(true, status["capture_incomplete"])
-        assertEquals("timeout", status["capture_incomplete_reason"])
-        assertEquals("fresh", status["snapshot_change_kind"])
+        assertEquals(true, status["results_may_be_stale"])
+        assertEquals("project_changed_since_inspection", status["snapshot_change_kind"])
+        assertEquals("extractor_failure", status["capture_incomplete_reason"])
     }
 
     @Test
@@ -1196,6 +1201,15 @@ class InspectionSnapshotStateTest {
             ),
         )
         assertEquals(
+            CaptureIncompleteReason.VIEW_NOT_READY,
+            classifyCaptureIncompleteReason(
+                mapOf(
+                    "exit_reason" to "settled",
+                    "view_ready_ok" to false,
+                ),
+            ),
+        )
+        assertEquals(
             CaptureIncompleteReason.VIEW_UPDATING_UNREADABLE,
             classifyCaptureIncompleteReason(
                 mapOf(
@@ -1253,6 +1267,16 @@ class InspectionSnapshotStateTest {
                     "exit_reason" to "deadline",
                     "view_ready_ok" to true,
                     "observed_inspection_view" to true,
+                ),
+            ),
+        )
+        assertEquals(
+            CaptureIncompleteReason.TIMEOUT,
+            classifyCaptureIncompleteReason(
+                mapOf(
+                    "exit_reason" to "timeout",
+                    "view_ready_ok" to false,
+                    "observed_inspection_view" to false,
                 ),
             ),
         )

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
@@ -117,7 +117,7 @@ class InspectionSnapshotStateTest {
             ),
             status["capture_diagnostic"],
         )
-        assertEquals("view_not_ready", status["capture_incomplete_reason"])
+        assertEquals("timeout", status["capture_incomplete_reason"])
         assertEquals(true, status["capture_incomplete"])
         assertFalse(status["clean_inspection"] as Boolean)
         assertFalse(status["has_inspection_results"] as Boolean)
@@ -441,7 +441,7 @@ class InspectionSnapshotStateTest {
         assertTrue(response.contains("\"status\": \"capture_incomplete\""))
         assertTrue(response.contains("\"results_may_be_incomplete\": true"))
         assertTrue(response.contains("\"snapshot_outcome\": \"capture_incomplete\""))
-        assertTrue(response.contains("\"capture_incomplete_reason\": \"view_not_ready\""))
+        assertTrue(response.contains("\"capture_incomplete_reason\": \"timeout\""))
         assertTrue(response.contains("\"capture_diagnostic\""))
         assertTrue(response.contains("\"exit_reason\": \"timeout\""))
         assertTrue(response.contains("\"view_ready_ok\": false"))
@@ -562,7 +562,7 @@ class InspectionSnapshotStateTest {
         val response = waitForInspection()
 
         assertTrue(response.contains("\"completion_reason\": \"capture_incomplete\""))
-        assertTrue(response.contains("\"capture_incomplete_reason\": \"view_not_ready\""))
+        assertTrue(response.contains("\"capture_incomplete_reason\": \"timeout\""))
         assertTrue(response.contains("\"capture_diagnostic\""))
         assertTrue(response.contains("\"exit_reason\": \"timeout\""))
         assertTrue(response.contains("\"view_ready_ok\": false"))
@@ -667,6 +667,38 @@ class InspectionSnapshotStateTest {
         assertEquals("project_changed_since_inspection", status["snapshot_change_kind"])
         assertEquals(listOf("project_changed_since_inspection"), status["stale_reasons"])
         assertEquals(currentRun.runId, status["snapshot_run_id"])
+    }
+
+    @Test
+    @DisplayName("Stored capture incomplete reason survives later PSI churn")
+    fun testStoredCaptureIncompleteReasonSurvivesPsiChurn() {
+        val currentRun = beginInspectionRun()
+        finishInspectionRun(snapshotKey(), currentRun.runId)
+        InspectionResultsStore.setSnapshot(
+            snapshotKey(),
+            InspectionResultsSnapshot(
+                problems = emptyList(),
+                timestamp = System.currentTimeMillis() - 16000L,
+                projectState = InspectionProjectStateSnapshot(psiModificationCount = 7L, unsavedProjectDocuments = 0),
+                outcome = InspectionSnapshotOutcome.CAPTURE_INCOMPLETE,
+                source = "inspection_view",
+                note = "capture note",
+                captureDiagnostic = mapOf(
+                    "exit_reason" to "timeout",
+                    "view_ready_ok" to false,
+                ),
+                captureIncompleteReason = CaptureIncompleteReason.TIMEOUT,
+                runId = currentRun.runId,
+                triggerTimeMs = currentRun.triggerTimeMs,
+            ),
+        )
+        every { PsiModificationTracker.getInstance(mockProject).modificationCount } returns 8L
+
+        val status = buildInspectionStatus()
+
+        assertEquals(true, status["capture_incomplete"])
+        assertEquals("timeout", status["capture_incomplete_reason"])
+        assertEquals("fresh", status["snapshot_change_kind"])
     }
 
     @Test
@@ -1155,7 +1187,7 @@ class InspectionSnapshotStateTest {
     @DisplayName("Capture incomplete diagnostics map to stable reason taxonomy")
     fun testCaptureIncompleteReasonTaxonomy() {
         assertEquals(
-            CaptureIncompleteReason.VIEW_NOT_READY,
+            CaptureIncompleteReason.TIMEOUT,
             classifyCaptureIncompleteReason(
                 mapOf(
                     "exit_reason" to "deadline",
@@ -1591,13 +1623,12 @@ class InspectionSnapshotStateTest {
         val updatingProblemFreeView = InspectionViewObservation(
             isUpdating = true,
             hasProblems = false,
-            rootChildCount = null,
+            rootChildCount = 0,
             updateStateReadable = true,
             problemStateReadable = true,
         )
 
-        assertFalse(isTransientUpdatingUnreadableEmptyCandidate(updatingProblemFreeView))
-        assertTrue(isTransientUpdatingProblemFreeCandidate(updatingProblemFreeView))
+        assertTrue(isTransientUpdatingUnreadableEmptyCandidate(updatingProblemFreeView))
         assertTrue(
             shouldTreatScopedEmptyExtractionAsSucceeded(
                 lastExtractionCycleSucceeded = false,
@@ -1620,6 +1651,20 @@ class InspectionSnapshotStateTest {
                 pollingElapsedMs = 60000L,
             )
         )
+    }
+
+    @Test
+    @DisplayName("Problem-free updating views without a readable empty tree do not prove emptiness")
+    fun testProblemFreeUpdatingViewsWithoutZeroChildTreeDoNotProveEmptiness() {
+        val updatingProblemFreeView = InspectionViewObservation(
+            isUpdating = true,
+            hasProblems = false,
+            rootChildCount = null,
+            updateStateReadable = true,
+            problemStateReadable = true,
+        )
+
+        assertFalse(isTransientUpdatingUnreadableEmptyCandidate(updatingProblemFreeView))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- preserve stored `capture_incomplete_reason` values before applying current-read staleness labels
- persist the computed reason on common `CAPTURE_INCOMPLETE` snapshots
- classify plain deadline/timeout exits as `timeout` while preserving stronger diagnostic buckets
- require readable zero-child evidence before transient updating problem-free views can prove scoped emptiness

Fixes #72.

## Validation
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test --tests 'com.shiny.inspectionmcp.InspectionSnapshotStateTest'`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :inspection-core:test --tests 'com.shiny.inspectionmcp.core.InspectionRoutingTest' :test --tests 'com.shiny.inspectionmcp.InspectionSnapshotStateTest' :mcp-server-jvm:test --tests 'com.shiny.inspectionmcp.mcpserver.McpServerTest'`
- `git diff --check`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py --json closeout --repo /Users/cbusillo/Developer/jetbrains-inspection-api --ide "IntelliJ IDEA" --scope changed_files --timeout-ms 180000 --prepare-timeout-ms 180000`
- pre-commit hook: full `:test`, `:inspection-core:test`, `:mcp-server-jvm:test`, and `buildPlugin`
