### PR TITLE
Fix unmapped inspection red-lane findings

### DIFF
--- a/.code/skills/jetbrains-inspection-workflow/SKILL.md
+++ b/.code/skills/jetbrains-inspection-workflow/SKILL.md
@@ -81,6 +81,10 @@ Keep exact command matrices, environment setup, and troubleshooting in
 6. For clean/capture classification, preserve non-clean outcomes for
    `capture_incomplete`, stale results, timeouts, indexing, session drift,
    route ambiguity, wrong-worktree routes, and cleanup failures.
+7. For red-lane smoke tests, require at least one current actionable finding in
+   the helper response, such as `total_problems > 0` with a non-empty
+   `problems` list. `capture_incomplete`, `non_empty_unmapped_tree`, or a
+   non-clean zero-problem response proves only that clean was not confirmed.
 
 ## IDE Smoke Testing
 

--- a/src/main/kotlin/com/shiny/inspectionmcp/EnhancedTreeExtractor.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/EnhancedTreeExtractor.kt
@@ -21,6 +21,9 @@ import java.awt.Component
 import java.awt.Container
 import java.io.File
 import java.lang.reflect.Method
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
 import java.util.concurrent.ConcurrentHashMap
 import javax.swing.JTree
 
@@ -265,6 +268,7 @@ class EnhancedTreeExtractor {
                         val child = node.getChildAt(i)
                         walkNode(child, problems, project, depth + 1)
                     }
+                    extractFallbackProblemFromTreeNode(node, problems, project)
                 }
                 
                 is DefaultMutableTreeNode -> {
@@ -273,6 +277,7 @@ class EnhancedTreeExtractor {
                         val child = node.getChildAt(i)
                         walkNode(child, problems, project, depth + 1)
                     }
+                    extractFallbackProblemFromTreeNode(node, problems, project)
                 }
                 
                 is TreeNode -> {
@@ -280,6 +285,7 @@ class EnhancedTreeExtractor {
                         val child = node.getChildAt(i)
                         walkNode(child, problems, project, depth + 1)
                     }
+                    extractFallbackProblemFromTreeNode(node, problems, project)
                 }
             }
         } catch (e: Exception) {
@@ -340,6 +346,208 @@ class EnhancedTreeExtractor {
                 "source" to "problems_view",
             )
         )
