### PR TITLE
Add plugin build fingerprint metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,8 @@ Typical response (truncated):
     "ide": {
       "name": "IntelliJ IDEA Ultimate",
       "product_code": "IU",
-      "plugin_version": "1.10.5"
+      "plugin_version": "1.10.5",
+      "plugin_build_fingerprint": "abc123def456-clean"
     }
   },
   "method": "enhanced_tree"
@@ -251,7 +252,8 @@ routing state.
       "name": "IntelliJ IDEA Ultimate",
       "version": "2025.1.1",
       "product_code": "IU",
-      "plugin_version": "1.10.5"
+      "plugin_version": "1.10.5",
+      "plugin_build_fingerprint": "abc123def456-clean"
     }
   },
   "registry": {
@@ -270,7 +272,13 @@ routing state.
 
 Identity responses and registry instance files share the same schema:
 `session_id`, `started_at_ms`, `heartbeat_ms`, `pid`, `port`, `ide_name`,
-`ide_version`, `ide_product_code`, `plugin_version`, and `open_projects`.
+`ide_version`, `ide_product_code`, `plugin_version`, `plugin_build_fingerprint`,
+`plugin_build_commit`, `plugin_build_short_commit`, `plugin_build_dirty`,
+`plugin_build_time`, and `open_projects`. Use `plugin_build_fingerprint` to
+distinguish same-version local or unreleased plugin builds when diagnosing stale
+running IDE processes. Repeated route summaries include only
+`plugin_build_fingerprint`; clients that need full build provenance should call
+`/identity` or read the registry instance file.
 Each project includes `project_key`, `name`, `base_path`, `project_file_path`,
 `project_instance_id`, and `focused` as a JSON boolean. `project_instance_id` is
 opaque and only stable for the lifetime of that IDE process; clients should use

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,57 @@ jacoco {
 group = "com.jetbrains.inspection"
 version = project.property("pluginVersion").toString()
 
+val generatedBuildInfoDir = layout.buildDirectory.dir("generated/resources/inspectionBuildInfo")
+val generateInspectionBuildInfo = tasks.register<Exec>("generateInspectionBuildInfo") {
+    val outputFile = generatedBuildInfoDir.map {
+        it.file("com/shiny/inspectionmcp/inspection-build.properties")
+    }
+    outputs.file(outputFile)
+    outputs.upToDateWhen { false }
+    outputs.cacheIf { false }
+    commandLine(
+        "sh",
+        "-c",
+        """
+        set -eu
+        out="${'$'}1"
+        mkdir -p "$(dirname "${'$'}out")"
+        commit="$(git rev-parse --verify HEAD 2>/dev/null || true)"
+        if [ -n "${'$'}commit" ]; then
+          short_commit="$(printf '%s' "${'$'}commit" | cut -c1-12)"
+          if [ -n "$(git status --porcelain 2>/dev/null || true)" ]; then
+            dirty="true"
+            state="dirty"
+          else
+            dirty="false"
+            state="clean"
+          fi
+        else
+          commit="unknown"
+          short_commit="unknown"
+          dirty="unknown"
+          state="unknown"
+        fi
+        build_time="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+        {
+          printf 'plugin.build.commit=%s\n' "${'$'}commit"
+          printf 'plugin.build.short_commit=%s\n' "${'$'}short_commit"
+          printf 'plugin.build.dirty=%s\n' "${'$'}dirty"
+          printf 'plugin.build.time=%s\n' "${'$'}build_time"
+          printf 'plugin.build.fingerprint=%s-%s\n' "${'$'}short_commit" "${'$'}state"
+        } > "${'$'}out"
+        """.trimIndent(),
+        "generateInspectionBuildInfo",
+        outputFile.get().asFile.absolutePath,
+    )
+}
+
+sourceSets {
+    main {
+        resources.srcDir(generatedBuildInfoDir)
+    }
+}
+
 repositories {
     mavenCentral()
     
@@ -52,6 +103,10 @@ kotlin {
 }
 
 tasks {
+    processResources {
+        dependsOn(generateInspectionBuildInfo)
+    }
+
     withType<JavaCompile> {
         sourceCompatibility = "21"
         targetCompatibility = "21"

--- a/inspection-core/src/main/kotlin/com/shiny/inspectionmcp/core/InspectionRouting.kt
+++ b/inspection-core/src/main/kotlin/com/shiny/inspectionmcp/core/InspectionRouting.kt
@@ -22,6 +22,7 @@ data class InspectionRouteIdentity(
     val ideProductCode: String?,
     val pluginVersion: String?,
     val projects: List<InspectionRouteProject>,
+    val pluginBuildFingerprint: String? = null,
 )
 
 data class InspectionRouteSelector(

--- a/mcp-server-jvm/src/main/kotlin/com/shiny/inspectionmcp/mcpserver/AutoRouting.kt
+++ b/mcp-server-jvm/src/main/kotlin/com/shiny/inspectionmcp/mcpserver/AutoRouting.kt
@@ -292,6 +292,7 @@ private fun toRouteIdentity(identity: JsonObject): InspectionRouteIdentity {
         ideVersion = identity.string("ide_version"),
         ideProductCode = identity.string("ide_product_code"),
         pluginVersion = identity.string("plugin_version"),
+        pluginBuildFingerprint = identity.string("plugin_build_fingerprint"),
         projects = identity["open_projects"]?.jsonArray?.filterIsInstance<JsonObject>()?.map(::toRouteProject) ?: emptyList(),
     )
 }

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -1238,6 +1238,11 @@ class InspectionHandler : HttpRequestHandler() {
                 "ide_version" to null,
                 "ide_product_code" to null,
                 "plugin_version" to null,
+                "plugin_build_fingerprint" to null,
+                "plugin_build_commit" to null,
+                "plugin_build_short_commit" to null,
+                "plugin_build_dirty" to null,
+                "plugin_build_time" to null,
                 "open_projects" to runCatching { openProjectIdentities() }.getOrDefault(emptyList()),
             )
         }
@@ -1273,7 +1278,8 @@ class InspectionHandler : HttpRequestHandler() {
             "product_code" to identity["ide_product_code"],
             "pid" to identity["pid"],
             "plugin_version" to identity["plugin_version"],
-        )
+            "plugin_build_fingerprint" to identity["plugin_build_fingerprint"],
+        ).filterValues { value -> value != null }
     }
 
     private fun routeSelectorMetadata(parameters: Map<String, List<String>>): Map<String, Any?> {
@@ -1320,6 +1326,7 @@ class InspectionHandler : HttpRequestHandler() {
             ideVersion = this["ide_version"] as? String,
             ideProductCode = this["ide_product_code"] as? String,
             pluginVersion = this["plugin_version"] as? String,
+            pluginBuildFingerprint = this["plugin_build_fingerprint"] as? String,
             projects = ((this["open_projects"] as? List<*>)?.filterIsInstance<Map<String, Any?>>()
                 ?: openProjectIdentities()).map { identity ->
                 InspectionRouteProject(

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionIdeIdentity.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionIdeIdentity.kt
@@ -15,12 +15,14 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.nio.file.StandardCopyOption
+import java.util.Properties
 import java.util.UUID
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
 private const val PLUGIN_ID = "com.shiny.inspection.api"
+private const val BUILD_INFO_RESOURCE = "/com/shiny/inspectionmcp/inspection-build.properties"
 private const val REGISTRY_DIR_ENV = "JETBRAINS_INSPECTION_REGISTRY_DIR"
 private const val REGISTRY_HEARTBEAT_SECONDS = 10L
 
@@ -29,8 +31,34 @@ internal object InspectionIdeSession {
     val startedAtMs: Long = System.currentTimeMillis()
 }
 
+internal data class InspectionPluginBuildInfo(
+    val commit: String?,
+    val shortCommit: String?,
+    val dirty: Boolean?,
+    val time: String?,
+    val fingerprint: String?,
+)
+
+internal fun loadInspectionPluginBuildInfo(): InspectionPluginBuildInfo {
+    val properties = Properties()
+    InspectionIdeSession::class.java.getResourceAsStream(BUILD_INFO_RESOURCE)?.use { stream ->
+        properties.load(stream)
+    }
+    fun value(key: String): String? = properties.getProperty(key)?.trim()?.takeIf { it.isNotEmpty() }
+    return InspectionPluginBuildInfo(
+        commit = value("plugin.build.commit"),
+        shortCommit = value("plugin.build.short_commit"),
+        dirty = value("plugin.build.dirty")?.toBooleanStrictOrNull(),
+        time = value("plugin.build.time"),
+        fingerprint = value("plugin.build.fingerprint"),
+    )
+}
+
+private val pluginBuildInfo: InspectionPluginBuildInfo by lazy { loadInspectionPluginBuildInfo() }
+
 internal fun buildInspectionIdentity(): Map<String, Any?> {
     val appInfo = ApplicationInfo.getInstance()
+    val buildInfo = pluginBuildInfo
     return mapOf(
         "session_id" to InspectionIdeSession.sessionId,
         "started_at_ms" to InspectionIdeSession.startedAtMs,
@@ -41,6 +69,11 @@ internal fun buildInspectionIdentity(): Map<String, Any?> {
         "ide_version" to appInfo.fullVersion,
         "ide_product_code" to resolveIdeProductCode(appInfo),
         "plugin_version" to PluginManagerCore.getPlugin(PluginId.getId(PLUGIN_ID))?.version,
+        "plugin_build_fingerprint" to buildInfo.fingerprint,
+        "plugin_build_commit" to buildInfo.commit,
+        "plugin_build_short_commit" to buildInfo.shortCommit,
+        "plugin_build_dirty" to buildInfo.dirty,
+        "plugin_build_time" to buildInfo.time,
         "open_projects" to openProjectIdentities(),
     )
 }

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionPluginBuildInfoTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionPluginBuildInfoTest.kt
@@ -1,0 +1,23 @@
+package com.shiny.inspectionmcp
+
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class InspectionPluginBuildInfoTest {
+
+    @Test
+    fun generatedBuildInfoResourceIsReadable() {
+        val buildInfo = loadInspectionPluginBuildInfo()
+
+        assertNotNull(buildInfo.commit)
+        assertNotNull(buildInfo.shortCommit)
+        assertNotNull(buildInfo.dirty)
+        assertNotNull(buildInfo.time)
+        assertNotNull(buildInfo.fingerprint)
+        val shortCommit = requireNotNull(buildInfo.shortCommit)
+        val fingerprint = requireNotNull(buildInfo.fingerprint)
+        assertTrue(shortCommit.isNotBlank())
+        assertTrue(fingerprint.contains(shortCommit))
+    }
+}


### PR DESCRIPTION
## Summary

- Generate plugin build metadata during Gradle builds and package it with the plugin.
- Expose full build provenance on `/identity` and registry instance records.
- Add compact `plugin_build_fingerprint` to repeated route summaries so stale loaded IDE builds are visible without bloating normal status/wait/problem payloads.
- Thread the fingerprint through MCP routing metadata and document the route-vs-identity split.

## Validation

- JetBrains closeout: `jb-inspect.py closeout --repo "$PWD" --scope changed_files --timeout-ms 90000`
- `./gradlew :test --tests com.shiny.inspectionmcp.InspectionPluginBuildInfoTest :inspection-core:test :mcp-server-jvm:test --tests com.shiny.inspectionmcp.mcpserver.McpServerTest --tests com.shiny.inspectionmcp.core.InspectionRoutingTest -Dkotlin.incremental=false`
- `./gradlew buildPlugin -Dkotlin.incremental=false`
- Commit hook full `:test`, `:inspection-core:test`, `:mcp-server-jvm:test`, and `buildPlugin`
