### PR TITLE
Add red-lane inspection dogfood fixture

### DIFF
--- a/.code/skills/jetbrains-inspection-workflow/SKILL.md
+++ b/.code/skills/jetbrains-inspection-workflow/SKILL.md
@@ -59,7 +59,12 @@ Keep exact command matrices, environment setup, and troubleshooting in
    smoke matrix (`./scripts/dogfood-smoke-matrix.sh`) when local IDEs are
    available; it exercises preexisting and helper-opened closeout paths and
    records cleanup evidence.
-6. For release readiness, run `./scripts/test-all.sh` or the commit gate before
+6. For verdict or extraction changes that must prove the red lane, run
+   `./scripts/dogfood-red-lane-smoke.sh` with a local IntelliJ IDEA and the
+   current plugin installed; it copies the maintained known-bad fixture and
+   requires structured JSON with `RED`, `total_problems > 0`, and cleanup
+   `closed`.
+7. For release readiness, run `./scripts/test-all.sh` or the commit gate before
    build/release commands, and confirm CI status when GitHub state matters.
 
 ## When Changing Behavior
@@ -81,7 +86,8 @@ Keep exact command matrices, environment setup, and troubleshooting in
 6. For clean/capture classification, preserve non-clean outcomes for
    `capture_incomplete`, stale results, timeouts, indexing, session drift,
    route ambiguity, wrong-worktree routes, and cleanup failures.
-7. For red-lane smoke tests, require current actionable findings in the helper
+7. For red-lane smoke tests, prefer `./scripts/dogfood-red-lane-smoke.sh` and
+   require current actionable findings in the helper
    response, such as `total_problems > 0`; a paginated current page may have an
    empty `problems` list even when matching findings exist. `capture_incomplete`, `non_empty_unmapped_tree`, or a
    non-clean zero-problem response proves only that clean was not confirmed.

