### PR TITLE
chore(gitignore): ignore local LLM runtime state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,25 @@
+# Local AI/LLM runtime state
+# Keep repo-level config folders such as .codex, .agents, .claude, .cursor,
+# .gemini, .continue, and .opencode visible unless a specific local-only leaf
+# is ignored below.
+.code/
+.antigravitycli/
+.codex/sessions/
+.codex/history*.jsonl
+.codex/log/
+.codex/logs/
+.codex/tmp/
+.agents/runs/
+.agents/tmp/
+.agents/cache/
+.claude/settings.local.json
+.claude/settings.local.*.json
+CLAUDE.local.md
+.aider.chat.history.md
+.aider.input.history
+.aider.llm.history
+.aider.tags.cache.*/
+
 ### macOS template
 # General
 .DS_Store
@@ -70,7 +92,6 @@ node_modules/
 
 out/
 mcp-server/coverage/
-.claude/
 .code/
 *.override.*
 /mcp-server-jvm/build/


### PR DESCRIPTION
## Summary
- ignore local AI/LLM runtime state such as `.code/`, `.antigravitycli/`, Codex/agent run leaves, Claude local settings, and Aider history/cache
- keep config-capable folders visible so repo-owned files such as `.codex/skills`, `.agents/skills`, `.claude/settings.json`, Cursor rules, Gemini settings, and Aider config can still be tracked intentionally

## Verification
- `git check-ignore --no-index` spot checks with global excludes disabled for ignored private leaves and visible config paths
