### PR TITLE
Tolerate missing git in build metadata

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,11 @@ val generateInspectionBuildInfo = tasks.register<Exec>("generateInspectionBuildI
         set -eu
         out="${'$'}1"
         mkdir -p "$(dirname "${'$'}out")"
-        commit="$(git rev-parse --verify HEAD 2>/dev/null || true)"
+        if command -v git >/dev/null 2>&1; then
+          commit="$(git rev-parse --verify HEAD 2>/dev/null || true)"
+        else
+          commit=""
+        fi
         if [ -n "${'$'}commit" ]; then
           short_commit="$(printf '%s' "${'$'}commit" | cut -c1-12)"
           if [ -n "$(git status --porcelain 2>/dev/null || true)" ]; then


### PR DESCRIPTION
## Summary
- make generated plugin build metadata tolerate environments where git is not installed
- keep the existing unknown metadata fallback instead of failing the build task

## Validation
- ./gradlew generateInspectionBuildInfo -Dkotlin.incremental=false
- direct no-git shell-path simulation produced plugin.build.fingerprint=unknown-unknown
- ./gradlew :test --tests com.shiny.inspectionmcp.InspectionPluginBuildInfoTest buildPlugin -Dkotlin.incremental=false
- uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py closeout --repo "/Users/cbusillo/Developer/jetbrains-inspection-api" --scope changed_files --timeout-ms 90000
- commit hook full gate passed