### PR TITLE
Add explicit inspection verdict contract

### DIFF
--- a/.code/skills/jetbrains-inspection-workflow/SKILL.md
+++ b/.code/skills/jetbrains-inspection-workflow/SKILL.md
@@ -81,10 +81,15 @@ Keep exact command matrices, environment setup, and troubleshooting in
 6. For clean/capture classification, preserve non-clean outcomes for
    `capture_incomplete`, stale results, timeouts, indexing, session drift,
    route ambiguity, wrong-worktree routes, and cleanup failures.
-7. For red-lane smoke tests, require at least one current actionable finding in
-   the helper response, such as `total_problems > 0` with a non-empty
-   `problems` list. `capture_incomplete`, `non_empty_unmapped_tree`, or a
+7. For red-lane smoke tests, require current actionable findings in the helper
+   response, such as `total_problems > 0`; a paginated current page may have an
+   empty `problems` list even when matching findings exist. `capture_incomplete`, `non_empty_unmapped_tree`, or a
    non-clean zero-problem response proves only that clean was not confirmed.
+8. Agent-facing inspection reports should use the helper verdict: `GREEN` means
+   inspection worked and found no actionable findings for the selected
+   scope/filter, `RED` means inspection worked and found actionable current
+   problems, and `UNKNOWN` means the IDE/plugin/helper did not prove either
+   state and the next action must be reported.
 
 ## IDE Smoke Testing
 

--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ The status endpoint includes a `clean_inspection` field that makes the outcome e
 - `results_may_be_stale: true` → Project changed after the last inspection; trigger again before trusting results
 - `snapshot_change_kind: "current_run_psi_churn"` → The latest run's snapshot saw a PSI modification-count tick after capture; the plugin keeps waiting instead of treating the snapshot as stale cached data.
 - `capture_incomplete_reason: "..."` → The subsystem bucket behind an inconclusive capture. IDE-state/retry buckets are `view_not_ready`, `view_updating_unreadable`, `unreadable_tree`, `current_run_psi_churn`, and `timeout`; plugin/helper investigation buckets are `extractor_failure`, `non_empty_unmapped_tree`, `helper_plugin_error`, and `unknown`.
-- `clean_inspection: true` → Inspection complete. No problems found
+- `clean_inspection: true` → Inspection complete; `inspection_verdict` is `GREEN` for the selected scope/filter
 - `has_inspection_results: true` → Problems found, retrieve with `/problems`
 - If all three are false and `time_since_last_trigger_ms` is recent, the inspection finished but results were not captured. Re-run the inspection or open the Inspection Results tool window.
 - If all three are false and `time_since_last_trigger_ms` is old, there was no recent inspection. Trigger one first.
@@ -494,11 +494,22 @@ The status endpoint includes a `clean_inspection` field that makes the outcome e
 Common completion reasons:
 - `results`: inspection completed and problems are ready to fetch.
 - `clean`: inspection completed and a clean empty result was confirmed.
-- `no_results`: inspection finished, but no results were captured. This can be a clean run or an unavailable/filtered IDE view.
+- `no_results`: inspection finished, but no trustworthy result was captured. Treat this as `UNKNOWN`, not clean; rerun inspection or open the Inspection Results view for the exact worktree.
 - `capture_incomplete`: inspection finished, but the plugin could not conclusively capture the IDE results. The response includes `capture_incomplete_reason` when a bucket can be assigned; re-run the inspection or open the Problems/Inspection Results view.
 - `stale_results`: cached results exist, but project files changed after the last inspection. Trigger again before trusting findings. Wait responses expose cached counts as `cached_total_problems`, not `total_problems`.
 - `no_recent_inspection`: no inspection run is known for the selected project. Trigger one first.
 - `no_project`: no matching project was open during the wait period. This is not reported as `timed_out`; open a project or pass the exact project name.
+
+For agent-facing reports, use `inspection_verdict` and the companion
+`inspection_verdict_reason`, `inspection_verdict_message`, and
+`inspection_verdict_next_action` fields. The verdict is `GREEN` when inspection
+worked and found no actionable findings for the selected scope/filter, `RED`
+when inspection worked and returned actionable current findings, and `UNKNOWN`
+when the IDE/plugin/helper did not produce a trustworthy result.
+`UNKNOWN` is not clean and not red; report the included diagnostic reason and
+next action, such as opening the exact worktree in the IDE, waiting for
+indexing, rerunning stale results, or updating the plugin/helper when capture
+evidence points to an extractor or helper bug.
 
 ### Freshness Notes
 - The plugin saves documents and refreshes external file changes before starting a new inspection run.

--- a/TESTING.md
+++ b/TESTING.md
@@ -92,7 +92,12 @@ non-clean outcomes. Cached stale findings are returned only when the helper is
 run with `--include-stale` for explicit diagnostics. `capture_incomplete`
 responses expose `capture_incomplete_reason` plus `capture_diagnostic`; use the
 reason bucket for triage and the diagnostic payload for counters and state
-evidence. When this repo changes
+evidence. Agent-facing reports should use the helper verdict: `GREEN` means the
+inspection worked and found no actionable findings for the selected
+scope/filter, `RED` means the inspection worked and returned actionable
+findings, and `UNKNOWN` means the tooling did not prove either state and must
+include the helper's next action.
+When this repo changes
 inspection status semantics, route metadata, clean/capture classification,
 lifecycle cleanup contracts, or MCP tool response contracts, update the skill
 docs/tests/scripts in the `jetbrains-inspection` skill as part of the same