+    }
+
+    private fun extractFallbackProblemFromTreeNode(
+        node: TreeNode,
+        problems: MutableList<Map<String, Any>>,
+        project: Project,
+    ) {
+        if (!shouldAddFallbackProblem(node)) {
+            return
+        }
+
+        val description = normalizeProblemDescription(treeNodeText(node))
+        if (description.isBlank() || isGenericInspectionTreeText(description)) {
+            return
+        }
+
+        val inspectionType = nearestInspectionType(node)
+        val filePath = nearestTreeFilePath(node, project)
+        val severity = severityFromTreeText(description)
+        problems.add(
+            mapOf(
+                "description" to description,
+                "file" to filePath,
+                "line" to 0,
+                "column" to 0,
+                "severity" to severity,
+                "category" to nearestInspectionCategory(node, inspectionType),
+                "inspectionType" to inspectionType,
+                "source" to "inspection_tree_fallback",
+                "locationKnown" to false,
+                "locationNote" to if (filePath != "unknown") {
+                    "Inspection result line unavailable from IDE tree; open Inspection Results for the exact line."
+                } else {
+                    "Inspection result location unavailable from IDE tree; open Inspection Results for the exact file and line."
+                },
+            )
+        )
+    }
+
+    private fun shouldAddFallbackProblem(node: TreeNode): Boolean {
+        if (node.childCount > 0) {
+            return false
+        }
+        val userObject = (node as? DefaultMutableTreeNode)?.userObject
+        if (userObject is ProblemDescriptionNode || userObject is InspectionNode || userObject is InspectionTreeNode) {
+            return false
+        }
+        return hasInspectionAncestor(node) && looksLikeInspectionProblemText(treeNodeText(node))
+    }
+
+    private fun hasInspectionAncestor(node: TreeNode): Boolean {
+        var current = node.parent
+        while (current != null) {
+            if (current is InspectionNode || current is InspectionTreeNode) {
+                return true
+            }
+            val text = current.toString()
+            if (looksLikeInspectionCategoryText(text)) {
+                return true
+            }
+            current = current.parent
+        }
+        return false
+    }
+
+    private fun treeNodeText(node: TreeNode): String {
+        return ((node as? DefaultMutableTreeNode)?.userObject ?: node).toString()
+    }
+
+    private fun treePath(node: TreeNode): List<TreeNode> {
+        val path = ArrayDeque<TreeNode>()
+        var current: TreeNode? = node
+        while (current != null) {
+            path.addFirst(current)
+            current = current.parent
+        }
+        return path.toList()
+    }
+
+    private fun nearestInspectionType(node: TreeNode): String {
+        var current: TreeNode? = node.parent
+        while (current != null) {
+            val text = current.toString().trim()
+            inspectionTypeNameFromText(text)?.let { return it }
+            current = current.parent
+        }
+        inspectionTypeFromText(node.toString().trim())?.let { return it }
+        return "InspectionTreeFallback"
+    }
+
+    private fun nearestInspectionCategory(node: TreeNode, inspectionType: String): String {
+        var current: TreeNode? = node.parent
+        while (current != null) {
+            val text = current.toString().trim()
+            if (text.isNotBlank() && !isGenericInspectionTreeText(text) && inspectionTypeNameFromText(text) == null) {
+                return text.take(80)
+            }
+            current = current.parent
+        }
+        return if (inspectionType == "InspectionTreeFallback") "General" else inspectionType
+    }
+
+    private fun nearestTreeFilePath(node: TreeNode, project: Project): String {
+        var current: TreeNode? = node
+        while (current != null) {
+            filePathFromTreeText(current.toString(), project)?.let { return it }
+            current = current.parent
+        }
+        return "unknown"
+    }
+
+    private fun filePathFromTreeText(text: String, project: Project): String? {
+        val normalized = text.trim()
+        if (normalized.isBlank()) return null
+        val fileMatch = Regex("(?:^|\\s)([^\\s:]+\\.(?:kt|kts|java|py|js|jsx|ts|tsx|swift|go|rs|rb|php|xml|json|ya?ml|sh|bash|zsh))(?:[:\\s]|$)")
+            .find(normalized)
+        val fileText = fileMatch?.groupValues?.getOrNull(1)?.trim('"', '\'', ',', ';', ')', ']') ?: return null
+        return resolveTreeFilePath(fileText, project)
+    }
+
+    private fun resolveTreeFilePath(fileText: String, project: Project): String {
+        val rawPath = runCatching { Paths.get(fileText) }.getOrNull()
+        if (rawPath != null && rawPath.isAbsolute) {
+            return rawPath.normalize().toString()
+        }
+        val basePath = project.basePath ?: return fileText
+        if (rawPath != null && fileText.contains('/')) {
+            return Paths.get(basePath, fileText).normalize().toString()
+        }
+        return findProjectFileByName(basePath, fileText) ?: fileText
+    }
+
+    private fun findProjectFileByName(basePath: String, fileName: String): String? {
+        val base = runCatching { Paths.get(basePath) }.getOrNull() ?: return null
+        return try {
+            Files.walk(base).use { stream ->
+                stream
+                    .filter { path -> Files.isRegularFile(path) && path.fileName?.toString() == fileName }
+                    .findFirst()
+                    .map(Path::toString)
+                    .orElse(null)
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun inspectionTypeFromText(text: String): String? {
+        inspectionTypeNameFromText(text)?.let { return it }
+        if (text.isBlank()) return null
+        return when {
+            text.contains("Unresolved", ignoreCase = true) -> "UnresolvedReference"
+            text.contains("Cannot resolve", ignoreCase = true) -> "UnresolvedReference"
+            text.contains("Symbol", ignoreCase = true) -> "UnresolvedReference"
+            text.contains("Typo", ignoreCase = true) -> "SpellCheckingInspection"
+            text.contains("Grammar", ignoreCase = true) -> "GrazieInspection"
+            else -> null
+        }
+    }
+
+    private fun inspectionTypeNameFromText(text: String): String? {
+        if (text.isBlank()) return null
+        return Regex("\\b([A-Za-z][A-Za-z0-9_]*(?:Inspection|Check))\\b").find(text)?.groupValues?.getOrNull(1)
+    }
+
+    private fun looksLikeInspectionProblemText(text: String): Boolean {
+        val normalized = text.trim()
+        return normalized.contains("Cannot resolve", ignoreCase = true) ||
+            normalized.contains("Unresolved", ignoreCase = true) ||
+            normalized.contains("never used", ignoreCase = true) ||
+            normalized.contains("deprecated", ignoreCase = true) ||
+            normalized.contains("is missing", ignoreCase = true) ||
+            normalized.contains("Missing ", ignoreCase = false) ||
+            normalized.contains("Unknown ", ignoreCase = false)
+    }
+
+    private fun looksLikeInspectionCategoryText(text: String): Boolean {
+        val normalized = text.trim()
+        return inspectionTypeFromText(normalized) != null ||
+            inspectionTypeNameFromText(normalized) != null ||
+            normalized.contains("probable bugs", ignoreCase = true) ||
+            normalized.contains("compiler", ignoreCase = true) ||
+            normalized.contains("declaration redundancy", ignoreCase = true)
+    }
+
+    private fun isGenericInspectionTreeText(text: String): Boolean {
+        val normalized = text.trim().lowercase()
+        return normalized.isBlank() ||
+            normalized == "root" ||
+            normalized == "inspection results" ||
+            normalized == "problems" ||
+            normalized == "empty"
+    }
+
+    private fun severityFromTreeText(text: String): String {
+        return when {
+            text.contains("error", ignoreCase = true) -> "error"
+            text.contains("warning", ignoreCase = true) -> "warning"
+            text.contains("weak", ignoreCase = true) -> "weak_warning"
+            text.contains("info", ignoreCase = true) -> "info"
+            else -> "warning"
+        }
     }
 
     private fun resolveVirtualFile(fileObj: Any?): VirtualFile? {
@@ -664,8 +872,37 @@ class EnhancedTreeExtractor {
                 }
                 
                 problems.add(problemMap)
+            } else {
+                extractFallbackProblemFromInspectionNode(node, problems)
             }
         } catch (e: Exception) {
         }
+    }
+
+    private fun extractFallbackProblemFromInspectionNode(
+        node: ProblemDescriptionNode,
+        problems: MutableList<Map<String, Any>>,
+    ) {
+        val description = normalizeProblemDescription(node.toString())
+        if (description.isBlank() || isGenericInspectionTreeText(description)) {
+            return
+        }
+
+        val inspectionType = nearestInspectionType(node)
+        val severity = severityFromTreeText(description)
+        problems.add(
+            mapOf(
+                "description" to description,
+                "file" to "unknown",
+                "line" to 0,
+                "column" to 0,
+                "severity" to severity,
+                "category" to if (inspectionType == "InspectionTreeFallback") "General" else inspectionType,
+                "inspectionType" to inspectionType,
+                "source" to "inspection_node_fallback",
+                "locationKnown" to false,
+                "locationNote" to "Inspection result descriptor unavailable from IDE; open Inspection Results for the exact file and line.",
+            )
+        )
     }
 }

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -306,6 +306,64 @@ internal fun classifyEmptyInspectionCapture(
         "Inspection finished, but the plugin could not conclusively confirm that the IDE results were empty. Re-run the inspection or open the Inspection Results/Problems tool window."
 }
 
