### PR TITLE
Clarify Every Code setup naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ You can also run `Tools` → `Copy MCP Setup`, pick your MCP client, then paste 
 Manual examples:
 
 ```bash
-# Code (Every)
+# Every Code
 code mcp add inspection-jetbrains "/path/to/java" -jar "/path/to/plugin/lib/jetbrains-inspection-mcp.jar"
 
 # Codex CLI

--- a/TESTING.md
+++ b/TESTING.md
@@ -53,7 +53,7 @@ primary agent-facing wrapper around this plugin's HTTP API. Run it from the
 installed or checked-out skill when validating behavior the agents rely on:
 
 ```bash
-HELPER="${CODEX_HOME:-$HOME/.code}/skills/jetbrains-inspection/scripts/jb-inspect.py"
+HELPER="${CODE_HOME:-${CODEX_HOME:-$HOME/.code}}/skills/jetbrains-inspection/scripts/jb-inspect.py"
 uv run "$HELPER" run \
   --repo "$PWD" \
   --scope changed_files
@@ -73,7 +73,7 @@ projects opened by the helper. Projects that were open before the helper started
 are left open. On macOS, lifecycle opens use `open -g` by default so the IDE should
 not take focus while a closeout is preparing a worktree. Auto-open requires a
 global trusted-root policy in
-`${CODEX_HOME:-$HOME/.code}/jetbrains-inspection.json`; test worktrees should be
+`${CODE_HOME:-${CODEX_HOME:-$HOME/.code}}/jetbrains-inspection.json`; test worktrees should be
 created under those roots, not random temp directories.
 
 Before it starts lifecycle auto-open, the helper adds the matching trusted root

--- a/scripts/dogfood-smoke-matrix.sh
+++ b/scripts/dogfood-smoke-matrix.sh
@@ -6,7 +6,7 @@ ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 cd "$ROOT" || exit 1
 
 DEFAULT_HELPER_DEV="$HOME/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py"
-DEFAULT_HELPER_HOME="${CODEX_HOME:-$HOME/.code}/skills/jetbrains-inspection/scripts/jb-inspect.py"
+DEFAULT_HELPER_HOME="${CODE_HOME:-${CODEX_HOME:-$HOME/.code}}/skills/jetbrains-inspection/scripts/jb-inspect.py"
 
 if [ -x "$DEFAULT_HELPER_DEV" ]; then
 	HELPER="$DEFAULT_HELPER_DEV"

--- a/src/main/kotlin/com/shiny/inspectionmcp/CopyMcpCommandAction.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/CopyMcpCommandAction.kt
@@ -84,7 +84,7 @@ private fun buildMcpSetupOptions(): List<McpSetupOption>? {
     val geminiCommand = "gemini mcp add -s user $name ${quote(javaBin)} -jar ${quote(jarPath.toString())}"
     val fixedPortNote = port?.let { "\n\nFixed-port fallback: add --env IDE_PORT=$it to target only this IDE." } ?: ""
     val allCommands = buildString {
-        appendLine("Code (Every)")
+        appendLine("Every Code")
         appendLine(codeCommand)
         appendLine()
         appendLine("Codex CLI")
@@ -99,7 +99,7 @@ private fun buildMcpSetupOptions(): List<McpSetupOption>? {
     }.trim()
 
     return listOf(
-        McpSetupOption("Code (Every)", codeCommand),
+        McpSetupOption("Every Code", codeCommand),
         McpSetupOption("Codex CLI", codexCommand),
         McpSetupOption("Claude Code", claudeCommand),
         McpSetupOption("Gemini CLI", geminiCommand),

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -17,7 +17,7 @@
             <li>Scope-based filtering (whole project, current file, directory)</li>
             <li>Trigger inspections programmatically and poll status</li>
             <li>Works with JetBrains IDEs (2025.x compatible)</li>
-            <li>Bundled MCP server + setup command for Code, Codex CLI, Claude Code, and Gemini CLI</li>
+            <li>Bundled MCP server + setup command for Every Code, Codex CLI, Claude Code, and Gemini CLI</li>
             <li>IDE-only inspections (e.g., PyCharm’s Odoo plugin checks) are made available to automation</li>
         </ul>
         <br/>


### PR DESCRIPTION
## Summary
- label the `code mcp add` setup path as Every Code instead of Code (Every)
- prefer CODE_HOME before CODEX_HOME in helper path examples
- update plugin setup copy to name Every Code while preserving the Codex CLI compatibility command

## Validation
- git diff --check
- ./scripts/commit-gate.sh --ci

Refs cbusillo/code#186
