### PR TITLE
Mark untracked files dirty in build metadata

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,7 +45,7 @@ abstract class GenerateInspectionBuildInfoTask : DefaultTask() {
         val shortCommit = commit.takeIf { it != "unknown" }?.take(12) ?: "unknown"
         val dirty = when {
             commit == "unknown" -> "unknown"
-            gitDiffIndexExitCode() == 0 -> "false"
+            gitDiffIndexExitCode() == 0 && !hasUntrackedFiles() -> "false"
             else -> "true"
         }
         val state = when (dirty) {
@@ -85,6 +85,16 @@ abstract class GenerateInspectionBuildInfoTask : DefaultTask() {
                 .start()
                 .waitFor()
         }.getOrNull()
+    }
+
+    private fun hasUntrackedFiles(): Boolean {
+        return runCatching {
+            val process = gitProcess("ls-files", "--others", "--exclude-standard")
+                .redirectError(ProcessBuilder.Redirect.DISCARD)
+                .start()
+            val output = process.inputStream.bufferedReader().use { it.readText() }.trim()
+            process.waitFor() == 0 && output.isNotEmpty()
+        }.getOrDefault(true)
     }
 
     private fun gitProcess(vararg args: String): ProcessBuilder {


### PR DESCRIPTION
## Summary
- include non-ignored untracked files in plugin build dirty detection
- keep ignored files excluded via git ls-files --others --exclude-standard
- fail closed to dirty if the untracked-file check cannot run

## Validation
- ./gradlew :test --tests com.shiny.inspectionmcp.InspectionPluginBuildInfoTest buildPlugin -Dkotlin.incremental=false
- uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py closeout --repo "/Users/cbusillo/Developer/jetbrains-inspection-api" --scope changed_files --timeout-ms 90000
- commit hook full gate passed
- temporary non-ignored untracked file produced plugin.build.fingerprint=*dirty
- after removing temporary untracked file, generator produced plugin.build.fingerprint=*clean