+internal fun buildUnmappedInspectionFallbackProblems(
+    project: Project,
+    captureScope: InspectionCaptureScope,
+    diagnostic: Map<String, Any?>?,
+): List<Map<String, Any>> {
+    val observedNonEmptyTree = diagnostic?.get("observed_non_empty_inspection_tree") as? Boolean ?: false
+    val descriptorCount = (diagnostic?.get("model_problem_descriptor_count") as? Number)?.toInt() ?: 0
+    if (!observedNonEmptyTree && descriptorCount <= 0) {
+        return emptyList()
+    }
+
+    val basePath = normalizeFileSystemPath(project.basePath)
+    fun resolvePath(raw: String?): String? {
+        val trimmed = raw?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+        return try {
+            val path = Paths.get(trimmed)
+            normalizeFileSystemPath(
+                if (path.isAbsolute || basePath == null) trimmed else Paths.get(basePath, trimmed).toString()
+            )
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    fun singleFileTarget(): String? {
+        captureScope.resolvedCurrentFile?.let(::resolvePath)?.let { return it }
+        val files = captureScope.files.orEmpty().mapNotNull(::resolvePath).distinct()
+        if (files.size == 1) return files.single()
+        val directoryTarget = resolvePath(captureScope.directoryParam)
+        if (directoryTarget != null) return directoryTarget
+        return basePath
+    }
+
+    val target = singleFileTarget() ?: "unknown"
+    val rootChildCount = (diagnostic?.get("last_view_observation") as? Map<*, *>)
+        ?.get("root_child_count") as? Number
+    val evidence = buildList {
+        if (observedNonEmptyTree) add("Inspection Results reported a non-empty problem tree")
+        if (descriptorCount > 0) add("$descriptorCount descriptor(s) were present but unmapped")
+        rootChildCount?.let { add("root child count: ${it.toInt()}") }
+    }.joinToString("; ").ifBlank { "Inspection Results reported unmapped problems" }
+
+    return listOf(
+        mapOf(
+            "description" to "Inspection Results contains unmapped problems for the requested scope. $evidence.",
+            "file" to target,
+            "line" to 0,
+            "column" to 0,
+            "severity" to "error",
+            "category" to "Inspection capture",
+            "inspectionType" to "UnmappedInspectionTree",
+            "source" to "unmapped_inspection_tree_fallback",
+            "locationKnown" to false,
+            "locationNote" to "The IDE reported problems, but the plugin could not map the tree rows to exact source locations.",
+        )
+    )
+}
+
 internal fun isSettledCleanInspectionView(observation: InspectionViewObservation): Boolean {
     return observation.updateStateReadable &&
         observation.problemStateReadable &&
@@ -2768,6 +2826,13 @@ class InspectionHandler : HttpRequestHandler() {
                             null
                         }
                         val captureIncompleteReason = classifyCaptureIncompleteReason(captureDiagnostic)
+                        val unmappedFallbackResults = if (
+                            bestResults.isEmpty() && emptyOutcome != InspectionSnapshotOutcome.CLEAN_CONFIRMED
+                        ) {
+                            buildUnmappedInspectionFallbackProblems(project, captureScope, captureDiagnostic)
+                        } else {
+                            emptyList()
+                        }
                         val snapshot = when {
                             bestResults.isNotEmpty() -> InspectionResultsSnapshot(
                                 problems = bestResults,
@@ -2776,6 +2841,18 @@ class InspectionHandler : HttpRequestHandler() {
                                 outcome = InspectionSnapshotOutcome.PROBLEMS_FOUND,
                                 source = bestSource,
                                 captureScope = captureScope,
+                                runId = runId,
+                                triggerTimeMs = inspectionRunStatesByProject[key]?.triggerTimeMs,
+                            )
+                            unmappedFallbackResults.isNotEmpty() -> InspectionResultsSnapshot(
+                                problems = unmappedFallbackResults,
+                                timestamp = System.currentTimeMillis(),
+                                projectState = snapshotState,
+                                outcome = InspectionSnapshotOutcome.PROBLEMS_FOUND,
+                                source = "unmapped_inspection_tree_fallback",
+                                note = emptyNote,
+                                captureScope = captureScope,
+                                captureDiagnostic = captureDiagnostic,
                                 runId = runId,
                                 triggerTimeMs = inspectionRunStatesByProject[key]?.triggerTimeMs,
                             )

--- a/src/test/kotlin/com/shiny/inspectionmcp/EnhancedTreeExtractorTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/EnhancedTreeExtractorTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.DisplayName
 import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.codeInspection.ui.InspectionResultsView
 import com.intellij.codeInspection.ui.InspectionTree
+import com.intellij.codeInspection.ui.ProblemDescriptionNode
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
@@ -23,6 +24,8 @@ import io.mockk.unmockkAll
 import javax.swing.JPanel
 import javax.swing.JTree
 import javax.swing.tree.DefaultMutableTreeNode
+import javax.swing.tree.TreeModel
+import javax.swing.tree.TreeNode
 
 class EnhancedTreeExtractorTest {
     
@@ -222,6 +225,146 @@ class EnhancedTreeExtractorTest {
     }
 
     @Test
+    @DisplayName("Should emit fallback finding for unmapped non-empty inspection tree")
+    fun testUnmappedInspectionTreeProducesFallbackFinding() {
+        val project = mockk<Project>(relaxed = true)
+        val inspectionView = mockk<InspectionResultsView>()
+        val inspectionTree = mockk<InspectionTree>()
+        val root = DefaultMutableTreeNode("Inspection Results")
+        val inspection = DefaultMutableTreeNode("CompilerInspection")
+        val fileGroup = DefaultMutableTreeNode("InspectionRedFixture.java")
+        fileGroup.add(DefaultMutableTreeNode("Cannot resolve symbol definitelyMissingInspectionSymbol"))
+        inspection.add(fileGroup)
+        root.add(inspection)
+        val tree = JTree(root)
+
+        every { inspectionView.tree } returns inspectionTree
+        every { inspectionTree.model } returns tree.model
+
+        val problems = extractor.extractAllProblemsFromInspectionView(inspectionView, project)
+
+        assertEquals(1, problems.size)
+        assertEquals("Cannot resolve symbol definitelyMissingInspectionSymbol", problems[0]["description"])
+        assertTrue((problems[0]["file"] as String).endsWith("InspectionRedFixture.java"))
+        assertEquals(false, problems[0]["locationKnown"])
+        assertEquals(0, problems[0]["line"])
+        assertEquals("CompilerInspection", problems[0]["inspectionType"])
+        assertEquals("inspection_tree_fallback", problems[0]["source"])
+    }
+
+    @Test
+    @DisplayName("Should emit fallback finding for descriptorless problem node")
+    fun testDescriptorlessProblemNodeProducesFallbackFinding() {
+        val project = mockk<Project>(relaxed = true)
+        val inspectionView = mockk<InspectionResultsView>()
+        val inspectionTree = mockk<InspectionTree>()
+        val treeModel = mockk<TreeModel>()
+        val problemNode = mockk<ProblemDescriptionNode>(relaxed = true)
+        every { problemNode.descriptor } returns null
+        every { problemNode.toString() } returns "Cannot resolve symbol MissingType"
+        every { problemNode.parent } returns null
+
+        every { inspectionView.tree } returns inspectionTree
+        every { inspectionTree.model } returns treeModel
+        every { treeModel.root } returns problemNode
+
+        val problems = extractor.extractAllProblemsFromInspectionView(inspectionView, project)
+
+        assertEquals(1, problems.size)
+        assertEquals("Cannot resolve symbol MissingType", problems[0]["description"])
+        assertEquals("UnresolvedReference", problems[0]["inspectionType"])
+        assertEquals("inspection_node_fallback", problems[0]["source"])
+        assertEquals(false, problems[0]["locationKnown"])
+    }
+
+    @Test
+    @DisplayName("Should emit fallback finding for generic non-mutable tree node")
+    fun testGenericTreeNodeProducesFallbackFinding() {
+        val project = mockk<Project>(relaxed = true)
+        every { project.basePath } returns "/tmp/project"
+        val inspectionView = mockk<InspectionResultsView>()
+        val inspectionTree = mockk<InspectionTree>()
+        val treeModel = mockk<TreeModel>()
+        val root = SimpleTreeNode("Inspection Results")
+        val inspection = SimpleTreeNode("CompilerInspection", root)
+        val fileGroup = SimpleTreeNode("src/InspectionRedFixture.java", inspection)
+        val problem = SimpleTreeNode("Cannot resolve symbol definitelyMissingInspectionSymbol", fileGroup)
+        root.children.add(inspection)
+        inspection.children.add(fileGroup)
+        fileGroup.children.add(problem)
+
+        every { inspectionView.tree } returns inspectionTree
+        every { inspectionTree.model } returns treeModel
+        every { treeModel.root } returns root
+
+        val problems = extractor.extractAllProblemsFromInspectionView(inspectionView, project)
+
+        assertEquals(1, problems.size)
+        assertEquals("/tmp/project/src/InspectionRedFixture.java", problems[0]["file"])
+        assertEquals("CompilerInspection", problems[0]["inspectionType"])
+        assertEquals("inspection_tree_fallback", problems[0]["source"])
+    }
+
+    @Test
+    @DisplayName("Should not emit fallback finding for generic empty inspection tree")
+    fun testGenericEmptyInspectionTreeDoesNotProduceFallbackFinding() {
+        val project = mockk<Project>(relaxed = true)
+        val inspectionView = mockk<InspectionResultsView>()
+        val inspectionTree = mockk<InspectionTree>()
+        val root = DefaultMutableTreeNode("Inspection Results")
+        root.add(DefaultMutableTreeNode("empty"))
+        val tree = JTree(root)
+
+        every { inspectionView.tree } returns inspectionTree
+        every { inspectionTree.model } returns tree.model
+
+        val problems = extractor.extractAllProblemsFromInspectionView(inspectionView, project)
+
+        assertTrue(problems.isEmpty())
+    }
+
+    @Test
+    @DisplayName("Should not emit fallback finding for clean keyword-like grouping text")
+    fun testCleanKeywordLikeInspectionTreeDoesNotProduceFallbackFinding() {
+        val project = mockk<Project>(relaxed = true)
+        val inspectionView = mockk<InspectionResultsView>()
+        val inspectionTree = mockk<InspectionTree>()
+        val root = DefaultMutableTreeNode("Inspection Results")
+        val profileGroup = DefaultMutableTreeNode("Inspection profile: Default")
+        profileGroup.add(DefaultMutableTreeNode("Error handling notes"))
+        profileGroup.add(DefaultMutableTreeNode("Warning summary"))
+        root.add(profileGroup)
+        val tree = JTree(root)
+
+        every { inspectionView.tree } returns inspectionTree
+        every { inspectionTree.model } returns tree.model
+
+        val problems = extractor.extractAllProblemsFromInspectionView(inspectionView, project)
+
+        assertTrue(problems.isEmpty())
+    }
+
+    @Test
+    @DisplayName("Should not emit fallback finding for benign leaf under inspection category")
+    fun testBenignLeafUnderInspectionCategoryDoesNotProduceFallbackFinding() {
+        val project = mockk<Project>(relaxed = true)
+        val inspectionView = mockk<InspectionResultsView>()
+        val inspectionTree = mockk<InspectionTree>()
+        val root = DefaultMutableTreeNode("Inspection Results")
+        val inspection = DefaultMutableTreeNode("CompilerInspection")
+        inspection.add(DefaultMutableTreeNode("Generated sources summary"))
+        root.add(inspection)
+        val tree = JTree(root)
+
+        every { inspectionView.tree } returns inspectionTree
+        every { inspectionTree.model } returns tree.model
+
+        val problems = extractor.extractAllProblemsFromInspectionView(inspectionView, project)
+
+        assertTrue(problems.isEmpty())
+    }
+
+    @Test
     @DisplayName("Should dedupe repeated problem maps from inspection view snapshots")
     fun testDedupeProblems() {
         val repeatedProblem = mapOf<String, Any>(
@@ -298,5 +441,21 @@ class EnhancedTreeExtractorTest {
         fun getSeverity(): String = "WARNING"
         fun getCategory(): String = "General"
         fun getInspectionToolId(): String = "FallbackInspection"
+    }
+
+    private class SimpleTreeNode(
+        private val label: String,
+        private val parentNode: TreeNode? = null,
+    ) : TreeNode {
+        val children = mutableListOf<TreeNode>()
+
+        override fun getChildAt(childIndex: Int): TreeNode = children[childIndex]
+        override fun getChildCount(): Int = children.size
+        override fun getParent(): TreeNode? = parentNode
+        override fun getIndex(node: TreeNode?): Int = children.indexOf(node)
+        override fun getAllowsChildren(): Boolean = true
+        override fun isLeaf(): Boolean = children.isEmpty()
+        override fun children(): java.util.Enumeration<out TreeNode> = java.util.Collections.enumeration(children)
+        override fun toString(): String = label
     }
 }

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
@@ -1301,6 +1301,102 @@ class InspectionSnapshotStateTest {
     }
 
     @Test
+    @DisplayName("Non-empty unmapped inspection tree becomes a scoped fallback finding")
+    fun testUnmappedInspectionFallbackFindingForSingleFileScope() {
+        val problems = buildUnmappedInspectionFallbackProblems(
+            project = mockProject,
+            captureScope = InspectionCaptureScope(
+                scopeParam = "files",
+                files = listOf("src/main/java/RedFixture.java"),
+            ),
+            diagnostic = mapOf(
+                "observed_non_empty_inspection_tree" to true,
+                "model_problem_descriptor_count" to 0,
+                "last_view_observation" to mapOf("root_child_count" to 1),
+            ),
+        )
+
+        assertEquals(1, problems.size)
+        val problem = problems.single()
+        assertEquals("/tmp/TestProject/src/main/java/RedFixture.java", problem["file"])
+        assertEquals("error", problem["severity"])
+        assertEquals("UnmappedInspectionTree", problem["inspectionType"])
+        assertEquals("unmapped_inspection_tree_fallback", problem["source"])
+        assertEquals(false, problem["locationKnown"])
+        assertTrue((problem["description"] as String).contains("non-empty problem tree"))
+    }
+
+    @Test
+    @DisplayName("Clean or empty evidence does not create fallback findings")
+    fun testUnmappedInspectionFallbackRequiresRedEvidence() {
+        val problems = buildUnmappedInspectionFallbackProblems(
+            project = mockProject,
+            captureScope = InspectionCaptureScope(
+                scopeParam = "files",
+                files = listOf("src/main/java/CleanFixture.java"),
+            ),
+            diagnostic = mapOf(
+                "observed_non_empty_inspection_tree" to false,
+                "model_problem_descriptor_count" to 0,
+            ),
+        )
+
+        assertEquals(emptyList<Map<String, Any>>(), problems)
+    }
+
+    @Test
+    @DisplayName("Descriptor-only unmapped evidence becomes a fallback finding")
+    fun testUnmappedInspectionFallbackFindingForDescriptorEvidence() {
+        val problems = buildUnmappedInspectionFallbackProblems(
+            project = mockProject,
+            captureScope = InspectionCaptureScope(scopeParam = "whole_project"),
+            diagnostic = mapOf(
+                "observed_non_empty_inspection_tree" to false,
+                "model_problem_descriptor_count" to 2,
+            ),
+        )
+
+        assertEquals(1, problems.size)
+        assertEquals("/tmp/TestProject", problems.single()["file"])
+        assertTrue((problems.single()["description"] as String).contains("2 descriptor(s)"))
+    }
+
+    @Test
+    @DisplayName("Whole-project non-empty tree evidence becomes a fallback finding")
+    fun testUnmappedInspectionFallbackFindingForWholeProjectTreeEvidence() {
+        val problems = buildUnmappedInspectionFallbackProblems(
+            project = mockProject,
+            captureScope = InspectionCaptureScope(scopeParam = "whole_project"),
+            diagnostic = mapOf(
+                "observed_non_empty_inspection_tree" to true,
+                "model_problem_descriptor_count" to 0,
+                "last_view_observation" to mapOf("root_child_count" to 2),
+            ),
+        )
+
+        assertEquals(1, problems.size)
+        assertEquals("/tmp/TestProject", problems.single()["file"])
+        assertTrue((problems.single()["description"] as String).contains("non-empty problem tree"))
+    }
+
+    @Test
+    @DisplayName("Unmapped fallback remains actionable when project base path is unavailable")
+    fun testUnmappedInspectionFallbackWithoutProjectBasePath() {
+        val projectWithoutBasePath = mockk<Project>()
+        every { projectWithoutBasePath.basePath } returns null
+
+        val problems = buildUnmappedInspectionFallbackProblems(
+            project = projectWithoutBasePath,
+            captureScope = InspectionCaptureScope(scopeParam = "whole_project"),
+            diagnostic = mapOf("observed_non_empty_inspection_tree" to true),
+        )
+
+        assertEquals(1, problems.size)
+        assertEquals("unknown", problems.single()["file"])
+        assertEquals(false, problems.single()["locationKnown"])
+    }
+
+    @Test
     @DisplayName("Transient updating unreadable empty views provide guarded clean evidence")
     fun testTransientUpdatingUnreadableEmptyViewEvidence() {
         val transientUpdatingUnreadableEmpty = InspectionViewObservation(


### PR DESCRIPTION
## Summary
- surface fallback findings when the IDE proves an inspection tree is non-empty but rows cannot be mapped to exact source locations
- add descriptorless and generic tree fallback extraction with tighter leaf-text gating to avoid clean-tree false positives
- document in the repo-local workflow skill that red-lane proof requires actionable findings, not zero-problem inconclusive states

## Proof / validation
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test`
- commit hook reran plugin/core/MCP/buildPlugin gates successfully
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew buildPlugin`
- installed rebuilt plugin into IntelliJ IDEA 2026.1 and restarted on exact worktree `/Users/cbusillo/.code/worktrees/jetbrains-inspection-api/fix-red-lane-findings`
- red smoke through `jb-inspect.py run --repo "$PWD" --port 63343 --ide "IntelliJ IDEA" --no-open --scope files --file inspection-core/src/main/kotlin/com/shiny/inspectionmcp/core/InspectionRedFixture.java`: `status=findings`, `clean=false`, `total_problems=1`, `source=unmapped_inspection_tree_fallback`, `observed_non_empty_inspection_tree=true`, `root_child_count=1`
- green smoke through `jb-inspect.py run --repo "$PWD" --port 63343 --ide "IntelliJ IDEA" --no-open --scope files --file inspection-core/src/main/kotlin/com/shiny/inspectionmcp/core/FilePattern.kt`: `status=clean`, `clean=true`, `total_problems=0`, `observed_non_empty_inspection_tree=false`, `root_child_count=0`
- final read-only agent review found no blockers after heuristic tightening

## Notes
The temporary red fixture used for live smoke was removed before commit.