--- a/mcp-server-jvm/src/main/kotlin/com/shiny/inspectionmcp/mcpserver/Main.kt
+++ b/mcp-server-jvm/src/main/kotlin/com/shiny/inspectionmcp/mcpserver/Main.kt
@@ -472,15 +472,45 @@ internal class ToolExecutor(
         val hasMore = pagination?.get("has_more")?.jsonPrimitive?.booleanOrNull == true
         val nextOffset = pagination?.get("next_offset")?.jsonPrimitive?.intOrNull
 
-        val guidance = when {
+        val guidance = inspectionVerdictGuidance(
+            obj,
+            when {
+                status == "stale_results" -> McpInspectionVerdict(
+                    "UNKNOWN",
+                    "stale_results",
+                    "Cached inspection results are stale because the project changed after the last run.",
+                    "Trigger inspection again before trusting cached results. Pass include_stale=true only for explicit cached-result diagnostics.",
+                )
+                status == "capture_incomplete" -> unknownCaptureVerdict(captureReason)
+                status == "no_results" -> McpInspectionVerdict(
+                    "UNKNOWN",
+                    "no_results",
+                    "No trustworthy inspection result was captured.",
+                    "Trigger and wait for a fresh inspection, or open the Inspection Results view for the exact worktree before treating the result as clean.",
+                )
+                total != null && total > 0 -> McpInspectionVerdict(
+                    "RED",
+                    "actionable_findings",
+                    "Inspection worked and returned actionable findings. Found $total problems total, showing ${shown ?: total}.",
+                    "Fix the reported findings, then rerun inspection.",
+                )
+                total == 0 -> McpInspectionVerdict(
+                    "GREEN",
+                    "no_matching_findings",
+                    "Inspection worked and found no actionable findings for the selected scope/filter.",
+                    "No inspection action required for this scope/filter.",
+                )
+                else -> null
+            },
+        ) ?: when {
             status == "stale_results" ->
                 "\n\nWARN: Cached inspection results are stale because the project changed after the last run. Trigger a new inspection before trusting these findings. Pass include_stale=true only for explicit cached-result diagnostics."
             status == "capture_incomplete" ->
                 captureIncompleteGuidance("WARN", captureReason)
             status == "no_results" ->
-                "\n\nWARN: No inspection results were captured. This can happen for clean runs or when the IDE results view was unavailable; re-run inspection if findings were expected."
+                "\n\nWARN: No trustworthy inspection result was captured. Trigger and wait for a fresh inspection before treating this as clean."
             total == 0 ->
-                "\n\nOK: No problems found matching filters."
+                "\n\nVERDICT: GREEN reason=no_matching_findings\nMESSAGE: Inspection worked and found no actionable findings for the selected scope/filter."
             total != null ->
                 "\n\nINFO: Found $total problems total, showing ${shown ?: total}."
             else -> ""
@@ -504,11 +534,52 @@ internal class ToolExecutor(
 
         val timeSince = obj["time_since_last_trigger_ms"]?.jsonPrimitive?.longOrNull
 
-        return when {
+        return inspectionVerdictGuidance(
+            obj,
+            when {
+                isScanning -> McpInspectionVerdict(
+                    "UNKNOWN",
+                    "inspection_still_running",
+                    "Inspection is still running.",
+                    "Wait before getting problems.",
+                )
+                stale -> McpInspectionVerdict(
+                    "UNKNOWN",
+                    "stale_results",
+                    "Project changed after the last inspection.",
+                    "Trigger inspection again before trusting cached results.",
+                )
+                captureIncomplete -> unknownCaptureVerdict(captureReason)
+                clean -> McpInspectionVerdict(
+                    "GREEN",
+                    "clean_confirmed",
+                    "Inspection complete and no actionable findings were found.",
+                    "No inspection action required for this scope/filter.",
+                )
+                hasResults -> McpInspectionVerdict(
+                    "UNKNOWN",
+                    "results_available_without_findings",
+                    "Inspection status says results are available, but this status response did not include actionable findings.",
+                    "Call inspection_get_problems and use its verdict before reporting GREEN or RED.",
+                )
+                timeSince != null && timeSince < 60000 -> McpInspectionVerdict(
+                    "UNKNOWN",
+                    "no_results",
+                    "Inspection finished but no trustworthy result was captured yet.",
+                    "Retry once, preferably with a narrower scope, before treating this as clean.",
+                )
+                else -> McpInspectionVerdict(
+                    "UNKNOWN",
+                    "no_recent_inspection",
+                    "No recent inspection result is available.",
+                    "Trigger inspection first.",
+                )
+            },
+        ) ?: when {
             isScanning -> "\n\nSTATUS: Inspection still running - wait before getting problems."
             stale -> "\n\nSTATUS: Project changed after the last inspection - trigger inspection again before trusting cached results."
             captureIncomplete -> captureIncompleteGuidance("STATUS", captureReason)
-            clean -> "\n\nSTATUS: Inspection complete - codebase is clean (no problems found)."
+            clean -> "\n\nSTATUS: Inspection complete - codebase is clean."
             hasResults -> "\n\nSTATUS: Inspection complete - problems found, ready to retrieve."
             timeSince != null && timeSince < 60000 ->
                 "\n\nSTATUS: Inspection finished but no results were captured yet. Retry once, preferably with a narrower scope, before treating this as clean."
@@ -523,7 +594,61 @@ internal class ToolExecutor(
         val reason = obj["completion_reason"]?.jsonPrimitive?.contentOrNull
         val captureReason = obj["capture_incomplete_reason"]?.jsonPrimitive?.contentOrNull
 
-        return when {
+        return inspectionVerdictGuidance(
+            obj,
+            when {
+                completed && reason == "clean" -> McpInspectionVerdict(
+                    "GREEN",
+                    "clean_confirmed",
+                    "Inspection complete and no actionable findings were found.",
+                    "No inspection action required for this scope/filter.",
+                )
+                completed && reason == "results" -> McpInspectionVerdict(
+                    "RED",
+                    "actionable_findings",
+                    "Inspection complete and problems are ready to retrieve.",
+                    "Call inspection_get_problems, fix the reported findings, then rerun inspection.",
+                )
+                completed && reason == "capture_incomplete" -> unknownCaptureVerdict(captureReason)
+                completed && reason == "stale_results" -> McpInspectionVerdict(
+                    "UNKNOWN",
+                    "stale_results",
+                    "Cached inspection results are stale.",
+                    "Trigger inspection again before trusting findings.",
+                )
+                completed && reason == "no_results" -> McpInspectionVerdict(
+                    "UNKNOWN",
+                    "no_results",
+                    "Inspection finished with no trustworthy captured result.",
+                    "Retry once with a narrower scope before treating this as clean.",
+                )
+                reason == "no_recent_inspection" -> McpInspectionVerdict(
+                    "UNKNOWN",
+                    "no_recent_inspection",
+                    "No recent inspection result is available.",
+                    "Trigger inspection first.",
+                )
+                reason == "no_project" -> McpInspectionVerdict(
+                    "UNKNOWN",
+                    "no_project",
+                    "No project was found.",
+                    "Ensure the IDE has an open project, or pass the exact project name.",
+                )
+                reason == "interrupted" -> McpInspectionVerdict(
+                    "UNKNOWN",
+                    "interrupted",
+                    "Inspection wait was interrupted.",
+                    "Try again.",
+                )
+                timedOut -> McpInspectionVerdict(
+                    "UNKNOWN",
+                    "timeout",
+                    "Inspection wait timed out.",
+                    "Try inspection_get_status or increase timeout_ms.",
+                )
+                else -> null
+            },
+        ) ?: when {
             completed && reason == "clean" -> "\n\nSTATUS: Inspection complete - codebase is clean."
             completed && reason == "results" -> "\n\nSTATUS: Inspection complete - problems found."
             completed && reason == "capture_incomplete" ->
@@ -531,7 +656,7 @@ internal class ToolExecutor(
             completed && reason == "stale_results" ->
                 "\n\nSTATUS: Cached inspection results are stale - trigger inspection again before trusting findings."
             completed && reason == "no_results" ->
-                "\n\nSTATUS: Inspection finished with no captured results. This can be clean; retry once with a narrower scope if findings were expected."
+                "\n\nSTATUS: Inspection finished with no trustworthy captured result. Retry once with a narrower scope before treating this as clean."
             reason == "no_recent_inspection" -> "\n\nSTATUS: No recent inspection - trigger inspection first."
             reason == "no_project" -> "\n\nSTATUS: No project found - ensure the IDE has an open project, or pass the exact project name."
             reason == "interrupted" -> "\n\nSTATUS: Wait interrupted - try again."
@@ -543,6 +668,132 @@ internal class ToolExecutor(
     private fun captureIncompleteGuidance(prefix: String, reason: String?): String {
         val reasonText = if (reason.isNullOrBlank()) "" else " reason=$reason."
         return "\n\n$prefix: capture_incomplete$reasonText do not treat as clean. Retry once, preferably with a narrower scope; if it repeats, report the reason and capture_diagnostic."
+    }
+
+    private data class McpInspectionVerdict(
+        val verdict: String,
+        val reason: String,
+        val message: String,
+        val nextAction: String,
+    )
+
+    private fun inspectionVerdictGuidance(obj: JsonObject, fallback: McpInspectionVerdict?): String? {
+        val blockerVerdict = blockerVerdict(obj)
+        val pluginVerdict = obj["inspection_verdict"]?.jsonPrimitive?.contentOrNull
+            ?.takeIf { it == "GREEN" || it == "RED" || it == "UNKNOWN" }
+            ?.let { verdict ->
+                McpInspectionVerdict(
+                    verdict = verdict,
+                    reason = obj["inspection_verdict_reason"]?.jsonPrimitive?.contentOrNull ?: "plugin_verdict",
+                    message = obj["inspection_verdict_message"]?.jsonPrimitive?.contentOrNull
+                        ?: "Inspection plugin provided the verdict.",
+                    nextAction = obj["inspection_verdict_next_action"]?.jsonPrimitive?.contentOrNull
+                        ?: "Follow the inspection plugin verdict.",
+                )
+            }
+
+        val verdict = blockerVerdict ?: pluginVerdict ?: fallback ?: return null
+        return "\n\nVERDICT: ${verdict.verdict} reason=${verdict.reason}" +
+            "\nMESSAGE: ${verdict.message}" +
+            "\nNEXT_ACTION: ${verdict.nextAction}"
+    }
+
+    private fun blockerVerdict(obj: JsonObject): McpInspectionVerdict? {
+        val status = obj["status"]?.jsonPrimitive?.contentOrNull
+        val completionReason = obj["completion_reason"]?.jsonPrimitive?.contentOrNull
+        val captureReason = obj["capture_incomplete_reason"]?.jsonPrimitive?.contentOrNull
+        return when {
+            obj["session_drift"]?.jsonPrimitive?.booleanOrNull == true -> McpInspectionVerdict(
+                "UNKNOWN",
+                "session_drift",
+                "The IDE/plugin session changed before inspection could be trusted.",
+                "Resolve the route again and rerun inspection.",
+            )
+            obj["ambiguous"]?.jsonPrimitive?.booleanOrNull == true -> McpInspectionVerdict(
+                "UNKNOWN",
+                "ambiguous_route",
+                "The inspection route is ambiguous.",
+                "Pass project_key, project_path, or worktree_path so the exact project is inspected.",
+            )
+            obj["unavailable"]?.jsonPrimitive?.booleanOrNull == true -> McpInspectionVerdict(
+                "UNKNOWN",
+                "inspection_api_unavailable",
+                "The inspection API is unavailable.",
+                "Open the exact worktree in the configured JetBrains IDE with the inspection plugin installed.",
+            )
+            obj["results_may_be_stale"]?.jsonPrimitive?.booleanOrNull == true || status == "stale_results" || completionReason == "stale_results" ->
+                McpInspectionVerdict(
+                    "UNKNOWN",
+                    "stale_results",
+                    "Cached inspection results are stale because the project changed after the last run.",
+                    "Trigger inspection again before trusting cached results. Pass include_stale=true only for explicit cached-result diagnostics.",
+                )
+            obj["capture_incomplete"]?.jsonPrimitive?.booleanOrNull == true || status == "capture_incomplete" || completionReason == "capture_incomplete" ->
+                unknownCaptureVerdict(captureReason)
+            obj["timed_out"]?.jsonPrimitive?.booleanOrNull == true || completionReason == "timeout" -> McpInspectionVerdict(
+                "UNKNOWN",
+                "timeout",
+                "Inspection wait timed out.",
+                "Try inspection_get_status or increase timeout_ms.",
+            )
+            obj["indexing"]?.jsonPrimitive?.booleanOrNull == true ||
+                obj["is_scanning"]?.jsonPrimitive?.booleanOrNull == true ||
+                obj["inspection_in_progress"]?.jsonPrimitive?.booleanOrNull == true ||
+                status == "indexing" ||
+                status == "running" -> McpInspectionVerdict(
+                    "UNKNOWN",
+                    "inspection_still_running",
+                    "Inspection is still running.",
+                    "Wait before getting problems.",
+                )
+            status == "no_results" || completionReason == "no_results" -> McpInspectionVerdict(
+                "UNKNOWN",
+                "no_results",
+                "Inspection finished with no trustworthy captured result.",
+                "Retry once with a narrower scope before treating this as clean.",
+            )
+            status == "no_project" || completionReason == "no_project" -> McpInspectionVerdict(
+                "UNKNOWN",
+                "no_project",
+                "No project was found.",
+                "Ensure the IDE has an open project, or pass the exact project name.",
+            )
+            status == "no_recent_inspection" || completionReason == "no_recent_inspection" -> McpInspectionVerdict(
+                "UNKNOWN",
+                "no_recent_inspection",
+                "No recent inspection result is available.",
+                "Trigger inspection first.",
+            )
+            completionReason == "interrupted" -> McpInspectionVerdict(
+                "UNKNOWN",
+                "interrupted",
+                "Inspection wait was interrupted.",
+                "Try again.",
+            )
+            else -> null
+        }
+    }
+
+    private fun unknownCaptureVerdict(reason: String?): McpInspectionVerdict {
+        val safeReason = reason?.takeIf { it.isNotBlank() } ?: "capture_incomplete"
+        val nextAction = when (safeReason) {
+            "non_empty_unmapped_tree", "extractor_failure", "helper_plugin_error" ->
+                "Treat this as a plugin/helper bug: capture the diagnostic payload, update the inspection plugin or helper skill, and rerun."
+            "view_not_ready", "view_updating_unreadable", "unreadable_tree", "no_results" ->
+                "Open the IDE Inspection Results or Problems view for the exact worktree, then rerun inspection."
+            "current_run_psi_churn" ->
+                "Save documents and rerun inspection after the IDE finishes updating PSI state."
+            "timeout" ->
+                "Wait for indexing/scanning to settle or rerun with a larger timeout."
+            else ->
+                "Retry once, preferably with a narrower scope; if it repeats, report the reason and capture_diagnostic."
+        }
+        return McpInspectionVerdict(
+            "UNKNOWN",
+            safeReason,
+            "Inspection finished, but the plugin could not conclusively capture IDE results.",
+            nextAction,
+        )
     }
 
     private fun toolText(text: String, isError: Boolean = false): JsonObject {

--- a/mcp-server-jvm/src/test/kotlin/com/shiny/inspectionmcp/mcpserver/McpServerTest.kt
+++ b/mcp-server-jvm/src/test/kotlin/com/shiny/inspectionmcp/mcpserver/McpServerTest.kt
@@ -166,7 +166,8 @@ class McpServerTest {
             val response = executor.handleToolCall(buildToolCall("inspection_get_problems", args))
             val text = response.firstText()
             assertTrue(text.contains("\"total_problems\": 2"))
-            assertTrue(text.contains("INFO: Found 2 problems total"))
+            assertTrue(text.contains("VERDICT: RED"))
+            assertTrue(text.contains("Found 2 problems total"))
             val query = server.lastQuery.get() ?: ""
             assertTrue(query.contains("file_pattern=my+file.js"))
             assertTrue(query.contains("limit=10"))
@@ -187,7 +188,8 @@ class McpServerTest {
 
             val result = executor.handleToolCall(buildToolCall("inspection_get_problems", args))
             val text = result.firstText()
-            assertTrue(text.contains("INFO: Found 5 problems total"))
+            assertTrue(text.contains("VERDICT: RED"))
+            assertTrue(text.contains("Found 5 problems total"))
             assertTrue(text.contains("NEXT: More results available"))
             val query = server.lastQuery.get() ?: ""
             assertTrue(query.contains("offset=2"))
@@ -204,8 +206,9 @@ class McpServerTest {
 
             val result = executor.handleToolCall(buildToolCall("inspection_get_problems", buildJsonObject { }))
             val text = result.firstText()
-            assertTrue(text.contains("No inspection results were captured"))
-            assertTrue(text.contains("clean runs"))
+            assertTrue(text.contains("VERDICT: UNKNOWN"))
+            assertTrue(text.contains("reason=no_results"))
+            assertFalse(text.contains("clean runs"))
         }
     }
 
@@ -241,8 +244,8 @@ class McpServerTest {
 
             val result = executor.handleToolCall(buildToolCall("inspection_get_problems", buildJsonObject { }))
             val text = result.firstText()
-            assertTrue(text.contains("do not treat as clean"))
-            assertTrue(text.contains("Retry once"))
+            assertTrue(text.contains("VERDICT: UNKNOWN"))
+            assertTrue(text.contains("NEXT_ACTION"))
             assertTrue(text.contains("reason=extractor_failure"))
             assertTrue(text.contains("capture_diagnostic"))
             assertFalse(text.contains("OK: No problems found matching filters"))
@@ -258,9 +261,26 @@ class McpServerTest {
 
             val result = executor.handleToolCall(buildToolCall("inspection_get_problems", buildJsonObject { }))
             val text = result.firstText()
+            assertTrue(text.contains("VERDICT: UNKNOWN"))
+            assertTrue(text.contains("reason=stale_results"))
             assertTrue(text.contains("results are stale"))
             assertTrue(text.contains("include_stale=true"))
             assertTrue(text.contains("explicit cached-result diagnostics"))
+        }
+    }
+
+    @Test
+    fun inspectionGetProblemsBlockerOverridesPluginRedVerdict() {
+        val response = """{"status":"stale_results","results_may_be_stale":true,"inspection_verdict":"RED","inspection_verdict_reason":"actionable_findings","total_problems":5,"problems":[]}"""
+        MockIdeServer(mapOf("/api/inspection/problems" to MockResponse(response))).use { server ->
+            server.start()
+            val executor = ToolExecutor(server.baseUrl, HttpClient.newHttpClient(), server.port.toString())
+
+            val result = executor.handleToolCall(buildToolCall("inspection_get_problems", buildJsonObject { }))
+            val text = result.firstText()
+            assertTrue(text.contains("VERDICT: UNKNOWN"))
+            assertTrue(text.contains("reason=stale_results"))
+            assertFalse(text.contains("VERDICT: RED"))
         }
     }
 
@@ -272,7 +292,10 @@ class McpServerTest {
             val executor = ToolExecutor(server.baseUrl, HttpClient.newHttpClient(), server.port.toString())
 
             val result = executor.handleToolCall(buildToolCall("inspection_get_problems", buildJsonObject { }))
-            assertTrue(result.firstText().contains("No problems found"))
+            val text = result.firstText()
+            assertTrue(text.contains("VERDICT: GREEN"))
+            assertTrue(text.contains("reason=no_matching_findings"))
+            assertFalse(text.contains("No problems found"))
         }
     }
 
@@ -370,7 +393,8 @@ class McpServerTest {
             val response = executor.handleToolCall(buildToolCall("inspection_get_status", buildJsonObject { }))
             val text = response.firstText()
             assertTrue(text.contains("\"has_inspection_results\": true"))
-            assertTrue(text.contains("STATUS: Inspection complete"))
+            assertTrue(text.contains("VERDICT: UNKNOWN"))
+            assertTrue(text.contains("reason=results_available_without_findings"))
         }
     }
 
@@ -407,6 +431,21 @@ class McpServerTest {
     }
 
     @Test
+    fun inspectionGetStatusBlockerOverridesPluginGreenVerdict() {
+        val response = """{"is_scanning":true,"inspection_in_progress":true,"inspection_verdict":"GREEN","inspection_verdict_reason":"clean_confirmed","clean_inspection":true}"""
+        MockIdeServer(mapOf("/api/inspection/status" to MockResponse(response))).use { server ->
+            server.start()
+            val executor = ToolExecutor(server.baseUrl, HttpClient.newHttpClient(), server.port.toString())
+
+            val result = executor.handleToolCall(buildToolCall("inspection_get_status", buildJsonObject { }))
+            val text = result.firstText()
+            assertTrue(text.contains("VERDICT: UNKNOWN"))
+            assertTrue(text.contains("reason=inspection_still_running"))
+            assertFalse(text.contains("VERDICT: GREEN"))
+        }
+    }
+
+    @Test
     fun inspectionGetStatusHandlesCleanInspection() {
         val response = """{"clean_inspection":true}"""
         MockIdeServer(mapOf("/api/inspection/status" to MockResponse(response))).use { server ->
@@ -414,7 +453,9 @@ class McpServerTest {
             val executor = ToolExecutor(server.baseUrl, HttpClient.newHttpClient(), server.port.toString())
 
             val result = executor.handleToolCall(buildToolCall("inspection_get_status", buildJsonObject { }))
-            assertTrue(result.firstText().contains("codebase is clean"))
+            val text = result.firstText()
+            assertTrue(text.contains("VERDICT: GREEN"))
+            assertTrue(text.contains("reason=clean_confirmed"))
         }
     }
 
@@ -426,7 +467,10 @@ class McpServerTest {
             val executor = ToolExecutor(server.baseUrl, HttpClient.newHttpClient(), server.port.toString())
 
             val result = executor.handleToolCall(buildToolCall("inspection_get_status", buildJsonObject { }))
-            assertTrue(result.firstText().contains("trigger inspection again"))
+            val text = result.firstText()
+            assertTrue(text.contains("VERDICT: UNKNOWN"))
+            assertTrue(text.contains("reason=stale_results"))
+            assertTrue(text.contains("Trigger inspection again"))
         }
     }
 
@@ -439,8 +483,8 @@ class McpServerTest {
 
             val result = executor.handleToolCall(buildToolCall("inspection_get_status", buildJsonObject { }))
             val text = result.firstText()
-            assertTrue(text.contains("do not treat as clean"))
-            assertTrue(text.contains("Retry once"))
+            assertTrue(text.contains("VERDICT: UNKNOWN"))
+            assertTrue(text.contains("NEXT_ACTION"))
             assertTrue(text.contains("reason=view_not_ready"))
             assertFalse(text.contains("codebase is clean"))
         }
@@ -454,7 +498,9 @@ class McpServerTest {
             val executor = ToolExecutor(server.baseUrl, HttpClient.newHttpClient(), server.port.toString())
 
             val result = executor.handleToolCall(buildToolCall("inspection_get_status", buildJsonObject { }))
-            assertTrue(result.firstText().contains("No recent inspection"))
+            val text = result.firstText()
+            assertTrue(text.contains("VERDICT: UNKNOWN"))
+            assertTrue(text.contains("reason=no_recent_inspection"))
         }
     }
 
@@ -466,7 +512,9 @@ class McpServerTest {
             val executor = ToolExecutor(server.baseUrl, HttpClient.newHttpClient(), server.port.toString())
 
             val result = executor.handleToolCall(buildToolCall("inspection_get_status", buildJsonObject { }))
-            assertTrue(result.firstText().contains("no results were captured"))
+            val text = result.firstText()
+            assertTrue(text.contains("VERDICT: UNKNOWN"))
+            assertTrue(text.contains("reason=no_results"))
         }
     }
 
@@ -479,7 +527,8 @@ class McpServerTest {
 
             val result = executor.handleToolCall(buildToolCall("inspection_get_status", buildJsonObject { }))
             val text = result.firstText()
-            assertTrue(text.contains("codebase is clean"))
+            assertTrue(text.contains("VERDICT: GREEN"))
+            assertTrue(text.contains("reason=clean_confirmed"))
             assertFalse(text.contains("STATUS: Inspection complete - problems found"))
         }
     }
@@ -543,8 +592,10 @@ class McpServerTest {
             val executor = ToolExecutor(server.baseUrl, HttpClient.newHttpClient(), server.port.toString())
 
             val result = executor.handleToolCall(buildToolCall("inspection_wait", buildJsonObject { }))
-            assertTrue(result.firstText().contains("No project found"))
-            assertTrue(result.firstText().contains("exact project name"))
+            val text = result.firstText()
+            assertTrue(text.contains("VERDICT: UNKNOWN"))
+            assertTrue(text.contains("reason=no_project"))
+            assertTrue(text.contains("exact project name"))
         }
     }
 
@@ -556,7 +607,9 @@ class McpServerTest {
             val executor = ToolExecutor(server.baseUrl, HttpClient.newHttpClient(), server.port.toString())
 
             val result = executor.handleToolCall(buildToolCall("inspection_wait", buildJsonObject { }))
-            assertTrue(result.firstText().contains("Wait interrupted"))
+            val text = result.firstText()
+            assertTrue(text.contains("VERDICT: UNKNOWN"))
+            assertTrue(text.contains("reason=interrupted"))
         }
     }
 
@@ -568,7 +621,24 @@ class McpServerTest {
             val executor = ToolExecutor(server.baseUrl, HttpClient.newHttpClient(), server.port.toString())
 
             val result = executor.handleToolCall(buildToolCall("inspection_wait", buildJsonObject { }))
-            assertTrue(result.firstText().contains("Wait timed out"))
+            val text = result.firstText()
+            assertTrue(text.contains("VERDICT: UNKNOWN"))
+            assertTrue(text.contains("reason=timeout"))
+        }
+    }
+
+    @Test
+    fun inspectionWaitBlockerOverridesPluginGreenVerdict() {
+        val response = """{"wait_completed":false,"timed_out":true,"inspection_verdict":"GREEN","inspection_verdict_reason":"clean_confirmed"}"""
+        MockIdeServer(mapOf("/api/inspection/wait" to MockResponse(response))).use { server ->
+            server.start()
+            val executor = ToolExecutor(server.baseUrl, HttpClient.newHttpClient(), server.port.toString())
+
+            val result = executor.handleToolCall(buildToolCall("inspection_wait", buildJsonObject { }))
+            val text = result.firstText()
+            assertTrue(text.contains("VERDICT: UNKNOWN"))
+            assertTrue(text.contains("reason=timeout"))
+            assertFalse(text.contains("VERDICT: GREEN"))
         }
     }
 
@@ -581,8 +651,9 @@ class McpServerTest {
 
             val result = executor.handleToolCall(buildToolCall("inspection_wait", buildJsonObject { }))
             val text = result.firstText()
-            assertTrue(text.contains("no captured results"))
-            assertTrue(text.contains("retry once"))
+            assertTrue(text.contains("VERDICT: UNKNOWN"))
+            assertTrue(text.contains("reason=no_results"))
+            assertTrue(text.contains("Retry once"))
         }
     }
 
@@ -594,7 +665,9 @@ class McpServerTest {
             val executor = ToolExecutor(server.baseUrl, HttpClient.newHttpClient(), server.port.toString())
 
             val result = executor.handleToolCall(buildToolCall("inspection_wait", buildJsonObject { }))
-            assertTrue(result.firstText().contains("No recent inspection"))
+            val text = result.firstText()
+            assertTrue(text.contains("VERDICT: UNKNOWN"))
+            assertTrue(text.contains("reason=no_recent_inspection"))
         }
     }
 
@@ -607,8 +680,9 @@ class McpServerTest {
 
             val result = executor.handleToolCall(buildToolCall("inspection_wait", buildJsonObject { }))
             val text = result.firstText()
-            assertTrue(text.contains("results are stale"))
-            assertTrue(text.contains("trigger inspection again"))
+            assertTrue(text.contains("VERDICT: UNKNOWN"))
+            assertTrue(text.contains("reason=stale_results"))
+            assertTrue(text.contains("Trigger inspection again"))
         }
     }
 
@@ -621,8 +695,8 @@ class McpServerTest {
 
             val result = executor.handleToolCall(buildToolCall("inspection_wait", buildJsonObject { }))
             val text = result.firstText()
-            assertTrue(text.contains("do not treat as clean"))
-            assertTrue(text.contains("Retry once"))
+            assertTrue(text.contains("VERDICT: UNKNOWN"))
+            assertTrue(text.contains("NEXT_ACTION"))
             assertTrue(text.contains("reason=timeout"))
             assertFalse(text.contains("codebase is clean"))
         }
@@ -681,7 +755,7 @@ class McpServerTest {
         val result = executor.handleToolCall(buildToolCall("inspection_get_status", buildJsonObject { }))
 
         assertFalse(result.isError())
-        assertTrue(result.firstText().contains("codebase is clean"))
+        assertTrue(result.firstText().contains("VERDICT: GREEN"))
         assertEquals(1, replacementClientFactoryCalls.get())
     }
 

--- a/scripts/test-automated.sh
+++ b/scripts/test-automated.sh
@@ -443,10 +443,12 @@ run_api_tests() {
         return 1
     fi
 
-    echo "⚠️  No problems found"
+    echo "⚠️  Inspection did not prove GREEN or RED"
     if [ "$HAS_RESULTS" = "false" ]; then
         echo "   No inspection results available yet"
         echo "   Try triggering inspection through port $IDE_PORT after the IDE finishes indexing."
+    else
+        echo "   The API returned zero actionable findings, but clean was not confirmed."
     fi
     return 1
 }

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -146,6 +146,13 @@ private data class CurrentRunPsiChurnReconciliation(
     val reconciled: Boolean,
 )
 
+private data class InspectionVerdict(
+    val verdict: String,
+    val reason: String,
+    val message: String,
+    val nextAction: String,
+)
+
 internal fun readInspectionRootChildCount(root: Any?): Int? {
     return when (root) {
         null -> null
@@ -735,6 +742,121 @@ class InspectionHandler : HttpRequestHandler() {
         }
     }
 
+    private fun addInspectionVerdict(target: MutableMap<String, Any?>) {
+        target.putAll(inspectionVerdictFields(target))
+    }
+
+    private fun addStatusInspectionVerdict(target: MutableMap<String, Any>) {
+        target.putAll(inspectionVerdictFields(target))
+    }
+
+    private fun inspectionVerdictFields(payload: Map<String, Any?>): Map<String, String> {
+        val verdict = inspectionVerdict(payload)
+        return mapOf(
+            "inspection_verdict" to verdict.verdict,
+            "inspection_verdict_reason" to verdict.reason,
+            "inspection_verdict_message" to verdict.message,
+            "inspection_verdict_next_action" to verdict.nextAction,
+        )
+    }
+
+    private fun inspectionVerdict(payload: Map<String, Any?>): InspectionVerdict {
+        val status = payload["status"] as? String
+        val completionReason = payload["completion_reason"] as? String
+        val unknownReason = unknownVerdictReason(payload)
+        if (unknownReason != null) {
+            return InspectionVerdict(
+                verdict = "UNKNOWN",
+                reason = unknownReason,
+                message = "Inspection did not produce a trustworthy GREEN or RED result.",
+                nextAction = unknownVerdictNextAction(unknownReason, payload),
+            )
+        }
+        val totalProblems = (payload["total_problems"] as? Number)?.toInt()
+        val problems = payload["problems"] as? List<*>
+        val hasExplicitZeroResult = totalProblems == 0
+        val hasCurrentFindings = ((totalProblems ?: problems?.size ?: 0) > 0) &&
+            payload["results_may_be_stale"] != true &&
+            payload["capture_incomplete"] != true
+        if (hasCurrentFindings) {
+            return InspectionVerdict(
+                verdict = "RED",
+                reason = "actionable_findings",
+                message = "Inspection worked and returned actionable findings for the selected scope/filter.",
+                nextAction = "Fix the reported findings, then rerun inspection.",
+            )
+        }
+        if (
+            (status == "results_available" && (hasExplicitZeroResult || payload["clean_inspection"] == true)) ||
+            status == "clean" ||
+            completionReason == "clean" ||
+            payload["clean_inspection"] == true
+        ) {
+            return InspectionVerdict(
+                verdict = "GREEN",
+                reason = if (status == "results_available") "no_matching_findings" else "clean_confirmed",
+                message = "Inspection worked and found no actionable findings for the selected scope/filter.",
+                nextAction = "No inspection action required for this scope/filter.",
+            )
+        }
+        return InspectionVerdict(
+            verdict = "UNKNOWN",
+            reason = completionReason ?: status ?: "unknown",
+            message = "Inspection did not produce a trustworthy GREEN or RED result.",
+            nextAction = unknownVerdictNextAction(completionReason ?: status ?: "unknown", payload),
+        )
+    }
+
+    private fun unknownVerdictReason(payload: Map<String, Any?>): String? {
+        val status = payload["status"] as? String
+        val completionReason = payload["completion_reason"] as? String
+        return when {
+            payload["session_drift"] == true -> "session_drift"
+            payload["ambiguous"] == true -> "ambiguous_route"
+            payload["unavailable"] == true -> "inspection_api_unavailable"
+            payload["results_may_be_stale"] == true || status == "stale_results" || completionReason == "stale_results" -> "stale_results"
+            payload["capture_incomplete"] == true || status == "capture_incomplete" || completionReason == "capture_incomplete" -> {
+                (payload["capture_incomplete_reason"] as? String) ?: "capture_incomplete"
+            }
+            payload["timed_out"] == true || completionReason == "timeout" -> "timeout"
+            payload["indexing"] == true || payload["is_scanning"] == true || payload["inspection_in_progress"] == true -> "inspection_still_running"
+            status == "no_results" || completionReason == "no_results" -> "no_results"
+            else -> null
+        }
+    }
+
+    private fun unknownVerdictNextAction(reason: String, payload: Map<String, Any?>): String {
+        if (reason in setOf("non_empty_unmapped_tree", "extractor_failure", "helper_plugin_error")) {
+            return "Treat this as a plugin/helper bug: include capture_diagnostic, update the plugin or helper, and rerun."
+        }
+        val diagnostic = payload["capture_diagnostic"] as? Map<*, *>
+        if (diagnostic?.get("observed_non_empty_inspection_tree") == true) {
+            return "Treat this as a plugin/helper capture bug and include capture_diagnostic when reporting it."
+        }
+        return when (reason) {
+            "view_not_ready", "view_updating_unreadable", "unreadable_tree", "no_results" ->
+                "Open the IDE Inspection Results or Problems view for the exact worktree, then rerun inspection."
+            "current_run_psi_churn" ->
+                "Save documents and rerun inspection after the IDE finishes updating PSI state."
+            "stale_results" ->
+                "Rerun inspection; stale cached findings must not be treated as current."
+            "timeout" ->
+                "Wait for indexing/scanning to settle or rerun with a larger timeout."
+            "inspection_still_running" ->
+                "Wait for indexing/scanning to finish, then rerun inspection."
+            "inspection_api_unavailable" ->
+                "Open the exact worktree in the configured JetBrains IDE with the inspection plugin installed."
+            "ambiguous_route" ->
+                "Pass project_key, project_path, or worktree_path so the plugin can inspect the exact project."
+            "session_drift" ->
+                "Resolve the route again and rerun; the IDE/plugin session changed."
+            "no_project" ->
+                "Open the exact worktree in the configured JetBrains IDE, or pass the exact project_key, project_path, or worktree_path."
+            else ->
+                "Do not report GREEN or RED. Rerun inspection and include diagnostics if it remains UNKNOWN."
+        }
+    }
+
     override fun isSupported(request: FullHttpRequest): Boolean {
         return request.uri().startsWith("/api/inspection") && request.method() == HttpMethod.GET
     }
@@ -953,8 +1075,7 @@ class InspectionHandler : HttpRequestHandler() {
         if (expectedSessionId == InspectionIdeSession.sessionId) {
             return null
         }
-        return formatJsonManually(
-            mapOf(
+        val response = mutableMapOf<String, Any>(
                 "error" to "IDE session changed",
                 "session_drift" to true,
                 "expected_session_id" to expectedSessionId,
@@ -962,7 +1083,8 @@ class InspectionHandler : HttpRequestHandler() {
                 "started_at_ms" to InspectionIdeSession.startedAtMs,
                 "message" to "The JetBrains IDE session changed. Resolve the route again and re-trigger inspection before trusting cached results.",
             )
-        )
+        addStatusInspectionVerdict(response)
+        return formatJsonManually(response)
     }
 
     private fun buildRouteResponse(parameters: Map<String, List<String>>): String {
@@ -1488,6 +1610,7 @@ class InspectionHandler : HttpRequestHandler() {
                     staleBase["include_stale"] = false
                 }
                 staleSnapshot?.captureDiagnostic?.let { staleBase["capture_diagnostic"] = it }
+                addInspectionVerdict(staleBase)
                 return formatJsonManually(staleBase.filterValues { it != null })
             }
             snapshot = reconcileSnapshotWithLiveProblems(project, snapshot)
@@ -1524,6 +1647,7 @@ class InspectionHandler : HttpRequestHandler() {
                 )
                 addCaptureIncompleteReason(response, snapshot, staleness)
                 snapshot.captureDiagnostic?.let { response["capture_diagnostic"] = it }
+                addInspectionVerdict(response)
                 return formatJsonManually(response)
             }
             val problems = if (snapshot?.problems != null) {
@@ -1575,17 +1699,18 @@ class InspectionHandler : HttpRequestHandler() {
                 snapshot?.triggerTimeMs?.let { response["snapshot_trigger_time_ms"] = it }
                 snapshot?.captureDiagnostic?.let { response["capture_diagnostic"] = it }
                 response["snapshot_change_kind"] = resolveSnapshotStaleness(project, snapshot).changeKind
+                addInspectionVerdict(response)
                 
                 formatJsonManually(response.filterValues { it != null })
             } else {
-                val response = mapOf(
+                val response = mutableMapOf<String, Any?>(
                     "status" to "no_results",
                     "project" to project.name,
                     "project_key" to key,
                     "session_id" to InspectionIdeSession.sessionId,
                     "route" to routeMetadata(project),
                     "timestamp" to System.currentTimeMillis(),
-                    "message" to "No inspection results found. Either run an inspection first, or the last inspection found no problems (100% pass).",
+                    "message" to "No trustworthy inspection result was captured. Trigger and wait for a fresh inspection, or open the Inspection Results view for the exact worktree.",
                     "total_problems" to 0,
                     "problems_shown" to 0,
                     "problems" to emptyList<Map<String, Any>>(),
@@ -1603,6 +1728,7 @@ class InspectionHandler : HttpRequestHandler() {
                     ),
                     "method" to "enhanced_tree",
                 )
+                addInspectionVerdict(response)
                 formatJsonManually(response)
             }
         } catch (_: Exception) {
@@ -1751,12 +1877,14 @@ class InspectionHandler : HttpRequestHandler() {
 
         // Clear indicator for a clean inspection (finished, confirmed, and not stale)
         val cleanInspection = (
-            !isLikelyStillRunning &&
+            !isIndexing &&
+                !isLikelyStillRunning &&
                 !inspectionInProgress &&
                 snapshot?.outcome == InspectionSnapshotOutcome.CLEAN_CONFIRMED &&
                 !staleness.stale
             )
         status["clean_inspection"] = cleanInspection
+        addStatusInspectionVerdict(status)
 
         return status
     }
@@ -1969,7 +2097,7 @@ class InspectionHandler : HttpRequestHandler() {
                     noResultsStableSince = now
                 }
                 if (noResultsWaitHasSettled(now, noResultsStableSince, timeSinceTrigger, minStableMs)) {
-                    status["wait_note"] = "Inspection finished but no results were captured. This can happen for clean runs or when the Inspection Results view was unavailable. Re-run the inspection or open the Inspection Results tool window if findings were expected."
+                    status["wait_note"] = "Inspection finished but no trustworthy result was captured. Treat this as UNKNOWN, not clean; rerun inspection or open the Inspection Results tool window for the exact worktree."
                     return formatWaitResponse(status, start, timeoutMs, pollMs, true, "no_results")
                 }
             } else {
@@ -2012,7 +2140,7 @@ class InspectionHandler : HttpRequestHandler() {
                     timeSinceTrigger != null &&
                     timeSinceTrigger >= 15000
                 ) {
-                    status["wait_note"] = "Inspection finished but no results were captured. This can happen for clean runs or when the Inspection Results view was unavailable. Re-run the inspection or open the Inspection Results tool window if findings were expected."
+                    status["wait_note"] = "Inspection finished but no trustworthy result was captured. Treat this as UNKNOWN, not clean; rerun inspection or open the Inspection Results tool window for the exact worktree."
                     return formatWaitResponse(status, start, timeoutMs, pollMs, true, "no_results")
                 }
                 return formatWaitResponse(status, start, timeoutMs, pollMs, false, "timeout")
@@ -2050,6 +2178,7 @@ class InspectionHandler : HttpRequestHandler() {
         response["wait_ms"] = elapsed
         response["timeout_ms"] = timeoutMs
         response["poll_ms"] = pollMs
+        addStatusInspectionVerdict(response)
         return formatJsonManually(response)
     }
 
@@ -2071,14 +2200,17 @@ class InspectionHandler : HttpRequestHandler() {
         response["wait_ms"] = System.currentTimeMillis() - startMs
         response["timeout_ms"] = timeoutMs
         response["poll_ms"] = pollMs
+        addStatusInspectionVerdict(response)
         return formatJsonManually(response)
     }
 
     private fun buildMissingProjectResponse(projectName: String?): MutableMap<String, Any> {
         val response = mutableMapOf<String, Any>()
         response["session_id"] = InspectionIdeSession.sessionId
+        response["status"] = "no_project"
         if (projectName == null) {
             response["error"] = "No project found"
+            addStatusInspectionVerdict(response)
             return response
         }
 
@@ -2108,6 +2240,7 @@ class InspectionHandler : HttpRequestHandler() {
             }
         }
 
+        addStatusInspectionVerdict(response)
         return response
     }
 

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -633,6 +633,8 @@ class InspectionHandlerTest {
 
         assertTrue(response.contains("Requested project 'NonExistent' is not open in the IDE."))
         assertTrue(response.contains("\"completion_reason\": \"no_project\""))
+        assertTrue(response.contains("\"inspection_verdict\": \"UNKNOWN\""))
+        assertTrue(response.contains("\"inspection_verdict_reason\": \"no_project\""))
         assertTrue(response.contains("\"wait_completed\": false"))
         assertTrue(response.contains("\"timed_out\": false"))
         assertTrue(response.contains("\"wait_note\":"))
@@ -664,6 +666,9 @@ class InspectionHandlerTest {
         }
 
         assertEquals("Requested project 'odoo api' is not open in the IDE.", response["error"])
+        assertEquals("no_project", response["status"])
+        assertEquals("UNKNOWN", response["inspection_verdict"])
+        assertEquals("no_project", response["inspection_verdict_reason"])
         val recentSuggestions = response["suggested_recent_projects"] as List<*>
         assertEquals(1, recentSuggestions.size)
         val suggestion = recentSuggestions.first() as Map<*, *>
@@ -703,6 +708,8 @@ class InspectionHandlerTest {
 
         assertEquals(HttpResponseStatus.CONFLICT, response.status())
         assertTrue(body.contains("\"session_drift\": true"))
+        assertTrue(body.contains("\"inspection_verdict\": \"UNKNOWN\""))
+        assertTrue(body.contains("\"inspection_verdict_reason\": \"session_drift\""))
         assertTrue(body.contains("\"expected_session_id\": \"old-session\""))
     }
 

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
@@ -143,6 +143,8 @@ class InspectionSnapshotStateTest {
         assertEquals(true, status["clean_inspection"])
         assertEquals(true, status["has_inspection_results"])
         assertEquals(false, status["capture_incomplete"])
+        assertEquals("GREEN", status["inspection_verdict"])
+        assertEquals("clean_confirmed", status["inspection_verdict_reason"])
     }
 
     @Test
@@ -165,6 +167,87 @@ class InspectionSnapshotStateTest {
         assertEquals(true, status["clean_inspection"])
         assertEquals(true, status["has_inspection_results"])
         assertEquals("clean_confirmed", status["snapshot_outcome"])
+    }
+
+    @Test
+    @DisplayName("Running inspection state overrides old clean verdict")
+    fun testRunningInspectionOverridesOldCleanVerdict() {
+        InspectionResultsStore.setSnapshot(
+            snapshotKey(),
+            InspectionResultsSnapshot(
+                problems = emptyList(),
+                timestamp = System.currentTimeMillis(),
+                projectState = InspectionProjectStateSnapshot(psiModificationCount = 7L, unsavedProjectDocuments = 0),
+                outcome = InspectionSnapshotOutcome.CLEAN_CONFIRMED,
+                source = "inspection_view",
+            ),
+        )
+        beginInspectionRun()
+
+        val status = buildInspectionStatus()
+
+        assertEquals(true, status["inspection_in_progress"])
+        assertEquals(true, status["is_scanning"])
+        assertEquals(false, status["clean_inspection"])
+        assertEquals("UNKNOWN", status["inspection_verdict"])
+        assertEquals("inspection_still_running", status["inspection_verdict_reason"])
+    }
+
+    @Test
+    @DisplayName("Running inspection state overrides old findings verdict")
+    fun testRunningInspectionOverridesOldFindingsVerdict() {
+        InspectionResultsStore.setSnapshot(
+            snapshotKey(),
+            InspectionResultsSnapshot(
+                problems = listOf(
+                    mapOf(
+                        "description" to "Old warning",
+                        "file" to "/tmp/TestProject/src/app.js",
+                        "line" to 12,
+                        "column" to 4,
+                        "severity" to "warning",
+                        "inspectionType" to "JSUnresolvedReference",
+                    )
+                ),
+                timestamp = System.currentTimeMillis(),
+                projectState = InspectionProjectStateSnapshot(psiModificationCount = 7L, unsavedProjectDocuments = 0),
+                outcome = InspectionSnapshotOutcome.PROBLEMS_FOUND,
+                source = "inspection_view",
+            ),
+        )
+        beginInspectionRun()
+
+        val status = buildInspectionStatus()
+
+        assertEquals(true, status["inspection_in_progress"])
+        assertEquals(true, status["is_scanning"])
+        assertEquals(1, status["total_problems"])
+        assertEquals("UNKNOWN", status["inspection_verdict"])
+        assertEquals("inspection_still_running", status["inspection_verdict_reason"])
+    }
+
+    @Test
+    @DisplayName("Indexing overrides clean snapshot verdict")
+    fun testIndexingOverridesCleanSnapshotVerdict() {
+        every { DumbService.getInstance(mockProject).isDumb } returns true
+        InspectionResultsStore.setSnapshot(
+            snapshotKey(),
+            InspectionResultsSnapshot(
+                problems = emptyList(),
+                timestamp = System.currentTimeMillis(),
+                projectState = InspectionProjectStateSnapshot(psiModificationCount = 7L, unsavedProjectDocuments = 0),
+                outcome = InspectionSnapshotOutcome.CLEAN_CONFIRMED,
+                source = "inspection_view",
+            ),
+        )
+
+        val status = buildInspectionStatus()
+
+        assertEquals(true, status["indexing"])
+        assertEquals(true, status["is_scanning"])
+        assertEquals(false, status["clean_inspection"])
+        assertEquals("UNKNOWN", status["inspection_verdict"])
+        assertEquals("inspection_still_running", status["inspection_verdict_reason"])
     }
 
     @Test
@@ -265,6 +348,8 @@ class InspectionSnapshotStateTest {
         assertEquals(1, status["total_problems"])
         assertEquals("problems_found", status["snapshot_outcome"])
         assertEquals("tool_window", status["results_source"])
+        assertEquals("RED", status["inspection_verdict"])
+        assertEquals("actionable_findings", status["inspection_verdict_reason"])
     }
 
     @Test
@@ -442,6 +527,8 @@ class InspectionSnapshotStateTest {
         assertTrue(response.contains("\"results_may_be_incomplete\": true"))
         assertTrue(response.contains("\"snapshot_outcome\": \"capture_incomplete\""))
         assertTrue(response.contains("\"capture_incomplete_reason\": \"timeout\""))
+        assertTrue(response.contains("\"inspection_verdict\": \"UNKNOWN\""))
+        assertTrue(response.contains("\"inspection_verdict_reason\": \"timeout\""))
         assertTrue(response.contains("\"capture_diagnostic\""))
         assertTrue(response.contains("\"exit_reason\": \"timeout\""))
         assertTrue(response.contains("\"view_ready_ok\": false"))
@@ -456,6 +543,10 @@ class InspectionSnapshotStateTest {
         val response = getInspectionProblems()
 
         assertTrue(response.contains("\"status\": \"no_results\""))
+        assertTrue(response.contains("\"inspection_verdict\": \"UNKNOWN\""))
+        assertTrue(response.contains("\"inspection_verdict_reason\": \"no_results\""))
+        assertTrue(response.contains("No trustworthy inspection result was captured"))
+        assertFalse(response.contains("100% pass"))
         assertTrue(response.contains("\"project\": \"TestProject\""))
         assertTrue(response.contains("\"project_key\":"))
         assertTrue(response.contains("\"total_problems\": 0"))
@@ -498,6 +589,33 @@ class InspectionSnapshotStateTest {
         assertTrue(response.contains("\"total_problems\": 1"))
         assertTrue(response.contains("Live warning"))
         assertTrue(response.contains("\"method\": \"tool_window\""))
+    }
+
+    @Test
+    @DisplayName("Problems endpoint verdict stays red for empty paginated pages with findings")
+    fun testProblemsEndpointVerdictUsesTotalForEmptyPage() {
+        InspectionResultsStore.setSnapshot(
+            snapshotKey(),
+            InspectionResultsSnapshot(
+                problems = listOf(
+                    staleProblem(description = "First warning", file = "/tmp/TestProject/src/app.js"),
+                    staleProblem(description = "Second warning", file = "/tmp/TestProject/src/other.js"),
+                ),
+                timestamp = System.currentTimeMillis(),
+                projectState = InspectionProjectStateSnapshot(psiModificationCount = 7L, unsavedProjectDocuments = 0),
+                outcome = InspectionSnapshotOutcome.PROBLEMS_FOUND,
+                source = "inspection_view",
+            ),
+        )
+
+        val response = getInspectionProblems(limit = 1, offset = 2)
+
+        assertTrue(response.contains("\"status\": \"results_available\""))
+        assertTrue(response.contains("\"total_problems\": 2"))
+        assertTrue(response.contains("\"problems_shown\": 0"))
+        assertTrue(response.contains("\"problems\": []"))
+        assertTrue(response.contains("\"inspection_verdict\": \"RED\""))
+        assertTrue(response.contains("\"inspection_verdict_reason\": \"actionable_findings\""))
     }
 
     @Test
@@ -563,6 +681,8 @@ class InspectionSnapshotStateTest {
 
         assertTrue(response.contains("\"completion_reason\": \"capture_incomplete\""))
         assertTrue(response.contains("\"capture_incomplete_reason\": \"timeout\""))
+        assertTrue(response.contains("\"inspection_verdict\": \"UNKNOWN\""))
+        assertTrue(response.contains("\"inspection_verdict_reason\": \"timeout\""))
         assertTrue(response.contains("\"capture_diagnostic\""))
         assertTrue(response.contains("\"exit_reason\": \"timeout\""))
         assertTrue(response.contains("\"view_ready_ok\": false"))
@@ -731,6 +851,8 @@ class InspectionSnapshotStateTest {
         val response = getInspectionProblems()
 
         assertTrue(response.contains("\"status\": \"stale_results\""))
+        assertTrue(response.contains("\"inspection_verdict\": \"UNKNOWN\""))
+        assertTrue(response.contains("\"inspection_verdict_reason\": \"stale_results\""))
         assertTrue(response.contains("\"results_may_be_stale\": true"))
         assertTrue(response.contains("\"snapshot_change_kind\": \"project_changed_since_inspection\""))
         assertTrue(response.contains("\"cached_total_problems\": 1"))
@@ -993,7 +1115,10 @@ class InspectionSnapshotStateTest {
         val response = waitForInspection()
 
         assertTrue(response.contains("\"completion_reason\": \"no_results\""))
-        assertTrue(response.contains("clean runs"))
+        assertTrue(response.contains("\"inspection_verdict\": \"UNKNOWN\""))
+        assertTrue(response.contains("\"inspection_verdict_reason\": \"no_results\""))
+        assertTrue(response.contains("Treat this as UNKNOWN, not clean"))
+        assertFalse(response.contains("clean runs"))
         assertFalse(response.contains("\"completion_reason\": \"capture_incomplete\""))
     }
 
@@ -2396,7 +2521,12 @@ class InspectionSnapshotStateTest {
         return getInspectionProblems(includeStale = false)
     }
 
-    private fun getInspectionProblems(scope: String = "whole_project", includeStale: Boolean): String {
+    private fun getInspectionProblems(
+        scope: String = "whole_project",
+        includeStale: Boolean = false,
+        limit: Int = 100,
+        offset: Int = 0,
+    ): String {
         val method = InspectionHandler::class.java.getDeclaredMethod(
             "getInspectionProblems",
             Project::class.java,
@@ -2409,7 +2539,7 @@ class InspectionSnapshotStateTest {
             Boolean::class.javaPrimitiveType,
         )
         method.isAccessible = true
-        return method.invoke(handler, mockProject, "all", scope, null, null, 100, 0, includeStale) as String
+        return method.invoke(handler, mockProject, "all", scope, null, null, limit, offset, includeStale) as String
     }
 
     private fun staleProblem(


### PR DESCRIPTION
## Summary
- Adds explicit GREEN / RED / UNKNOWN inspection verdict fields to plugin HTTP responses and MCP output.
- Treats blockers such as stale results, capture-incomplete, timeouts, indexing/running, session drift, route ambiguity, and no-results as UNKNOWN instead of clean.
- Preserves RED from `total_problems > 0`, including empty paginated result pages.

## Validation
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test :mcp-server-jvm:test`
- shared helper `py_compile` and regression tests passed during rollout validation
- JetBrains helper closeout on the branch returned GREEN
- final review agents agreed this is PR-ready with no blockers

## Plan alignment
- Establishes the base contract for “GREEN or RED when proven, UNKNOWN when the tool could not prove either.”
- This should merge before the red-lane dogfood fixture PR.