--- a/.github/github.json
+++ b/.github/github.json
@@ -28,7 +28,8 @@
     },
     "manualSmoke": {
       "automatedIde": "./scripts/test-automated.sh",
-      "dogfoodMatrix": "./scripts/dogfood-smoke-matrix.sh"
+      "dogfoodMatrix": "./scripts/dogfood-smoke-matrix.sh",
+      "redLaneDogfood": "./scripts/dogfood-red-lane-smoke.sh"
     },
     "docsRequiredWhen": [
       "behavior changes",

--- a/TESTING.md
+++ b/TESTING.md
@@ -103,6 +103,29 @@ lifecycle cleanup contracts, or MCP tool response contracts, update the skill
 docs/tests/scripts in the `jetbrains-inspection` skill as part of the same
 workstream.
 
+### Red lane dogfood
+
+Use `./scripts/dogfood-red-lane-smoke.sh` when changing verdict semantics,
+capture behavior, extraction, helper closeout, or release readiness. It copies
+the maintained known-bad Java project in `test-fixtures/inspection-red-lane` to
+a disposable local project, runs the external `jb-inspect.py closeout`, and
+requires `VERDICT=RED`, `total_problems > 0`, and cleanup `closed`. The helper
+may exit non-zero because `RED` is not readiness-clean; the smoke trusts the
+structured JSON verdict and still fails on invalid JSON or missing cleanup.
+IntelliJ IDEA is the required product for this Java fixture;
+product-specific PyCharm or WebStorm red-lane fixtures should be added
+separately if needed.
+
+```bash
+./scripts/dogfood-red-lane-smoke.sh \
+  --ide "IntelliJ IDEA" \
+  --json-out tmp/dogfood-red-lane.json
+```
+
+This is a live IDE smoke, not a normal CI unit test. `./scripts/test-all.sh`
+runs `./scripts/test-red-lane-smoke-script.sh`, which stubs the helper to keep
+the script contract from drifting without requiring a GUI IDE.
+
 Before shipping changes to clean/capture classification, run the focused
 `InspectionSnapshotStateTest` coverage, then build the plugin with
 `./gradlew buildPlugin`. Smoke the installed plugin from the agent helper in the

--- a/TESTING_INSTRUCTIONS.md
+++ b/TESTING_INSTRUCTIONS.md
@@ -81,6 +81,25 @@ product-specific IDE failure.
 9. For linked worktrees, confirm the route `base_path` exactly equals the linked
    worktree, not the main checkout.
 
+## Red lane live smoke
+
+Use this when changing verdict classification, extraction, or helper closeout
+behavior and you need to prove a real IDE finding reaches agents as `RED`:
+
+```bash
+./scripts/dogfood-red-lane-smoke.sh \
+  --ide "IntelliJ IDEA" \
+  --json-out tmp/dogfood-red-lane.json
+```
+
+The command copies `test-fixtures/inspection-red-lane` to a disposable project
+under `~/.code/working/jetbrains-inspection-api/red-lane-smoke`, runs helper
+closeout with `scope=whole_project`, and passes only when the structured helper
+JSON reports `VERDICT=RED`, reports `total_problems > 0`, and closes the
+helper-owned project. The helper may exit non-zero because `RED` is not
+readiness-clean. Use IntelliJ IDEA for the maintained Java fixture; product-specific RED
+fixtures for PyCharm or WebStorm should be added separately if needed.
+
 ## Fast-path scopes (manual)
 
 Changed files only (fast inner loop):

--- a/scripts/dogfood-red-lane-smoke.sh
+++ b/scripts/dogfood-red-lane-smoke.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "$ROOT" || exit 1
+
+DEFAULT_HELPER_DEV="$HOME/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py"
+DEFAULT_HELPER_HOME="${CODE_HOME:-${CODEX_HOME:-$HOME/.code}}/skills/jetbrains-inspection/scripts/jb-inspect.py"
+
+if [ -x "$DEFAULT_HELPER_DEV" ]; then
+	HELPER="$DEFAULT_HELPER_DEV"
+else
+	HELPER="$DEFAULT_HELPER_HOME"
+fi
+
+FIXTURE="$ROOT/test-fixtures/inspection-red-lane"
+IDE="IntelliJ IDEA"
+TIMEOUT_MS=180000
+PREPARE_TIMEOUT_MS=180000
+WORK_ROOT="$HOME/.code/working/jetbrains-inspection-api/red-lane-smoke"
+JSON_OUT=""
+KEEP_PROJECT=0
+
+usage() {
+	cat <<'USAGE'
+Usage: ./scripts/dogfood-red-lane-smoke.sh [options]
+
+Copies the maintained inspection-red-lane fixture to a disposable local project,
+runs the JetBrains inspection helper closeout, and requires a RED verdict.
+This is a live IDE dogfood smoke, not a normal CI unit test.
+
+Options:
+  --helper PATH              Path to jb-inspect.py.
+  --ide NAME                 IDE selector. Default: IntelliJ IDEA.
+  --timeout-ms MS            Helper wait timeout. Default: 180000.
+  --prepare-timeout-ms MS    Helper prepare/open timeout. Default: 180000.
+  --work-root PATH           Parent directory for disposable fixture copies.
+  --json-out PATH            Write JSON report to PATH.
+  --keep-project             Leave the disposable fixture project on disk.
+  -h, --help                 Show this help.
+
+The fixture intentionally contains unresolved Java symbols. A passing smoke means:
+IDE inspection produced actionable findings, the plugin captured them, and the
+helper reported VERDICT=RED.
+USAGE
+}
+
+die() {
+	echo "ERROR: $*" >&2
+	exit 2
+}
+
+abs_path() {
+	local path=$1
+	case "$path" in
+	/*) printf '%s\n' "$path" ;;
+	*) printf '%s/%s\n' "$PWD" "$path" ;;
+	esac
+}
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--helper)
+		[ $# -ge 2 ] || die "--helper requires a path"
+		HELPER=$2
+		shift 2
+		;;
+	--ide)
+		[ $# -ge 2 ] || die "--ide requires a value"
+		IDE=$2
+		shift 2
+		;;
+	--timeout-ms)
+		[ $# -ge 2 ] || die "--timeout-ms requires a value"
+		TIMEOUT_MS=$2
+		shift 2
+		;;
+	--prepare-timeout-ms)
+		[ $# -ge 2 ] || die "--prepare-timeout-ms requires a value"
+		PREPARE_TIMEOUT_MS=$2
+		shift 2
+		;;
+	--work-root)
+		[ $# -ge 2 ] || die "--work-root requires a path"
+		WORK_ROOT=$2
+		shift 2
+		;;
+	--json-out)
+		[ $# -ge 2 ] || die "--json-out requires a path"
+		JSON_OUT=$2
+		shift 2
+		;;
+	--keep-project)
+		KEEP_PROJECT=1
+		shift
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		die "unknown option: $1"
+		;;
+	esac
+done
+
+[ -x "$HELPER" ] || die "helper is not executable: $HELPER"
+[ -d "$FIXTURE" ] || die "fixture is missing: $FIXTURE"
+
+WORK_ROOT=$(abs_path "$WORK_ROOT")
+mkdir -p "$WORK_ROOT"
+
+RUN_ID=$(date -u +%Y%m%dT%H%M%SZ)-$$
+PROJECT="$WORK_ROOT/inspection-red-lane-$RUN_ID"
+RAW_OUT="$WORK_ROOT/inspection-red-lane-$RUN_ID.raw.json"
+ERR_OUT="$WORK_ROOT/inspection-red-lane-$RUN_ID.stderr.txt"
+PAYLOAD_FILE="$WORK_ROOT/inspection-red-lane-$RUN_ID.payload.json"
+COMMAND_FILE="$WORK_ROOT/inspection-red-lane-$RUN_ID.command.json"
+
+# shellcheck disable=SC2329
+cleanup() {
+	if [ "$KEEP_PROJECT" -eq 0 ]; then
+		rm -rf "$PROJECT"
+	fi
+}
+trap cleanup EXIT
+
+rm -rf "$PROJECT"
+mkdir -p "$PROJECT"
+cp -R "$FIXTURE"/. "$PROJECT"/
+
+CMD=(uv run "$HELPER" --json closeout --repo "$PROJECT" --ide "$IDE" --scope whole_project --profile RedLane --timeout-ms "$TIMEOUT_MS" --prepare-timeout-ms "$PREPARE_TIMEOUT_MS")
+jq -n '$ARGS.positional' --args -- "${CMD[@]}" >"$COMMAND_FILE"
+
+"${CMD[@]}" >"$RAW_OUT" 2>"$ERR_OUT"
+EXIT_CODE=$?
+
+if jq empty "$RAW_OUT" >/dev/null 2>&1; then
+	cp "$RAW_OUT" "$PAYLOAD_FILE"
+else
+	jq -n --arg error "helper did not emit valid JSON" --arg raw "$(head -c 4000 "$RAW_OUT" 2>/dev/null || true)" '{status:"error", error_reason:"invalid_helper_json", error:$error, raw_output_excerpt:$raw}' >"$PAYLOAD_FILE"
+fi
+
+VERDICT=$(jq -r '.verdict // .inspection_verdict // ""' "$PAYLOAD_FILE")
+TOTAL=$(jq -r '.total_problems // 0' "$PAYLOAD_FILE")
+CLEANUP_STATUS=$(jq -r '.cleanup.status // ""' "$PAYLOAD_FILE")
+
+if [ "$EXIT_CODE" -le 1 ] && [ "$VERDICT" = "RED" ] && [ "$TOTAL" != "0" ] && [ "$TOTAL" != "null" ] && [ "$CLEANUP_STATUS" = "closed" ]; then
+	STATUS="ok"
+	BUCKET="red_confirmed"
+else
+	STATUS="failed"
+	BUCKET="red_not_confirmed"
+fi
+
+REPORT=$(
+	jq -n \
+		--arg status "$STATUS" \
+		--arg bucket "$BUCKET" \
+		--arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+			--arg helper "$HELPER" \
+			--arg ide "$IDE" \
+			--arg fixture "$FIXTURE" \
+			--arg project "$PROJECT" \
+			--argjson exit_code "$EXIT_CODE" \
+			--slurpfile command "$COMMAND_FILE" \
+			--slurpfile payload "$PAYLOAD_FILE" \
+			--arg stderr "$(head -c 4000 "$ERR_OUT" 2>/dev/null || true)" '
+      def command: $command[0];
+      def payload: $payload[0];
+      {
+        status: $status,
+        bucket: $bucket,
+        generated_at: $generated_at,
+        helper: $helper,
+        ide: $ide,
+        fixture: $fixture,
+        project: $project,
+        exit_code: $exit_code,
+        verdict: (payload.verdict // payload.inspection_verdict // null),
+        verdict_reason: (payload.verdict_reason // payload.inspection_verdict_reason // null),
+        total_problems: (payload.total_problems // null),
+        problems_shown: (payload.problems_shown // null),
+        cleanup: (payload.cleanup // null),
+        route: (payload.route // null),
+        command: command,
+        payload: payload,
+        stderr_excerpt: (if $stderr == "" then null else $stderr end)
+      }'
+)
+
+printf '%s\n' "$REPORT" | jq -r '"status=\(.status) bucket=\(.bucket) verdict=\(.verdict) total=\(.total_problems // "-") cleanup=\(.cleanup.status // "-")"'
+
+if [ -n "$JSON_OUT" ]; then
+	mkdir -p "$(dirname "$JSON_OUT")"
+	printf '%s\n' "$REPORT" >"$JSON_OUT"
+	echo "wrote $JSON_OUT" >&2
+fi
+
+if [ "$STATUS" = "ok" ]; then
+	exit 0
+fi
+
+exit 1

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -164,6 +164,18 @@ fi
 
 print_result $BUILD_RESULT "Plugin build"
 
+# Step 4b: Smoke Script Contract Tests
+print_section "4b. Smoke Script Contract Tests"
+
+echo "Running red-lane smoke script contract test..."
+if ./scripts/test-red-lane-smoke-script.sh; then
+  RED_LANE_SCRIPT_RESULT=0
+else
+  RED_LANE_SCRIPT_RESULT=1
+fi
+
+print_result $RED_LANE_SCRIPT_RESULT "Red-lane smoke script contract"
+
 # Step 5: Coverage Verification
 print_section "5. Coverage Verification"
 
@@ -205,6 +217,7 @@ print_result $PLUGIN_TEST_RESULT "  Plugin tests"
 print_result $CORE_TEST_RESULT "  Core tests"
 print_result $MCP_TEST_RESULT "  MCP server tests"
 print_result $BUILD_RESULT "  Plugin build"
+print_result $RED_LANE_SCRIPT_RESULT "  Red-lane smoke script contract"
 print_result $PLUGIN_COVERAGE_RESULT "  Plugin coverage threshold"
 print_result $CORE_COVERAGE_RESULT "  Core coverage threshold"
 print_result $MCP_COVERAGE_RESULT "  MCP coverage threshold"

--- a/scripts/test-red-lane-smoke-script.sh
+++ b/scripts/test-red-lane-smoke-script.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "$ROOT"
+
+FIXTURE_SOURCE="test-fixtures/inspection-red-lane/src/main/java/com/example/redlane/DefinitelyRed.java"
+FIXTURE_PROFILE="test-fixtures/inspection-red-lane/.idea/inspectionProfiles/RedLane.xml"
+
+grep -q 'INTENTIONAL RED-LANE FIXTURE' "$FIXTURE_SOURCE"
+grep -q 'MissingType value = MissingType.create();' "$FIXTURE_SOURCE"
+grep -q 'private void unusedMethod()' "$FIXTURE_SOURCE"
+grep -q 'JavaErrorInspection' "$FIXTURE_PROFILE"
+grep -q 'UnusedDeclaration' "$FIXTURE_PROFILE"
+grep -q -- '--scope whole_project' scripts/dogfood-red-lane-smoke.sh
+grep -q -- '--profile RedLane' scripts/dogfood-red-lane-smoke.sh
+
+TMP_DIR=$(mktemp -d)
+cleanup() {
+	rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+HELPER="$TMP_DIR/jb-inspect.py"
+cat >"$HELPER" <<'STUB'
+#!/usr/bin/env python3
+import json
+import sys
+from pathlib import Path
+
+repo = ""
+args = sys.argv[1:]
+while args:
+    arg = args.pop(0)
+    if arg == "--repo" and args:
+        repo = args.pop(0)
+
+fixture = Path(repo) / "src/main/java/com/example/redlane/DefinitelyRed.java"
+if not repo or not fixture.exists():
+    print(json.dumps({"status": "error", "error_reason": "missing_fixture"}))
+    sys.exit(3)
+
+print(json.dumps({
+    "status": "findings",
+    "verdict": "RED",
+    "verdict_reason": "actionable_findings",
+    "verdict_message": "Inspection worked and returned actionable findings.",
+    "total_problems": 1,
+    "problems_shown": 1,
+    "clean": False,
+    "cleanup": {"status": "closed"},
+    "route": {"base_path": repo, "project_name": "inspection-red-lane", "ide": {"name": "IntelliJ IDEA"}},
+    "problems": [{"severity": "error", "file": str(fixture), "line": 6, "description": "Cannot resolve symbol MissingType"}],
+}))
+STUB
+chmod +x "$HELPER"
+
+JSON_OUT="$TMP_DIR/report.json"
+./scripts/dogfood-red-lane-smoke.sh \
+  --helper "$HELPER" \
+  --work-root "$TMP_DIR/work" \
+  --json-out "$JSON_OUT"
+
+jq -e '
+  .status == "ok" and
+  .bucket == "red_confirmed" and
+  .verdict == "RED" and
+  .total_problems == 1 and
+  .cleanup.status == "closed" and
+  (.payload.problems[0].description | contains("MissingType"))
+' "$JSON_OUT" >/dev/null
+
+echo "red-lane smoke script contract passed"

--- a/test-fixtures/inspection-red-lane/.idea/inspectionProfiles/RedLane.xml
+++ b/test-fixtures/inspection-red-lane/.idea/inspectionProfiles/RedLane.xml
@@ -1,0 +1,7 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0" is_locked="false">
+    <option name="myName" value="RedLane" />
+    <inspection_tool class="JavaErrorInspection" enabled="true" level="ERROR" enabled_by_default="true" />
+    <inspection_tool class="UnusedDeclaration" enabled="true" level="WARNING" enabled_by_default="true" />
+  </profile>
+</component>

--- a/test-fixtures/inspection-red-lane/.idea/inspectionProfiles/profiles_settings.xml
+++ b/test-fixtures/inspection-red-lane/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="PROJECT_PROFILE" value="RedLane" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/test-fixtures/inspection-red-lane/.idea/misc.xml
+++ b/test-fixtures/inspection-red-lane/.idea/misc.xml
@@ -1,0 +1,3 @@
+<project version="4">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK" />
+</project>

--- a/test-fixtures/inspection-red-lane/.idea/modules.xml
+++ b/test-fixtures/inspection-red-lane/.idea/modules.xml
@@ -1,0 +1,7 @@
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/inspection-red-lane.iml" filepath="$PROJECT_DIR$/inspection-red-lane.iml" />
+    </modules>
+  </component>
+</project>

--- a/test-fixtures/inspection-red-lane/FIXTURE.md
+++ b/test-fixtures/inspection-red-lane/FIXTURE.md
@@ -1,0 +1,9 @@
+# Inspection Red Lane Fixture
+
+This project is intentionally broken. `DefinitelyRed.java` must reference the
+unresolved `MissingType` symbol so `scripts/dogfood-red-lane-smoke.sh` can prove
+the live IDE, plugin, and helper report `VERDICT=RED` with `total_problems > 0`.
+
+Do not add `MissingType` or otherwise make this project compile. If the fixture changes, run
+`./scripts/test-red-lane-smoke-script.sh` and, when a local IntelliJ IDEA with
+the plugin is available, `./scripts/dogfood-red-lane-smoke.sh`.

--- a/test-fixtures/inspection-red-lane/build.gradle
+++ b/test-fixtures/inspection-red-lane/build.gradle
@@ -1,0 +1,9 @@
+plugins {
+    id "java"
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}

--- a/test-fixtures/inspection-red-lane/inspection-red-lane.iml
+++ b/test-fixtures/inspection-red-lane/inspection-red-lane.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/test-fixtures/inspection-red-lane/settings.gradle
+++ b/test-fixtures/inspection-red-lane/settings.gradle
@@ -1,0 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenCentral()
+    }
+}
+
+rootProject.name = "inspection-red-lane"

--- a/test-fixtures/inspection-red-lane/src/main/java/com/example/redlane/DefinitelyRed.java
+++ b/test-fixtures/inspection-red-lane/src/main/java/com/example/redlane/DefinitelyRed.java
@@ -1,0 +1,15 @@
+package com.example.redlane;
+
+public class DefinitelyRed {
+    private String unusedField = "unused";
+
+    public static void main(String[] args) {
+        // INTENTIONAL RED-LANE FIXTURE: MissingType must remain unresolved.
+        MissingType value = MissingType.create();
+        System.out.println(value);
+    }
+
+    private void unusedMethod() {
+        System.out.println(unusedField);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a maintained intentionally broken Java fixture at `test-fixtures/inspection-red-lane`.
- Adds `scripts/dogfood-red-lane-smoke.sh` to prove a live helper-opened IntelliJ project returns RED with actionable findings.
- Adds a stubbed contract test wired into `scripts/test-all.sh` so the bad fixture and red-lane script do not drift without requiring a GUI IDE in CI.
- Updates testing docs, repo metadata, and repo-local skill guidance.

## Validation
- live smoke: `status=ok bucket=red_confirmed verdict=RED total=1 cleanup=closed`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test :mcp-server-jvm:test`
- `bash -n scripts/dogfood-red-lane-smoke.sh scripts/test-red-lane-smoke-script.sh`
- `shellcheck scripts/dogfood-red-lane-smoke.sh scripts/test-red-lane-smoke-script.sh`
- `./scripts/test-red-lane-smoke-script.sh`
- `git diff --check`
- final review agents agreed this is PR-ready with no blockers

## Merge note
- Stacked on #108. Merge #108 first; this PR should then shrink to the red-lane fixture/test/docs commit.

## Plan alignment
- Gives us a maintained RED lane so future agents cannot claim “no problems found” when the plugin/helper failed to surface actionable findings.
