### PR TITLE
Add linked worktree lifecycle open regression

### DIFF
--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -1076,6 +1076,38 @@ class InspectionHandlerTest {
     }
 
     @Test
+    fun `test lifecycle open schedules linked worktree when main checkout is open`() {
+        val tempDir = Files.createTempDirectory("inspection-open-linked-worktree")
+        val mainCheckout = tempDir.resolve("main")
+        val linkedWorktree = tempDir.resolve("worktrees/feature")
+        Files.createDirectories(mainCheckout)
+        Files.createDirectories(linkedWorktree)
+        every { mockProject.basePath } returns mainCheckout.toString()
+        every { mockProject.projectFilePath } returns mainCheckout.resolve(".idea/misc.xml").toString()
+        every { mockApplication.invokeLater(any()) } answers {
+            firstArg<Runnable>().run()
+        }
+        var openedPath: Path? = null
+        handler.openProjectPath = { path: Path ->
+            openedPath = path
+            mockProject(
+                name = "Feature",
+                basePath = linkedWorktree.toString(),
+                projectFilePath = linkedWorktree.resolve(".idea/misc.xml").toString(),
+            )
+        }
+
+        val response = processGetRequest(lifecycleOpenUri(linkedWorktree))
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"status\": \"opening\""))
+        assertTrue(body.contains("\"opening_scheduled\": true"))
+        assertFalse(body.contains("\"status\": \"already_open\""))
+        assertEquals(linkedWorktree.toAbsolutePath().normalize(), openedPath)
+    }
+
+    @Test
     fun `test lifecycle open reports already open project file path`() {
         val tempDir = Files.createTempDirectory("inspection-open-file-existing")
         val projectFilePath = tempDir.resolve(".idea/misc.xml").toString()


### PR DESCRIPTION
## Summary

- add regression coverage for lifecycle opening a linked worktree while the main checkout is already open
- assert the main checkout is not treated as `already_open` for the linked worktree request
- preserve the exact-worktree safety invariant from #104

Closes #104.

## Verification

- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test --tests com.shiny.inspectionmcp.InspectionHandlerTest`
- commit hook ran and passed plugin tests, `:inspection-core:test`, `:mcp-server-jvm:test`, and `buildPlugin`
- verified JetBrains Marketplace version `1.13.2` is the latest published artifact and matches GitHub release `v1.13.2` at commit `076269f54867-clean`
- installed the actual Marketplace `1.13.2` build locally and confirmed the linked-worktree prepare succeeds in IntelliJ with the main checkout already open

## Notes

The local issue #104 reproduction was explained by stale local IDE plugin state: IntelliJ/WebStorm were still running `1.13.1`. The released Marketplace `1.13.2` contains the working lifecycle behavior. This PR keeps the root-open plus linked-worktree case covered so future lifecycle routing changes do not regress into accepting the wrong checkout.
