### PR TITLE
Isolate build metadata git environment

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,8 +69,7 @@ abstract class GenerateInspectionBuildInfoTask : DefaultTask() {
 
     private fun gitHeadCommit(): String? {
         return runCatching {
-            val process = ProcessBuilder("git", "rev-parse", "--verify", "HEAD")
-                .directory(gitDirectory.get().asFile)
+            val process = gitProcess("rev-parse", "--verify", "HEAD")
                 .redirectError(ProcessBuilder.Redirect.DISCARD)
                 .start()
             val output = process.inputStream.bufferedReader().use { it.readText() }.trim()
@@ -80,13 +79,23 @@ abstract class GenerateInspectionBuildInfoTask : DefaultTask() {
 
     private fun gitDiffIndexExitCode(): Int? {
         return runCatching {
-            ProcessBuilder("git", "diff-index", "--quiet", "HEAD", "--")
-                .directory(gitDirectory.get().asFile)
+            gitProcess("diff-index", "--quiet", "HEAD", "--")
                 .redirectOutput(ProcessBuilder.Redirect.DISCARD)
                 .redirectError(ProcessBuilder.Redirect.DISCARD)
                 .start()
                 .waitFor()
         }.getOrNull()
+    }
+
+    private fun gitProcess(vararg args: String): ProcessBuilder {
+        return ProcessBuilder("git", *args)
+            .directory(gitDirectory.get().asFile)
+            .apply {
+                environment().remove("GIT_DIR")
+                environment().remove("GIT_WORK_TREE")
+                environment().remove("GIT_INDEX_FILE")
+                environment().remove("GIT_PREFIX")
+            }
     }
 }
 


### PR DESCRIPTION
## Summary
- clear inherited GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE/GIT_PREFIX before build metadata git subprocesses
- prevent Gradle daemon environment from making the generator see a mismatched worktree/index
- preserve shell-free generation and missing-git fallback

## Validation
- ./gradlew :test --tests com.shiny.inspectionmcp.InspectionPluginBuildInfoTest buildPlugin -Dkotlin.incremental=false
- uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py closeout --repo "/Users/cbusillo/Developer/jetbrains-inspection-api" --scope changed_files --timeout-ms 90000
- commit hook full gate passed