### PR TITLE
Stabilize capture incomplete reason classification

### DIFF
--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -303,13 +303,6 @@ internal fun isTransientUpdatingUnreadableEmptyCandidate(observation: Inspection
         observation.rootChildCount == 0
 }
 
-internal fun isTransientUpdatingProblemFreeCandidate(observation: InspectionViewObservation): Boolean {
-    return observation.updateStateReadable &&
-        observation.problemStateReadable &&
-        observation.isUpdating &&
-        !observation.hasProblems
-}
-
 internal fun isOpaqueSettledEmptyInspectionViewCandidate(observation: InspectionViewObservation): Boolean {
     return observation.updateStateReadable &&
         observation.problemStateReadable &&
@@ -549,7 +542,6 @@ internal fun classifyCaptureIncompleteReason(
 
     return when {
         exitReason == "helper_plugin_error" -> CaptureIncompleteReason.HELPER_PLUGIN_ERROR
-        viewReadyOk == false || observedInspectionView == false -> CaptureIncompleteReason.VIEW_NOT_READY
         observedNonEmptyInspectionTree == true -> CaptureIncompleteReason.NON_EMPTY_UNMAPPED_TREE
         inspectionViewUpdating == true &&
             (unreadableProblemStateObservationCount > 0 || nullRootChildObservationCount > 0) ->
@@ -561,6 +553,7 @@ internal fun classifyCaptureIncompleteReason(
             (successfulExtractionCount == 0 || lastExtractionCycleSucceeded == false) ->
             CaptureIncompleteReason.EXTRACTOR_FAILURE
         exitReason == "deadline" || exitReason == "timeout" -> CaptureIncompleteReason.TIMEOUT
+        viewReadyOk == false || observedInspectionView == false -> CaptureIncompleteReason.VIEW_NOT_READY
         else -> fallbackReason
     }
 }
@@ -619,7 +612,10 @@ class InspectionHandler : HttpRequestHandler() {
         if (snapshot?.outcome != InspectionSnapshotOutcome.CAPTURE_INCOMPLETE) {
             return null
         }
-        if (staleness.changeKind == CaptureIncompleteReason.CURRENT_RUN_PSI_CHURN.apiValue) {
+        if (
+            snapshot.captureIncompleteReason == null &&
+            staleness.changeKind == CaptureIncompleteReason.CURRENT_RUN_PSI_CHURN.apiValue
+        ) {
             return CaptureIncompleteReason.CURRENT_RUN_PSI_CHURN
         }
         return snapshot.captureIncompleteReason ?: classifyCaptureIncompleteReason(
@@ -2421,7 +2417,7 @@ class InspectionHandler : HttpRequestHandler() {
                                             readableEmptyInspectionViewStableSince = loopNow
                                         }
                                     }
-                                    isTransientUpdatingProblemFreeCandidate(viewObservation) &&
+                                    isTransientUpdatingUnreadableEmptyCandidate(viewObservation) &&
                                         !observedNonEmptyInspectionTree -> {
                                         observedTransientEmptyInspectionViewEvidence = true
                                         transientUpdatingEmptyObservationCount += 1
@@ -2672,6 +2668,7 @@ class InspectionHandler : HttpRequestHandler() {
                                 captureDiagnostic = captureDiagnostic,
                                 runId = runId,
                                 triggerTimeMs = inspectionRunStatesByProject[key]?.triggerTimeMs,
+                                captureIncompleteReason = captureIncompleteReason,
                             )
                         }
                         if (snapshot.outcome == InspectionSnapshotOutcome.CAPTURE_INCOMPLETE && bestResults.isEmpty()) {

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
@@ -117,7 +117,7 @@ class InspectionSnapshotStateTest {
             ),
             status["capture_diagnostic"],
         )
-        assertEquals("view_not_ready", status["capture_incomplete_reason"])
+        assertEquals("timeout", status["capture_incomplete_reason"])
         assertEquals(true, status["capture_incomplete"])
         assertFalse(status["clean_inspection"] as Boolean)
         assertFalse(status["has_inspection_results"] as Boolean)
@@ -441,7 +441,7 @@ class InspectionSnapshotStateTest {
         assertTrue(response.contains("\"status\": \"capture_incomplete\""))
         assertTrue(response.contains("\"results_may_be_incomplete\": true"))
         assertTrue(response.contains("\"snapshot_outcome\": \"capture_incomplete\""))
-        assertTrue(response.contains("\"capture_incomplete_reason\": \"view_not_ready\""))
+        assertTrue(response.contains("\"capture_incomplete_reason\": \"timeout\""))
         assertTrue(response.contains("\"capture_diagnostic\""))
         assertTrue(response.contains("\"exit_reason\": \"timeout\""))
         assertTrue(response.contains("\"view_ready_ok\": false"))
@@ -562,7 +562,7 @@ class InspectionSnapshotStateTest {
         val response = waitForInspection()
 
         assertTrue(response.contains("\"completion_reason\": \"capture_incomplete\""))
-        assertTrue(response.contains("\"capture_incomplete_reason\": \"view_not_ready\""))
+        assertTrue(response.contains("\"capture_incomplete_reason\": \"timeout\""))
         assertTrue(response.contains("\"capture_diagnostic\""))
         assertTrue(response.contains("\"exit_reason\": \"timeout\""))
         assertTrue(response.contains("\"view_ready_ok\": false"))
@@ -667,6 +667,43 @@ class InspectionSnapshotStateTest {
         assertEquals("project_changed_since_inspection", status["snapshot_change_kind"])
         assertEquals(listOf("project_changed_since_inspection"), status["stale_reasons"])
         assertEquals(currentRun.runId, status["snapshot_run_id"])
+    }
+
+    @Test
+    @DisplayName("Status preserves stored capture reason during current-run PSI churn")
+    fun testStatusPreservesStoredCaptureReasonDuringCurrentRunPsiChurn() {
+        val extractor = mockk<EnhancedTreeExtractor>()
+        val currentRun = beginInspectionRun()
+        finishInspectionRun(snapshotKey(), currentRun.runId)
+        every { extractor.extractAllProblems(mockProject) } returns listOf(staleProblem(description = "Unexpected live warning"))
+        enhancedTreeExtractorFactory = { extractor }
+        InspectionResultsStore.setSnapshot(
+            snapshotKey(),
+            InspectionResultsSnapshot(
+                problems = emptyList(),
+                timestamp = System.currentTimeMillis() - 16000L,
+                projectState = InspectionProjectStateSnapshot(psiModificationCount = 7L, unsavedProjectDocuments = 0),
+                outcome = InspectionSnapshotOutcome.CAPTURE_INCOMPLETE,
+                source = "inspection_view",
+                captureDiagnostic = mapOf(
+                    "exit_reason" to "deadline",
+                    "view_ready_ok" to true,
+                    "observed_inspection_view" to true,
+                    "extraction_failure_count" to 2,
+                    "successful_extraction_count" to 0,
+                ),
+                captureIncompleteReason = CaptureIncompleteReason.EXTRACTOR_FAILURE,
+                runId = currentRun.runId,
+                triggerTimeMs = currentRun.triggerTimeMs,
+            ),
+        )
+        every { PsiModificationTracker.getInstance(mockProject).modificationCount } returns 8L
+
+        val status = buildInspectionStatus()
+
+        assertEquals(true, status["results_may_be_stale"])
+        assertEquals("project_changed_since_inspection", status["snapshot_change_kind"])
+        assertEquals("extractor_failure", status["capture_incomplete_reason"])
     }
 
     @Test
@@ -1158,7 +1195,7 @@ class InspectionSnapshotStateTest {
             CaptureIncompleteReason.VIEW_NOT_READY,
             classifyCaptureIncompleteReason(
                 mapOf(
-                    "exit_reason" to "deadline",
+                    "exit_reason" to "settled",
                     "view_ready_ok" to false,
                 ),
             ),
@@ -1221,6 +1258,16 @@ class InspectionSnapshotStateTest {
                     "exit_reason" to "deadline",
                     "view_ready_ok" to true,
                     "observed_inspection_view" to true,
+                ),
+            ),
+        )
+        assertEquals(
+            CaptureIncompleteReason.TIMEOUT,
+            classifyCaptureIncompleteReason(
+                mapOf(
+                    "exit_reason" to "timeout",
+                    "view_ready_ok" to false,
+                    "observed_inspection_view" to false,
                 ),
             ),
         )
@@ -1586,8 +1633,8 @@ class InspectionSnapshotStateTest {
     }
 
     @Test
-    @DisplayName("Updating problem-free views can prove scoped empty results after deadline")
-    fun testUpdatingProblemFreeViewsCanProveScopedEmptyResults() {
+    @DisplayName("Updating problem-free views need zero-child evidence before proving scoped empty results")
+    fun testUpdatingProblemFreeViewsNeedZeroChildEvidence() {
         val updatingProblemFreeView = InspectionViewObservation(
             isUpdating = true,
             hasProblems = false,
@@ -1595,9 +1642,10 @@ class InspectionSnapshotStateTest {
             updateStateReadable = true,
             problemStateReadable = true,
         )
+        val updatingZeroChildView = updatingProblemFreeView.copy(rootChildCount = 0)
 
         assertFalse(isTransientUpdatingUnreadableEmptyCandidate(updatingProblemFreeView))
-        assertTrue(isTransientUpdatingProblemFreeCandidate(updatingProblemFreeView))
+        assertTrue(isTransientUpdatingUnreadableEmptyCandidate(updatingZeroChildView))
         assertTrue(
             shouldTreatScopedEmptyExtractionAsSucceeded(
                 lastExtractionCycleSucceeded = false,
@@ -1611,6 +1659,21 @@ class InspectionSnapshotStateTest {
                 observedInspectionView = true,
                 inspectionViewUpdating = true,
                 hasTransientEmptyInspectionViewEvidence = true,
+                extractionSucceeded = true,
+                hasScopedMatcher = true,
+                scopedContextResultsEmpty = true,
+                bestResultsEmpty = true,
+                observedNonEmptyInspectionTree = false,
+                stableForMs = 60000L,
+                pollingElapsedMs = 60000L,
+            )
+        )
+        assertFalse(
+            shouldTrustStableScopedEmptyResults(
+                viewReadyOk = true,
+                observedInspectionView = true,
+                inspectionViewUpdating = true,
+                hasTransientEmptyInspectionViewEvidence = false,
                 extractionSucceeded = true,
                 hasScopedMatcher = true,
                 scopedContextResultsEmpty = true,


### PR DESCRIPTION
## Summary
- preserve computed `capture_incomplete_reason` on incomplete snapshots and keep explicit stored reasons stable during later current-run PSI churn reads
- make timeout/deadline exits beat generic readiness buckets while preserving concrete structural/extractor buckets
- narrow transient empty evidence to zero-child/readable updating observations instead of arbitrary problem-free updating views

## Validation
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test --tests 'com.shiny.inspectionmcp.InspectionSnapshotStateTest'`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py closeout --repo "$PWD" --scope changed_files` (first run returned `capture_incomplete` while the IDE view was still updating; retry on the exact worktree returned `STATUS: clean` with cleanup `closed`)
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew test`
- commit hook: `./gradlew :test`, `:inspection-core:test`, `:mcp-server-jvm:test`, `buildPlugin`

Refs #72
