### PR TITLE
Harden inspection red-lane verdicts

### DIFF
--- a/.code/skills/jetbrains-inspection-workflow/SKILL.md
+++ b/.code/skills/jetbrains-inspection-workflow/SKILL.md
@@ -60,10 +60,10 @@ Keep exact command matrices, environment setup, and troubleshooting in
    available; it exercises preexisting and helper-opened closeout paths and
    records cleanup evidence.
 6. For verdict or extraction changes that must prove the red lane, run
-   `./scripts/dogfood-red-lane-smoke.sh` with a local IntelliJ IDEA and the
-   current plugin installed; it copies the maintained known-bad fixture and
-   requires structured JSON with `RED`, `total_problems > 0`, and cleanup
-   `closed`.
+   `./scripts/dogfood-red-lane-smoke.sh --product intellij|pycharm|webstorm`
+   with the matching local IDE and the current plugin installed; it copies the
+   maintained known-bad fixture and requires structured JSON with `RED`,
+   `total_problems > 0`, and cleanup `closed`.
 7. For release readiness, run `./scripts/test-all.sh` or the commit gate before
    build/release commands, and confirm CI status when GitHub state matters.
 
@@ -86,8 +86,8 @@ Keep exact command matrices, environment setup, and troubleshooting in
 6. For clean/capture classification, preserve non-clean outcomes for
    `capture_incomplete`, stale results, timeouts, indexing, session drift,
    route ambiguity, wrong-worktree routes, and cleanup failures.
-7. For red-lane smoke tests, prefer `./scripts/dogfood-red-lane-smoke.sh` and
-   require current actionable findings in the helper
+7. For red-lane smoke tests, prefer `./scripts/dogfood-red-lane-smoke.sh` with
+   the relevant `--product` and require current actionable findings in the helper
    response, such as `total_problems > 0`; a paginated current page may have an
    empty `problems` list even when matching findings exist. `capture_incomplete`, `non_empty_unmapped_tree`, or a
    non-clean zero-problem response proves only that clean was not confirmed.

--- a/.github/github.json
+++ b/.github/github.json
@@ -29,7 +29,10 @@
     "manualSmoke": {
       "automatedIde": "./scripts/test-automated.sh",
       "dogfoodMatrix": "./scripts/dogfood-smoke-matrix.sh",
-      "redLaneDogfood": "./scripts/dogfood-red-lane-smoke.sh"
+      "redLaneDogfood": "./scripts/dogfood-red-lane-smoke.sh",
+      "redLaneDogfoodIntelliJ": "./scripts/dogfood-red-lane-smoke.sh --product intellij",
+      "redLaneDogfoodPyCharm": "./scripts/dogfood-red-lane-smoke.sh --product pycharm",
+      "redLaneDogfoodWebStorm": "./scripts/dogfood-red-lane-smoke.sh --product webstorm"
     },
     "docsRequiredWhen": [
       "behavior changes",

--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ curl "http://localhost:63340/api/inspection/problems?include_stale=true"
 - `include_unversioned` (optional): `true|false` when `scope=changed_files` (default `true`).
 - `changed_files_mode` (optional): `all|staged|unstaged` (best‑effort; falls back to `all`).
 - `max_files` (optional): Positive integer to cap files inspected for responsiveness. Invalid values return HTTP 400 with `error`, `parameter`, and `message` fields.
-- `profile` (optional): Name of inspection profile to use; falls back to current profile if not found.
+- `profile` (optional): Name of inspection profile to use. If an explicitly requested profile is missing or cannot be verified, the result is `UNKNOWN`/`capture_incomplete` rather than silently falling back to another profile.
 
 **Examples**:
 ```bash

--- a/TESTING.md
+++ b/TESTING.md
@@ -106,25 +106,34 @@ workstream.
 ### Red lane dogfood
 
 Use `./scripts/dogfood-red-lane-smoke.sh` when changing verdict semantics,
-capture behavior, extraction, helper closeout, or release readiness. It copies
-the maintained known-bad Java project in `test-fixtures/inspection-red-lane` to
-a disposable local project, runs the external `jb-inspect.py closeout`, and
-requires `VERDICT=RED`, `total_problems > 0`, and cleanup `closed`. The helper
-may exit non-zero because `RED` is not readiness-clean; the smoke trusts the
-structured JSON verdict and still fails on invalid JSON or missing cleanup.
-IntelliJ IDEA is the required product for this Java fixture;
-product-specific PyCharm or WebStorm red-lane fixtures should be added
-separately if needed.
+capture behavior, extraction, helper closeout, or release readiness. It copies a
+maintained known-bad project fixture to a disposable local project, runs the
+external `jb-inspect.py closeout`, and requires `VERDICT=RED`,
+`total_problems > 0`, and cleanup `closed`. The helper may exit non-zero because
+`RED` is not readiness-clean; the smoke trusts the structured JSON verdict and
+still fails on invalid JSON or missing cleanup.
 
 ```bash
 ./scripts/dogfood-red-lane-smoke.sh \
+  --product intellij \
   --ide "IntelliJ IDEA" \
   --json-out tmp/dogfood-red-lane.json
+
+./scripts/dogfood-red-lane-smoke.sh \
+  --product pycharm \
+  --ide "PyCharm" \
+  --json-out tmp/dogfood-red-lane-pycharm.json
+
+./scripts/dogfood-red-lane-smoke.sh \
+  --product webstorm \
+  --ide "WebStorm" \
+  --json-out tmp/dogfood-red-lane-webstorm.json
 ```
 
 This is a live IDE smoke, not a normal CI unit test. `./scripts/test-all.sh`
-runs `./scripts/test-red-lane-smoke-script.sh`, which stubs the helper to keep
-the script contract from drifting without requiring a GUI IDE.
+runs `./scripts/test-red-lane-smoke-script.sh`, which stubs the helper and
+checks the IntelliJ, PyCharm, and WebStorm fixture contracts without requiring a
+GUI IDE.
 
 Before shipping changes to clean/capture classification, run the focused
 `InspectionSnapshotStateTest` coverage, then build the plugin with

--- a/TESTING_INSTRUCTIONS.md
+++ b/TESTING_INSTRUCTIONS.md
@@ -88,17 +88,27 @@ behavior and you need to prove a real IDE finding reaches agents as `RED`:
 
 ```bash
 ./scripts/dogfood-red-lane-smoke.sh \
+  --product intellij \
   --ide "IntelliJ IDEA" \
   --json-out tmp/dogfood-red-lane.json
+
+./scripts/dogfood-red-lane-smoke.sh \
+  --product pycharm \
+  --ide "PyCharm" \
+  --json-out tmp/dogfood-red-lane-pycharm.json
+
+./scripts/dogfood-red-lane-smoke.sh \
+  --product webstorm \
+  --ide "WebStorm" \
+  --json-out tmp/dogfood-red-lane-webstorm.json
 ```
 
-The command copies `test-fixtures/inspection-red-lane` to a disposable project
-under `~/.code/working/jetbrains-inspection-api/red-lane-smoke`, runs helper
-closeout with `scope=whole_project`, and passes only when the structured helper
-JSON reports `VERDICT=RED`, reports `total_problems > 0`, and closes the
-helper-owned project. The helper may exit non-zero because `RED` is not
-readiness-clean. Use IntelliJ IDEA for the maintained Java fixture; product-specific RED
-fixtures for PyCharm or WebStorm should be added separately if needed.
+The command copies the selected `test-fixtures/inspection-red-lane*` fixture to a
+disposable project under
+`~/.code/working/jetbrains-inspection-api/red-lane-smoke`, runs helper closeout
+with `scope=whole_project`, and passes only when the structured helper JSON
+reports `VERDICT=RED`, reports `total_problems > 0`, and closes the helper-owned
+project. The helper may exit non-zero because `RED` is not readiness-clean.
 
 ## Fast-path scopes (manual)
 

--- a/scripts/dogfood-red-lane-smoke.sh
+++ b/scripts/dogfood-red-lane-smoke.sh
@@ -14,8 +14,8 @@ else
 	HELPER="$DEFAULT_HELPER_HOME"
 fi
 
-FIXTURE="$ROOT/test-fixtures/inspection-red-lane"
-IDE="IntelliJ IDEA"
+PRODUCT="intellij"
+IDE=""
 TIMEOUT_MS=180000
 PREPARE_TIMEOUT_MS=180000
 WORK_ROOT="$HOME/.code/working/jetbrains-inspection-api/red-lane-smoke"
@@ -32,7 +32,8 @@ This is a live IDE dogfood smoke, not a normal CI unit test.
 
 Options:
   --helper PATH              Path to jb-inspect.py.
-  --ide NAME                 IDE selector. Default: IntelliJ IDEA.
+  --product NAME             Fixture product: intellij, pycharm, webstorm. Default: intellij.
+  --ide NAME                 IDE selector. Defaults from --product.
   --timeout-ms MS            Helper wait timeout. Default: 180000.
   --prepare-timeout-ms MS    Helper prepare/open timeout. Default: 180000.
   --work-root PATH           Parent directory for disposable fixture copies.
@@ -40,9 +41,9 @@ Options:
   --keep-project             Leave the disposable fixture project on disk.
   -h, --help                 Show this help.
 
-The fixture intentionally contains unresolved Java symbols. A passing smoke means:
-IDE inspection produced actionable findings, the plugin captured them, and the
-helper reported VERDICT=RED.
+Each fixture intentionally contains a product-specific inspection finding. A
+passing smoke means IDE inspection produced actionable findings, the plugin
+captured them, and the helper reported VERDICT=RED.
 USAGE
 }
 
@@ -61,6 +62,11 @@ abs_path() {
 
 while [ $# -gt 0 ]; do
 	case "$1" in
+	--product)
+		[ $# -ge 2 ] || die "--product requires a value"
+		PRODUCT=$2
+		shift 2
+		;;
 	--helper)
 		[ $# -ge 2 ] || die "--helper requires a path"
 		HELPER=$2
@@ -105,6 +111,37 @@ while [ $# -gt 0 ]; do
 	esac
 done
 
+case "$PRODUCT" in
+intellij | idea)
+	PRODUCT="intellij"
+	FIXTURE="$ROOT/test-fixtures/inspection-red-lane"
+	PROJECT_SLUG="inspection-red-lane"
+	DEFAULT_IDE="IntelliJ IDEA"
+	REQUIRED_PROFILE_TOOLS=("UnusedDeclaration")
+	;;
+	pycharm | python)
+		PRODUCT="pycharm"
+		FIXTURE="$ROOT/test-fixtures/inspection-red-lane-pycharm"
+		PROJECT_SLUG="inspection-red-lane-pycharm"
+		DEFAULT_IDE="PyCharm"
+		REQUIRED_PROFILE_TOOLS=("PyStatementEffectInspection")
+		;;
+	webstorm | javascript | js)
+		PRODUCT="webstorm"
+		FIXTURE="$ROOT/test-fixtures/inspection-red-lane-webstorm"
+		PROJECT_SLUG="inspection-red-lane-webstorm"
+		DEFAULT_IDE="WebStorm"
+		REQUIRED_PROFILE_TOOLS=("JsonDuplicatePropertyKeys" "JsonStandardCompliance")
+		;;
+*)
+	die "unknown product: $PRODUCT"
+	;;
+esac
+
+if [ -z "$IDE" ]; then
+	IDE=$DEFAULT_IDE
+fi
+
 [ -x "$HELPER" ] || die "helper is not executable: $HELPER"
 [ -d "$FIXTURE" ] || die "fixture is missing: $FIXTURE"
 
@@ -112,11 +149,11 @@ WORK_ROOT=$(abs_path "$WORK_ROOT")
 mkdir -p "$WORK_ROOT"
 
 RUN_ID=$(date -u +%Y%m%dT%H%M%SZ)-$$
-PROJECT="$WORK_ROOT/inspection-red-lane-$RUN_ID"
-RAW_OUT="$WORK_ROOT/inspection-red-lane-$RUN_ID.raw.json"
-ERR_OUT="$WORK_ROOT/inspection-red-lane-$RUN_ID.stderr.txt"
-PAYLOAD_FILE="$WORK_ROOT/inspection-red-lane-$RUN_ID.payload.json"
-COMMAND_FILE="$WORK_ROOT/inspection-red-lane-$RUN_ID.command.json"
+PROJECT="$WORK_ROOT/$PROJECT_SLUG-$RUN_ID"
+RAW_OUT="$WORK_ROOT/$PROJECT_SLUG-$RUN_ID.raw.json"
+ERR_OUT="$WORK_ROOT/$PROJECT_SLUG-$RUN_ID.stderr.txt"
+PAYLOAD_FILE="$WORK_ROOT/$PROJECT_SLUG-$RUN_ID.payload.json"
+COMMAND_FILE="$WORK_ROOT/$PROJECT_SLUG-$RUN_ID.command.json"
 
 # shellcheck disable=SC2329
 cleanup() {
@@ -129,6 +166,13 @@ trap cleanup EXIT
 rm -rf "$PROJECT"
 mkdir -p "$PROJECT"
 cp -R "$FIXTURE"/. "$PROJECT"/
+
+PROFILE_FILE="$PROJECT/.idea/inspectionProfiles/RedLane.xml"
+[ -f "$PROFILE_FILE" ] || die "fixture profile is missing: $PROFILE_FILE"
+for tool in "${REQUIRED_PROFILE_TOOLS[@]}"; do
+	grep -q "class=\"$tool\"[^>]*enabled=\"true\"" "$PROFILE_FILE" || \
+		die "fixture profile does not enable required inspection tool: $tool"
+done
 
 CMD=(uv run "$HELPER" --json closeout --repo "$PROJECT" --ide "$IDE" --scope whole_project --profile RedLane --timeout-ms "$TIMEOUT_MS" --prepare-timeout-ms "$PREPARE_TIMEOUT_MS")
 jq -n '$ARGS.positional' --args -- "${CMD[@]}" >"$COMMAND_FILE"
@@ -160,6 +204,7 @@ REPORT=$(
 		--arg bucket "$BUCKET" \
 		--arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
 			--arg helper "$HELPER" \
+			--arg product "$PRODUCT" \
 			--arg ide "$IDE" \
 			--arg fixture "$FIXTURE" \
 			--arg project "$PROJECT" \
@@ -174,6 +219,7 @@ REPORT=$(
         bucket: $bucket,
         generated_at: $generated_at,
         helper: $helper,
+        product: $product,
         ide: $ide,
         fixture: $fixture,
         project: $project,

--- a/scripts/test-red-lane-smoke-script.sh
+++ b/scripts/test-red-lane-smoke-script.sh
@@ -5,16 +5,43 @@ set -euo pipefail
 ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 cd "$ROOT"
 
-FIXTURE_SOURCE="test-fixtures/inspection-red-lane/src/main/java/com/example/redlane/DefinitelyRed.java"
-FIXTURE_PROFILE="test-fixtures/inspection-red-lane/.idea/inspectionProfiles/RedLane.xml"
-
-grep -q 'INTENTIONAL RED-LANE FIXTURE' "$FIXTURE_SOURCE"
-grep -q 'MissingType value = MissingType.create();' "$FIXTURE_SOURCE"
-grep -q 'private void unusedMethod()' "$FIXTURE_SOURCE"
-grep -q 'JavaErrorInspection' "$FIXTURE_PROFILE"
-grep -q 'UnusedDeclaration' "$FIXTURE_PROFILE"
+grep -q -- '--product NAME' scripts/dogfood-red-lane-smoke.sh
+grep -q -- 'inspection-red-lane-pycharm' scripts/dogfood-red-lane-smoke.sh
+grep -q -- 'inspection-red-lane-webstorm' scripts/dogfood-red-lane-smoke.sh
 grep -q -- '--scope whole_project' scripts/dogfood-red-lane-smoke.sh
 grep -q -- '--profile RedLane' scripts/dogfood-red-lane-smoke.sh
+
+assert_fixture_intellij() {
+	local fixture_source="test-fixtures/inspection-red-lane/src/main/java/com/example/redlane/DefinitelyRed.java"
+	local fixture_profile="test-fixtures/inspection-red-lane/.idea/inspectionProfiles/RedLane.xml"
+
+	grep -q 'INTENTIONAL RED-LANE FIXTURE' "$fixture_source"
+	grep -q 'private String redLaneField' "$fixture_source"
+	grep -q 'redLaneField must stay non-final' "$fixture_source"
+	grep -q 'UnusedDeclaration' "$fixture_profile"
+}
+
+assert_fixture_pycharm() {
+	local fixture_source="test-fixtures/inspection-red-lane-pycharm/src/definitely_red.py"
+	local fixture_profile="test-fixtures/inspection-red-lane-pycharm/.idea/inspectionProfiles/RedLane.xml"
+
+	grep -q 'INTENTIONAL RED-LANE FIXTURE' "$fixture_source"
+	grep -q '1 + 1' "$fixture_source"
+	test -f test-fixtures/inspection-red-lane-pycharm/pyproject.toml
+	grep -q 'PyStatementEffectInspection' "$fixture_profile"
+}
+
+assert_fixture_webstorm() {
+	local fixture_source="test-fixtures/inspection-red-lane-webstorm/src/definitely-red.json"
+	local fixture_profile="test-fixtures/inspection-red-lane-webstorm/.idea/inspectionProfiles/RedLane.xml"
+
+	grep -q 'INTENTIONAL RED-LANE FIXTURE' "$fixture_source"
+	grep -q '"duplicate": "first"' "$fixture_source"
+	grep -q '"duplicate": "second"' "$fixture_source"
+	test -f test-fixtures/inspection-red-lane-webstorm/package.json
+	grep -q 'JsonDuplicatePropertyKeys' "$fixture_profile"
+	grep -q 'JsonStandardCompliance' "$fixture_profile"
+}
 
 TMP_DIR=$(mktemp -d)
 cleanup() {
@@ -30,15 +57,35 @@ import sys
 from pathlib import Path
 
 repo = ""
+ide = ""
 args = sys.argv[1:]
 while args:
     arg = args.pop(0)
     if arg == "--repo" and args:
         repo = args.pop(0)
+    elif arg == "--ide" and args:
+        ide = args.pop(0)
 
-fixture = Path(repo) / "src/main/java/com/example/redlane/DefinitelyRed.java"
-if not repo or not fixture.exists():
-    print(json.dumps({"status": "error", "error_reason": "missing_fixture"}))
+fixtures = [
+    ("IntelliJ IDEA", "src/main/java/com/example/redlane/DefinitelyRed.java", "redLaneField"),
+    ("PyCharm", "src/definitely_red.py", "1 + 1"),
+    ("WebStorm", "src/definitely-red.json", "duplicate"),
+]
+
+selected = None
+for expected_ide, rel_path, marker in fixtures:
+    path = Path(repo) / rel_path
+    if path.exists():
+        selected = (expected_ide, path, marker)
+        break
+
+if not repo or selected is None:
+    print(json.dumps({"status": "error", "error_reason": "missing_fixture", "repo": repo}))
+    sys.exit(3)
+
+expected_ide, fixture, marker = selected
+if ide != expected_ide:
+    print(json.dumps({"status": "error", "error_reason": "wrong_ide", "expected_ide": expected_ide, "actual_ide": ide}))
     sys.exit(3)
 
 print(json.dumps({
@@ -50,25 +97,45 @@ print(json.dumps({
     "problems_shown": 1,
     "clean": False,
     "cleanup": {"status": "closed"},
-    "route": {"base_path": repo, "project_name": "inspection-red-lane", "ide": {"name": "IntelliJ IDEA"}},
-    "problems": [{"severity": "error", "file": str(fixture), "line": 6, "description": "Cannot resolve symbol MissingType"}],
+    "route": {"base_path": repo, "project_name": Path(repo).name, "ide": {"name": ide}},
+    "problems": [{"severity": "error", "file": str(fixture), "line": 1, "description": f"Cannot resolve symbol {marker}"}],
 }))
 STUB
 chmod +x "$HELPER"
 
-JSON_OUT="$TMP_DIR/report.json"
-./scripts/dogfood-red-lane-smoke.sh \
-  --helper "$HELPER" \
-  --work-root "$TMP_DIR/work" \
-  --json-out "$JSON_OUT"
+run_case() {
+	local product=$1
+	local expected_ide=$2
+	local expected_marker=$3
+	local json_out="$TMP_DIR/$product-report.json"
 
-jq -e '
-  .status == "ok" and
-  .bucket == "red_confirmed" and
-  .verdict == "RED" and
-  .total_problems == 1 and
-  .cleanup.status == "closed" and
-  (.payload.problems[0].description | contains("MissingType"))
-' "$JSON_OUT" >/dev/null
+	./scripts/dogfood-red-lane-smoke.sh \
+		--product "$product" \
+		--helper "$HELPER" \
+		--work-root "$TMP_DIR/work" \
+		--json-out "$json_out"
+
+	jq -e \
+		--arg product "$product" \
+		--arg expected_ide "$expected_ide" \
+		--arg expected_marker "$expected_marker" '
+    .status == "ok" and
+    .bucket == "red_confirmed" and
+    .product == $product and
+    .ide == $expected_ide and
+    .verdict == "RED" and
+    .total_problems == 1 and
+    .cleanup.status == "closed" and
+    (.payload.problems[0].description | contains($expected_marker))
+  ' "$json_out" >/dev/null
+}
+
+assert_fixture_intellij
+assert_fixture_pycharm
+assert_fixture_webstorm
+
+run_case intellij "IntelliJ IDEA" redLaneField
+run_case pycharm PyCharm '1 + 1'
+run_case webstorm WebStorm duplicate
 
 echo "red-lane smoke script contract passed"

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -82,6 +82,7 @@ internal enum class CaptureIncompleteReason(val apiValue: String) {
     EXTRACTOR_FAILURE("extractor_failure"),
     NON_EMPTY_UNMAPPED_TREE("non_empty_unmapped_tree"),
     CURRENT_RUN_PSI_CHURN("current_run_psi_churn"),
+    INSPECTION_TRIGGER_EMPTY_MODEL("inspection_trigger_empty_model"),
     TIMEOUT("timeout"),
     HELPER_PLUGIN_ERROR("helper_plugin_error"),
     UNKNOWN("unknown"),
@@ -296,7 +297,13 @@ internal fun classifyEmptyInspectionCapture(
     observedStableEmptyResultsWithoutInspectionView: Boolean,
     observedModelCleanInspection: Boolean = false,
     observedNonEmptyInspectionTree: Boolean,
+    suspiciousEmptyModelReason: String? = null,
 ): Pair<InspectionSnapshotOutcome, String?> {
+    if (!suspiciousEmptyModelReason.isNullOrBlank()) {
+        return InspectionSnapshotOutcome.CAPTURE_INCOMPLETE to
+            "Inspection finished with an empty model in a proof lane where findings were expected. Treat this as an IDE/plugin/helper issue, not a clean result."
+    }
+
     if (
         viewReadyOk &&
             !observedNonEmptyInspectionTree &&
@@ -313,62 +320,28 @@ internal fun classifyEmptyInspectionCapture(
         "Inspection finished, but the plugin could not conclusively confirm that the IDE results were empty. Re-run the inspection or open the Inspection Results/Problems tool window."
 }
 
-internal fun buildUnmappedInspectionFallbackProblems(
-    project: Project,
-    captureScope: InspectionCaptureScope,
-    diagnostic: Map<String, Any?>?,
-): List<Map<String, Any>> {
-    val observedNonEmptyTree = diagnostic?.get("observed_non_empty_inspection_tree") as? Boolean ?: false
-    val descriptorCount = (diagnostic?.get("model_problem_descriptor_count") as? Number)?.toInt() ?: 0
-    if (!observedNonEmptyTree && descriptorCount <= 0) {
-        return emptyList()
+internal fun suspiciousEmptyInspectionModelReason(
+    ideProductCode: String?,
+    requestedProfileName: String?,
+    modelVerdict: InspectionModelVerdict,
+    problemDescriptorCount: Int,
+    bestResultsEmpty: Boolean,
+    observedNonEmptyInspectionTree: Boolean,
+): String? {
+    val isWebStorm = ideProductCode.equals("WS", ignoreCase = true)
+    val isRedLaneProof = requestedProfileName.equals("RedLane", ignoreCase = true)
+    return if (
+        isWebStorm &&
+            isRedLaneProof &&
+            bestResultsEmpty &&
+            !observedNonEmptyInspectionTree &&
+            modelVerdict == InspectionModelVerdict.CLEAN &&
+            problemDescriptorCount == 0
+    ) {
+        CaptureIncompleteReason.INSPECTION_TRIGGER_EMPTY_MODEL.apiValue
+    } else {
+        null
     }
-
-    val basePath = normalizeFileSystemPath(project.basePath)
-    fun resolvePath(raw: String?): String? {
-        val trimmed = raw?.trim()?.takeIf { it.isNotEmpty() } ?: return null
-        return try {
-            val path = Paths.get(trimmed)
-            normalizeFileSystemPath(
-                if (path.isAbsolute || basePath == null) trimmed else Paths.get(basePath, trimmed).toString()
-            )
-        } catch (_: Exception) {
-            null
-        }
-    }
-
-    fun singleFileTarget(): String? {
-        captureScope.resolvedCurrentFile?.let(::resolvePath)?.let { return it }
-        val files = captureScope.files.orEmpty().mapNotNull(::resolvePath).distinct()
-        if (files.size == 1) return files.single()
-        val directoryTarget = resolvePath(captureScope.directoryParam)
-        if (directoryTarget != null) return directoryTarget
-        return basePath
-    }
-
-    val target = singleFileTarget() ?: "unknown"
-    val rootChildCount = (diagnostic?.get("last_view_observation") as? Map<*, *>)
-        ?.get("root_child_count") as? Number
-    val evidence = buildList {
-        if (observedNonEmptyTree) add("Inspection Results reported a non-empty problem tree")
-        if (descriptorCount > 0) add("$descriptorCount descriptor(s) were present but unmapped")
-        rootChildCount?.let { add("root child count: ${it.toInt()}") }
-    }.joinToString("; ").ifBlank { "Inspection Results reported unmapped problems" }
-
-    return listOf(
-        mapOf(
-            "description" to "Inspection Results contains unmapped problems for the requested scope. $evidence.",
-            "file" to target,
-            "line" to 0,
-            "column" to 0,
-            "severity" to "error",
-            "category" to "Inspection capture",
-            "inspectionType" to "UnmappedInspectionTree",
-            "source" to "unmapped_inspection_tree_fallback",
-            "locationKnown" to false,
-            "locationNote" to "The IDE reported problems, but the plugin could not map the tree rows to exact source locations.",
-        )
-    )
 }
 
 internal fun isSettledCleanInspectionView(observation: InspectionViewObservation): Boolean {
@@ -621,6 +594,32 @@ internal fun shouldTreatScopedEmptyExtractionAsSucceeded(
         (observedTransientEmptyInspectionViewEvidence && lastToolExtractionSucceeded)
 }
 
+internal fun shouldTreatNonEmptyInspectionTreeAsStaleCleanEvidence(
+    observedNonEmptyInspectionTree: Boolean,
+    modelExtractionClean: Boolean,
+    modelProblemDescriptorCount: Int,
+    bestResultsEmpty: Boolean,
+    extractionFailureCount: Int,
+    lastExtractionCycleSucceeded: Boolean,
+    lastToolExtractionSucceeded: Boolean,
+    inspectionViewUpdating: Boolean,
+    stableForMs: Long,
+    pollingElapsedMs: Long,
+    minStableMs: Long = 5000L,
+    minPollingMs: Long = 30000L,
+): Boolean {
+    return observedNonEmptyInspectionTree &&
+        modelExtractionClean &&
+        modelProblemDescriptorCount == 0 &&
+        bestResultsEmpty &&
+        extractionFailureCount == 0 &&
+        lastExtractionCycleSucceeded &&
+        lastToolExtractionSucceeded &&
+        !inspectionViewUpdating &&
+        stableForMs >= minStableMs &&
+        pollingElapsedMs >= minPollingMs
+}
+
 internal fun classifyCaptureIncompleteReason(
     captureDiagnostic: Map<String, Any?>?,
     snapshotChangeKind: String? = null,
@@ -646,6 +645,8 @@ internal fun classifyCaptureIncompleteReason(
 
     return when {
         exitReason == "helper_plugin_error" -> CaptureIncompleteReason.HELPER_PLUGIN_ERROR
+        exitReason == CaptureIncompleteReason.INSPECTION_TRIGGER_EMPTY_MODEL.apiValue ->
+            CaptureIncompleteReason.INSPECTION_TRIGGER_EMPTY_MODEL
         observedNonEmptyInspectionTree == true -> CaptureIncompleteReason.NON_EMPTY_UNMAPPED_TREE
         inspectionViewUpdating == true &&
             (unreadableProblemStateObservationCount > 0 || nullRootChildObservationCount > 0) ->
@@ -826,7 +827,7 @@ class InspectionHandler : HttpRequestHandler() {
     }
 
     private fun unknownVerdictNextAction(reason: String, payload: Map<String, Any?>): String {
-        if (reason in setOf("non_empty_unmapped_tree", "extractor_failure", "helper_plugin_error")) {
+        if (reason in setOf("non_empty_unmapped_tree", "extractor_failure", "helper_plugin_error", "inspection_trigger_empty_model")) {
             return "Treat this as a plugin/helper bug: include capture_diagnostic, update the plugin or helper, and rerun."
         }
         val diagnostic = payload["capture_diagnostic"] as? Map<*, *>
@@ -2406,6 +2407,51 @@ class InspectionHandler : HttpRequestHandler() {
             
             syncProjectState(project)
 
+            val profileManager = com.intellij.profile.codeInspection.InspectionProjectProfileManager.getInstance(project)
+            val requestedProfileName = profileName?.trim()?.takeIf { it.isNotEmpty() }
+            val profileNames = try {
+                profileManager.profiles.map { it.name }.sorted()
+            } catch (_: Exception) {
+                null
+            }
+            val requestedProfileMissing = requestedProfileName != null &&
+                profileNames != null &&
+                requestedProfileName !in profileNames
+            val requestedProfileUnverified = requestedProfileName != null && profileNames == null
+            if (requestedProfileMissing || requestedProfileUnverified) {
+                val exitReason = if (requestedProfileMissing) "profile_missing" else "profile_list_unreadable"
+                val note = if (requestedProfileMissing) {
+                    "Requested inspection profile '$requestedProfileName' was not found."
+                } else {
+                    "Requested inspection profile '$requestedProfileName' could not be verified."
+                }
+                resultsStore.setSnapshot(
+                    key,
+                    InspectionResultsSnapshot(
+                        problems = emptyList(),
+                        timestamp = System.currentTimeMillis(),
+                        projectState = captureProjectState(project),
+                        outcome = InspectionSnapshotOutcome.CAPTURE_INCOMPLETE,
+                        source = "profile_resolution",
+                        note = note,
+                        captureScope = captureScope,
+                        captureDiagnostic = mapOf(
+                            "profile_requested" to requestedProfileName,
+                            "profile_missing" to requestedProfileMissing,
+                            "profile_unverified" to requestedProfileUnverified,
+                            "profile_list_readable" to (profileNames != null),
+                            "profile_available_names" to profileNames?.take(25),
+                            "profile_source" to "request",
+                            "exit_reason" to exitReason,
+                        ).filterValues { it != null },
+                        captureIncompleteReason = CaptureIncompleteReason.HELPER_PLUGIN_ERROR,
+                        runId = runId,
+                        triggerTimeMs = inspectionRunStatesByProject[key]?.triggerTimeMs,
+                    )
+                )
+                return
+            }
+
             val changedFilesScopeFiles = if (scopeParam?.lowercase()?.trim() == "changed_files") {
                 resolveChangedFilesScopeFiles(
                     project = project,
@@ -2457,14 +2503,28 @@ class InspectionHandler : HttpRequestHandler() {
                 resolvedChangedFiles = changedFilesScopeFiles,
             )
             
-            @Suppress("USELESS_CAST")
-            val inspectionManager = InspectionManager.getInstance(project) as com.intellij.codeInspection.ex.InspectionManagerEx
-            val profileManager = com.intellij.profile.codeInspection.InspectionProjectProfileManager.getInstance(project)
-            val profile = if (!profileName.isNullOrBlank()) {
-                profileManager.getProfile(profileName)
+            val profile = if (requestedProfileName != null) {
+                profileManager.getProfile(requestedProfileName)
             } else {
                 profileManager.currentProfile
             }
+            val resolvedProfileName = try {
+                profile.name
+            } catch (_: Exception) {
+                null
+            }
+            val profileDiagnostic = mapOf(
+                "profile_requested" to requestedProfileName,
+                "profile_resolved_name" to resolvedProfileName,
+                "profile_missing" to false,
+                "profile_unverified" to false,
+                "profile_list_readable" to (profileNames != null),
+                "profile_available_names" to profileNames?.take(25),
+                "profile_source" to if (requestedProfileName != null) "request" else "current",
+            ).filterValues { it != null }
+
+            @Suppress("USELESS_CAST")
+            val inspectionManager = InspectionManager.getInstance(project) as com.intellij.codeInspection.ex.InspectionManagerEx
             
             @Suppress("UnstableApiUsage", "USELESS_CAST")
             val globalContext = inspectionManager.createNewGlobalContext() as com.intellij.codeInspection.ex.GlobalInspectionContextImpl
@@ -2529,6 +2589,7 @@ class InspectionHandler : HttpRequestHandler() {
                         var observedOpaqueSettledEmptyInspectionView = false
                         var observedModelCleanInspection = false
                         var observedNonEmptyInspectionTree = false
+                        var observedStaleNonEmptyInspectionTree = false
                         var observedTransientEmptyInspectionViewEvidence = false
                         var inspectionViewUpdating = false
                         var lastViewObservation: InspectionViewObservation? = null
@@ -2779,6 +2840,25 @@ class InspectionHandler : HttpRequestHandler() {
                             val stableForMs = loopNow - lastChangeMs
                             val pollingElapsedMs = loopNow - captureStartMs
                             if (
+                                !observedStaleNonEmptyInspectionTree &&
+                                shouldTreatNonEmptyInspectionTreeAsStaleCleanEvidence(
+                                    observedNonEmptyInspectionTree = observedNonEmptyInspectionTree,
+                                    modelExtractionClean = modelExtractionClean,
+                                    modelProblemDescriptorCount = contextExtraction.problemDescriptorCount,
+                                    bestResultsEmpty = bestResults.isEmpty(),
+                                    extractionFailureCount = extractionFailureCount,
+                                    lastExtractionCycleSucceeded = lastExtractionCycleSucceeded,
+                                    lastToolExtractionSucceeded = lastToolExtractionSucceeded,
+                                    inspectionViewUpdating = inspectionViewUpdating,
+                                    stableForMs = stableForMs,
+                                    pollingElapsedMs = pollingElapsedMs,
+                                )
+                            ) {
+                                observedStaleNonEmptyInspectionTree = true
+                            }
+                            val effectiveObservedNonEmptyInspectionTree =
+                                observedNonEmptyInspectionTree && !observedStaleNonEmptyInspectionTree
+                            if (
                                 !observedStableReadableEmptyInspectionView &&
                                 shouldPromoteStableReadableEmptyInspectionView(
                                     readableEmptyInspectionViewStableSince = readableEmptyInspectionViewStableSince,
@@ -2810,7 +2890,7 @@ class InspectionHandler : HttpRequestHandler() {
                                     ),
                                     scopedContextResultsEmpty = scopedContextResults.isEmpty(),
                                     bestResultsEmpty = bestResults.isEmpty(),
-                                    observedNonEmptyInspectionTree = observedNonEmptyInspectionTree,
+                                    observedNonEmptyInspectionTree = effectiveObservedNonEmptyInspectionTree,
                                     stableForMs = stableForMs,
                                     pollingElapsedMs = pollingElapsedMs,
                                 )
@@ -2821,9 +2901,9 @@ class InspectionHandler : HttpRequestHandler() {
                                 !observedModelCleanInspection &&
                                 modelExtractionClean &&
                                 viewReadyOk &&
-                                lastViewObservation?.hasProblems != true &&
+                                (lastViewObservation?.hasProblems != true || observedStaleNonEmptyInspectionTree) &&
                                 bestResults.isEmpty() &&
-                                !observedNonEmptyInspectionTree &&
+                                !effectiveObservedNonEmptyInspectionTree &&
                                 stableForMs >= 5000L &&
                                 pollingElapsedMs >= 30000L
                             ) {
@@ -2857,6 +2937,25 @@ class InspectionHandler : HttpRequestHandler() {
                         }
 
                         if (
+                            !observedStaleNonEmptyInspectionTree &&
+                            shouldTreatNonEmptyInspectionTreeAsStaleCleanEvidence(
+                                observedNonEmptyInspectionTree = observedNonEmptyInspectionTree,
+                                modelExtractionClean = modelExtractionClean,
+                                modelProblemDescriptorCount = contextExtraction.problemDescriptorCount,
+                                bestResultsEmpty = bestResults.isEmpty(),
+                                extractionFailureCount = extractionFailureCount,
+                                lastExtractionCycleSucceeded = lastExtractionCycleSucceeded,
+                                lastToolExtractionSucceeded = lastToolExtractionSucceeded,
+                                inspectionViewUpdating = inspectionViewUpdating,
+                                stableForMs = System.currentTimeMillis() - lastChangeMs,
+                                pollingElapsedMs = System.currentTimeMillis() - captureStartMs,
+                            )
+                        ) {
+                            observedStaleNonEmptyInspectionTree = true
+                        }
+                        val effectiveObservedNonEmptyInspectionTree =
+                            observedNonEmptyInspectionTree && !observedStaleNonEmptyInspectionTree
+                        if (
                             !observedStableEmptyResultsWithoutInspectionView &&
                             shouldTrustStableScopedEmptyResults(
                                 viewReadyOk = viewReadyOk,
@@ -2875,7 +2974,7 @@ class InspectionHandler : HttpRequestHandler() {
                                 ),
                                 scopedContextResultsEmpty = scopedContextResults.isEmpty(),
                                 bestResultsEmpty = bestResults.isEmpty(),
-                                observedNonEmptyInspectionTree = observedNonEmptyInspectionTree,
+                                observedNonEmptyInspectionTree = effectiveObservedNonEmptyInspectionTree,
                                 stableForMs = System.currentTimeMillis() - lastChangeMs,
                                 pollingElapsedMs = System.currentTimeMillis() - captureStartMs,
                             )
@@ -2888,9 +2987,9 @@ class InspectionHandler : HttpRequestHandler() {
                             !observedModelCleanInspection &&
                             modelExtractionClean &&
                             viewReadyOk &&
-                            lastViewObservation?.hasProblems != true &&
+                            (lastViewObservation?.hasProblems != true || observedStaleNonEmptyInspectionTree) &&
                             bestResults.isEmpty() &&
-                            !observedNonEmptyInspectionTree &&
+                            !effectiveObservedNonEmptyInspectionTree &&
                             finalStableForMs >= 5000L &&
                             finalPollingElapsedMs >= 30000L
                         ) {
@@ -2898,7 +2997,16 @@ class InspectionHandler : HttpRequestHandler() {
                         }
 
                         syncProjectState(project)
-                        val snapshotState = captureProjectState(project)
+                        val snapshotState = captureStableProjectState(project)
+                        val ideProductCode = safeInspectionIdentity()["ide_product_code"] as? String
+                        val suspiciousEmptyModelReason = suspiciousEmptyInspectionModelReason(
+                            ideProductCode = ideProductCode,
+                            requestedProfileName = requestedProfileName,
+                            modelVerdict = modelVerdict,
+                            problemDescriptorCount = contextExtraction.problemDescriptorCount,
+                            bestResultsEmpty = bestResults.isEmpty(),
+                            observedNonEmptyInspectionTree = effectiveObservedNonEmptyInspectionTree,
+                        )
                         val (emptyOutcome, emptyNote) = classifyEmptyInspectionCapture(
                             viewReadyOk = viewReadyOk,
                             observedInspectionView = observedInspectionView,
@@ -2906,7 +3014,8 @@ class InspectionHandler : HttpRequestHandler() {
                             observedStableReadableEmptyInspectionView = observedStableReadableEmptyInspectionView,
                             observedStableEmptyResultsWithoutInspectionView = observedStableEmptyResultsWithoutInspectionView,
                             observedModelCleanInspection = observedModelCleanInspection,
-                            observedNonEmptyInspectionTree = observedNonEmptyInspectionTree,
+                            observedNonEmptyInspectionTree = effectiveObservedNonEmptyInspectionTree,
+                            suspiciousEmptyModelReason = suspiciousEmptyModelReason,
                         )
                         val captureEndMs = System.currentTimeMillis()
                         val captureDiagnostic = if (bestResults.isEmpty()) {
@@ -2914,7 +3023,15 @@ class InspectionHandler : HttpRequestHandler() {
                             val stableForMs = captureEndMs - lastChangeMs
                             val readableStableForMs = readableEmptyInspectionViewStableSince?.let { captureEndMs - it } ?: 0L
                             mapOf(
-                                "exit_reason" to captureExitReason,
+                                "profile_requested" to requestedProfileName,
+                                "profile_resolved_name" to resolvedProfileName,
+                                "profile_missing" to false,
+                                "profile_list_readable" to (profileNames != null),
+                                "profile_available_names" to profileNames?.take(25),
+                                "profile_source" to if (requestedProfileName != null) "request" else "current",
+                                "exit_reason" to (suspiciousEmptyModelReason ?: captureExitReason),
+                                "ide_product_code" to ideProductCode,
+                                "suspicious_empty_model" to (suspiciousEmptyModelReason != null),
                                 "polling_elapsed_ms" to (captureEndMs - captureStartMs),
                                 "stable_for_ms" to stableForMs,
                                 "has_scoped_matcher" to (scopeProblemMatcher != null),
@@ -2932,7 +3049,9 @@ class InspectionHandler : HttpRequestHandler() {
                                 "model_readable_tool_count" to contextExtraction.readableToolCount,
                                 "model_unreadable_tool_count" to contextExtraction.unreadableToolCount,
                                 "model_unreadable_reasons" to contextExtraction.unreadableReasons,
-                                "observed_non_empty_inspection_tree" to observedNonEmptyInspectionTree,
+                                "observed_non_empty_inspection_tree" to effectiveObservedNonEmptyInspectionTree,
+                                "observed_raw_non_empty_inspection_tree" to observedNonEmptyInspectionTree,
+                                "observed_stale_non_empty_inspection_tree" to observedStaleNonEmptyInspectionTree,
                                 "inspection_view_updating" to inspectionViewUpdating,
                                 "inspection_view_observation_count" to inspectionViewObservationCount,
                                 "readable_empty_inspection_view_observation_count" to readableEmptyInspectionViewObservationCount,
@@ -2959,13 +3078,6 @@ class InspectionHandler : HttpRequestHandler() {
                             null
                         }
                         val captureIncompleteReason = classifyCaptureIncompleteReason(captureDiagnostic)
-                        val unmappedFallbackResults = if (
-                            bestResults.isEmpty() && emptyOutcome != InspectionSnapshotOutcome.CLEAN_CONFIRMED
-                        ) {
-                            buildUnmappedInspectionFallbackProblems(project, captureScope, captureDiagnostic)
-                        } else {
-                            emptyList()
-                        }
                         val snapshot = when {
                             bestResults.isNotEmpty() -> InspectionResultsSnapshot(
                                 problems = bestResults,
@@ -2974,18 +3086,6 @@ class InspectionHandler : HttpRequestHandler() {
                                 outcome = InspectionSnapshotOutcome.PROBLEMS_FOUND,
                                 source = bestSource,
                                 captureScope = captureScope,
-                                runId = runId,
-                                triggerTimeMs = inspectionRunStatesByProject[key]?.triggerTimeMs,
-                            )
-                            unmappedFallbackResults.isNotEmpty() -> InspectionResultsSnapshot(
-                                problems = unmappedFallbackResults,
-                                timestamp = System.currentTimeMillis(),
-                                projectState = snapshotState,
-                                outcome = InspectionSnapshotOutcome.PROBLEMS_FOUND,
-                                source = "unmapped_inspection_tree_fallback",
-                                note = emptyNote,
-                                captureScope = captureScope,
-                                captureDiagnostic = captureDiagnostic,
                                 runId = runId,
                                 triggerTimeMs = inspectionRunStatesByProject[key]?.triggerTimeMs,
                             )
@@ -3211,6 +3311,19 @@ class InspectionHandler : HttpRequestHandler() {
             psiModificationCount = PsiModificationTracker.getInstance(project).modificationCount,
             unsavedProjectDocuments = countProjectUnsavedDocuments(project)
         )
+    }
+
+    private fun captureStableProjectState(project: Project): InspectionProjectStateSnapshot {
+        var previous = captureProjectState(project)
+        repeat(10) {
+            Thread.sleep(75)
+            val current = captureProjectState(project)
+            if (current == previous) {
+                return current
+            }
+            previous = current
+        }
+        return previous
     }
 
     private fun resolveSnapshotStaleness(project: Project, snapshot: InspectionResultsSnapshot?): SnapshotStaleness {

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -178,6 +178,106 @@ class InspectionHandlerTest {
         assertEquals(false, status["results_may_be_stale"])
         assertEquals(0, status["total_problems"])
     }
+
+    @Test
+    fun `test explicit missing inspection profile publishes capture incomplete snapshot`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        every { mockApplication.isDispatchThread } returns true
+        every { mockVirtualFileManager.syncRefresh() } returns 0L
+        every { mockProfileManager.profiles } returns emptyList()
+        every { mockProfileManager.getProfile("RedLane") } returns mockProfile
+        every { mockApplication.executeOnPooledThread(any<Runnable>()) } answers {
+            firstArg<Runnable>().run()
+            mockk(relaxed = true)
+        }
+        mockInspectionPrerequisites(mockProject)
+
+        val response = processTriggerRequest("/api/inspection/trigger?profile=RedLane")
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"profile\": \"RedLane\""))
+        verify(exactly = 0) { mockProfileManager.getProfile("RedLane") }
+        verify(exactly = 0) { mockInspectionManager.createNewGlobalContext() }
+        val status = buildInspectionStatus()
+        assertEquals("capture_incomplete", status["snapshot_outcome"])
+        assertEquals("profile_resolution", status["results_source"])
+        assertEquals(true, status["capture_incomplete"])
+        assertEquals("helper_plugin_error", status["capture_incomplete_reason"])
+        assertEquals("UNKNOWN", status["inspection_verdict"])
+        assertEquals("helper_plugin_error", status["inspection_verdict_reason"])
+        @Suppress("UNCHECKED_CAST")
+        val diagnostic = status["capture_diagnostic"] as Map<String, Any?>
+        assertEquals("RedLane", diagnostic["profile_requested"])
+        assertEquals(true, diagnostic["profile_missing"])
+        assertEquals("profile_missing", diagnostic["exit_reason"])
+    }
+
+    @Test
+    fun `test explicit missing inspection profile is checked before empty changed files shortcut`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        every { mockApplication.isDispatchThread } returns true
+        every { mockVirtualFileManager.syncRefresh() } returns 0L
+        every { mockProfileManager.profiles } returns emptyList()
+        every { mockApplication.executeOnPooledThread(any<Runnable>()) } answers {
+            firstArg<Runnable>().run()
+            mockk(relaxed = true)
+        }
+        mockInspectionPrerequisites(mockProject)
+
+        val response = processTriggerRequest("/api/inspection/trigger?scope=changed_files&include_unversioned=false&profile=RedLane")
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"scope\": \"changed_files\""))
+        assertTrue(body.contains("\"profile\": \"RedLane\""))
+        verify(exactly = 0) { mockInspectionManager.createNewGlobalContext() }
+        val status = buildInspectionStatus()
+        assertEquals("capture_incomplete", status["snapshot_outcome"])
+        assertEquals("profile_resolution", status["results_source"])
+        assertEquals(true, status["capture_incomplete"])
+        assertEquals("UNKNOWN", status["inspection_verdict"])
+        assertEquals("helper_plugin_error", status["inspection_verdict_reason"])
+        @Suppress("UNCHECKED_CAST")
+        val diagnostic = status["capture_diagnostic"] as Map<String, Any?>
+        assertEquals("RedLane", diagnostic["profile_requested"])
+        assertEquals(true, diagnostic["profile_missing"])
+        assertEquals("profile_missing", diagnostic["exit_reason"])
+    }
+
+    @Test
+    fun `test explicit inspection profile with unreadable profile list is unknown`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        every { mockApplication.isDispatchThread } returns true
+        every { mockVirtualFileManager.syncRefresh() } returns 0L
+        every { mockProfileManager.profiles } throws IllegalStateException("profiles unavailable")
+        every { mockApplication.executeOnPooledThread(any<Runnable>()) } answers {
+            firstArg<Runnable>().run()
+            mockk(relaxed = true)
+        }
+        mockInspectionPrerequisites(mockProject)
+
+        val response = processTriggerRequest("/api/inspection/trigger?profile=RedLane")
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"profile\": \"RedLane\""))
+        verify(exactly = 0) { mockInspectionManager.createNewGlobalContext() }
+        val status = buildInspectionStatus()
+        assertEquals("capture_incomplete", status["snapshot_outcome"])
+        assertEquals("profile_resolution", status["results_source"])
+        assertEquals("UNKNOWN", status["inspection_verdict"])
+        assertEquals("helper_plugin_error", status["inspection_verdict_reason"])
+        @Suppress("UNCHECKED_CAST")
+        val diagnostic = status["capture_diagnostic"] as Map<String, Any?>
+        assertEquals("RedLane", diagnostic["profile_requested"])
+        assertEquals(true, diagnostic["profile_unverified"])
+        assertEquals(false, diagnostic["profile_list_readable"])
+        assertEquals("profile_list_unreadable", diagnostic["exit_reason"])
+    }
     
     @Test
     fun `test isSupported returns true for inspection endpoints`() {

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
@@ -760,6 +760,78 @@ class InspectionSnapshotStateTest {
     }
 
     @Test
+    @DisplayName("Wait does not trust same-run global context findings after PSI churn without live confirmation")
+    fun testWaitDoesNotTrustSameRunGlobalContextFindingsAfterPsiChurnWithoutLiveConfirmation() {
+        val extractor = mockk<EnhancedTreeExtractor>()
+        val currentRun = beginInspectionRun()
+        finishInspectionRun(snapshotKey(), currentRun.runId)
+        setLastInspectionTriggerTime(System.currentTimeMillis() - 16000L)
+        every { extractor.extractAllProblems(mockProject) } returns emptyList()
+        enhancedTreeExtractorFactory = { extractor }
+        val problems = listOf(staleProblem(description = "Model warning"))
+        InspectionResultsStore.setSnapshot(
+            snapshotKey(),
+            InspectionResultsSnapshot(
+                problems = problems,
+                timestamp = System.currentTimeMillis() - 16000L,
+                projectState = InspectionProjectStateSnapshot(psiModificationCount = 7L, unsavedProjectDocuments = 0),
+                outcome = InspectionSnapshotOutcome.PROBLEMS_FOUND,
+                source = "global_context",
+                runId = currentRun.runId,
+                triggerTimeMs = currentRun.triggerTimeMs,
+            ),
+        )
+        every { PsiModificationTracker.getInstance(mockProject).modificationCount } returns 8L
+
+        val response = waitForInspection(timeoutMs = 7000L, pollMs = 200L)
+        val status = buildInspectionStatus()
+
+        assertTrue(response.contains("\"completion_reason\": \"stale_results\""))
+        assertFalse(response.contains("\"completion_reason\": \"results\""))
+        assertTrue(response.contains("\"results_may_be_stale\": true"))
+        assertTrue(response.contains("\"cached_total_problems\": 1"))
+        assertEquals(true, status["results_may_be_stale"])
+        assertEquals("project_changed_since_inspection", status["snapshot_change_kind"])
+        assertEquals(7L, InspectionResultsStore.getProjectState(snapshotKey())?.psiModificationCount)
+        assertEquals(currentRun.runId, InspectionResultsStore.getRunId(snapshotKey()))
+    }
+
+    @Test
+    @DisplayName("Wait reconciles same-run global context findings when live findings still match")
+    fun testWaitReconcilesSameRunGlobalContextFindingsWithLiveConfirmation() {
+        val extractor = mockk<EnhancedTreeExtractor>()
+        val currentRun = beginInspectionRun()
+        finishInspectionRun(snapshotKey(), currentRun.runId)
+        setLastInspectionTriggerTime(System.currentTimeMillis() - 16000L)
+        val problems = listOf(staleProblem(description = "Model warning"))
+        every { extractor.extractAllProblems(mockProject) } returns problems
+        enhancedTreeExtractorFactory = { extractor }
+        InspectionResultsStore.setSnapshot(
+            snapshotKey(),
+            InspectionResultsSnapshot(
+                problems = problems,
+                timestamp = System.currentTimeMillis() - 16000L,
+                projectState = InspectionProjectStateSnapshot(psiModificationCount = 7L, unsavedProjectDocuments = 0),
+                outcome = InspectionSnapshotOutcome.PROBLEMS_FOUND,
+                source = "global_context",
+                runId = currentRun.runId,
+                triggerTimeMs = currentRun.triggerTimeMs,
+            ),
+        )
+        every { PsiModificationTracker.getInstance(mockProject).modificationCount } returns 8L
+
+        val response = waitForInspection(timeoutMs = 7000L, pollMs = 200L)
+        val status = buildInspectionStatus()
+
+        assertTrue(response.contains("\"completion_reason\": \"results\""))
+        assertFalse(response.contains("\"completion_reason\": \"stale_results\""))
+        assertEquals(false, status["results_may_be_stale"])
+        assertEquals("fresh", status["snapshot_change_kind"])
+        assertEquals(8L, InspectionResultsStore.getProjectState(snapshotKey())?.psiModificationCount)
+        assertEquals(currentRun.runId, InspectionResultsStore.getRunId(snapshotKey()))
+    }
+
+    @Test
     @DisplayName("Status distinguishes unreconciled current-run PSI churn")
     fun testStatusReportsCurrentRunPsiChurnWhenReconcileCannotConfirm() {
         val extractor = mockk<EnhancedTreeExtractor>()
@@ -1255,6 +1327,20 @@ class InspectionSnapshotStateTest {
 
         assertEquals(InspectionSnapshotOutcome.CAPTURE_INCOMPLETE, nonEmptyTree.first)
 
+        val suspiciousEmptyModel = classifyEmptyInspectionCapture(
+            viewReadyOk = true,
+            observedInspectionView = true,
+            observedSettledEmptyInspectionView = true,
+            observedStableReadableEmptyInspectionView = false,
+            observedStableEmptyResultsWithoutInspectionView = false,
+            observedModelCleanInspection = true,
+            observedNonEmptyInspectionTree = false,
+            suspiciousEmptyModelReason = CaptureIncompleteReason.INSPECTION_TRIGGER_EMPTY_MODEL.apiValue,
+        )
+
+        assertEquals(InspectionSnapshotOutcome.CAPTURE_INCOMPLETE, suspiciousEmptyModel.first)
+        assertTrue(suspiciousEmptyModel.second?.contains("empty model") == true)
+
         val stableReadableEmptyView = classifyEmptyInspectionCapture(
             viewReadyOk = true,
             observedInspectionView = true,
@@ -1325,6 +1411,81 @@ class InspectionSnapshotStateTest {
         )
 
         assertEquals(InspectionSnapshotOutcome.CAPTURE_INCOMPLETE, stillUnreadableView.first)
+    }
+
+    @Test
+    @DisplayName("Suspicious WebStorm RedLane empty model is not treated as clean")
+    fun testSuspiciousWebStormRedLaneEmptyModelReason() {
+        assertEquals(
+            CaptureIncompleteReason.INSPECTION_TRIGGER_EMPTY_MODEL.apiValue,
+            suspiciousEmptyInspectionModelReason(
+                ideProductCode = "WS",
+                requestedProfileName = "RedLane",
+                modelVerdict = InspectionModelVerdict.CLEAN,
+                problemDescriptorCount = 0,
+                bestResultsEmpty = true,
+                observedNonEmptyInspectionTree = false,
+            ),
+        )
+
+        assertEquals(
+            null,
+            suspiciousEmptyInspectionModelReason(
+                ideProductCode = "IU",
+                requestedProfileName = "RedLane",
+                modelVerdict = InspectionModelVerdict.CLEAN,
+                problemDescriptorCount = 0,
+                bestResultsEmpty = true,
+                observedNonEmptyInspectionTree = false,
+            ),
+        )
+
+        assertEquals(
+            null,
+            suspiciousEmptyInspectionModelReason(
+                ideProductCode = "WS",
+                requestedProfileName = "Default",
+                modelVerdict = InspectionModelVerdict.CLEAN,
+                problemDescriptorCount = 0,
+                bestResultsEmpty = true,
+                observedNonEmptyInspectionTree = false,
+            ),
+        )
+
+        assertEquals(
+            CaptureIncompleteReason.INSPECTION_TRIGGER_EMPTY_MODEL,
+            classifyCaptureIncompleteReason(
+                mapOf("exit_reason" to CaptureIncompleteReason.INSPECTION_TRIGGER_EMPTY_MODEL.apiValue),
+            ),
+        )
+    }
+
+    @Test
+    @DisplayName("Suspicious empty model verdict tells agents to report a plugin bug")
+    fun testSuspiciousEmptyModelNextActionReportsPluginBug() {
+        InspectionResultsStore.setSnapshot(
+            snapshotKey(),
+            InspectionResultsSnapshot(
+                problems = emptyList(),
+                timestamp = System.currentTimeMillis(),
+                projectState = InspectionProjectStateSnapshot(psiModificationCount = 7L, unsavedProjectDocuments = 0),
+                outcome = InspectionSnapshotOutcome.CAPTURE_INCOMPLETE,
+                source = "inspection_view",
+                captureDiagnostic = mapOf(
+                    "exit_reason" to CaptureIncompleteReason.INSPECTION_TRIGGER_EMPTY_MODEL.apiValue,
+                    "ide_product_code" to "WS",
+                    "suspicious_empty_model" to true,
+                ),
+                captureIncompleteReason = CaptureIncompleteReason.INSPECTION_TRIGGER_EMPTY_MODEL,
+            ),
+        )
+
+        val status = buildInspectionStatus()
+
+        assertEquals("UNKNOWN", status["inspection_verdict"])
+        assertEquals(CaptureIncompleteReason.INSPECTION_TRIGGER_EMPTY_MODEL.apiValue, status["inspection_verdict_reason"])
+        assertTrue((status["inspection_verdict_next_action"] as String).contains("plugin/helper bug"))
+        assertEquals(false, status["clean_inspection"])
     }
 
     @Test
@@ -1423,102 +1584,6 @@ class InspectionSnapshotStateTest {
             CaptureIncompleteReason.HELPER_PLUGIN_ERROR,
             classifyCaptureIncompleteReason(mapOf("exit_reason" to "helper_plugin_error")),
         )
-    }
-
-    @Test
-    @DisplayName("Non-empty unmapped inspection tree becomes a scoped fallback finding")
-    fun testUnmappedInspectionFallbackFindingForSingleFileScope() {
-        val problems = buildUnmappedInspectionFallbackProblems(
-            project = mockProject,
-            captureScope = InspectionCaptureScope(
-                scopeParam = "files",
-                files = listOf("src/main/java/RedFixture.java"),
-            ),
-            diagnostic = mapOf(
-                "observed_non_empty_inspection_tree" to true,
-                "model_problem_descriptor_count" to 0,
-                "last_view_observation" to mapOf("root_child_count" to 1),
-            ),
-        )
-
-        assertEquals(1, problems.size)
-        val problem = problems.single()
-        assertEquals("/tmp/TestProject/src/main/java/RedFixture.java", problem["file"])
-        assertEquals("error", problem["severity"])
-        assertEquals("UnmappedInspectionTree", problem["inspectionType"])
-        assertEquals("unmapped_inspection_tree_fallback", problem["source"])
-        assertEquals(false, problem["locationKnown"])
-        assertTrue((problem["description"] as String).contains("non-empty problem tree"))
-    }
-
-    @Test
-    @DisplayName("Clean or empty evidence does not create fallback findings")
-    fun testUnmappedInspectionFallbackRequiresRedEvidence() {
-        val problems = buildUnmappedInspectionFallbackProblems(
-            project = mockProject,
-            captureScope = InspectionCaptureScope(
-                scopeParam = "files",
-                files = listOf("src/main/java/CleanFixture.java"),
-            ),
-            diagnostic = mapOf(
-                "observed_non_empty_inspection_tree" to false,
-                "model_problem_descriptor_count" to 0,
-            ),
-        )
-
-        assertEquals(emptyList<Map<String, Any>>(), problems)
-    }
-
-    @Test
-    @DisplayName("Descriptor-only unmapped evidence becomes a fallback finding")
-    fun testUnmappedInspectionFallbackFindingForDescriptorEvidence() {
-        val problems = buildUnmappedInspectionFallbackProblems(
-            project = mockProject,
-            captureScope = InspectionCaptureScope(scopeParam = "whole_project"),
-            diagnostic = mapOf(
-                "observed_non_empty_inspection_tree" to false,
-                "model_problem_descriptor_count" to 2,
-            ),
-        )
-
-        assertEquals(1, problems.size)
-        assertEquals("/tmp/TestProject", problems.single()["file"])
-        assertTrue((problems.single()["description"] as String).contains("2 descriptor(s)"))
-    }
-
-    @Test
-    @DisplayName("Whole-project non-empty tree evidence becomes a fallback finding")
-    fun testUnmappedInspectionFallbackFindingForWholeProjectTreeEvidence() {
-        val problems = buildUnmappedInspectionFallbackProblems(
-            project = mockProject,
-            captureScope = InspectionCaptureScope(scopeParam = "whole_project"),
-            diagnostic = mapOf(
-                "observed_non_empty_inspection_tree" to true,
-                "model_problem_descriptor_count" to 0,
-                "last_view_observation" to mapOf("root_child_count" to 2),
-            ),
-        )
-
-        assertEquals(1, problems.size)
-        assertEquals("/tmp/TestProject", problems.single()["file"])
-        assertTrue((problems.single()["description"] as String).contains("non-empty problem tree"))
-    }
-
-    @Test
-    @DisplayName("Unmapped fallback remains actionable when project base path is unavailable")
-    fun testUnmappedInspectionFallbackWithoutProjectBasePath() {
-        val projectWithoutBasePath = mockk<Project>()
-        every { projectWithoutBasePath.basePath } returns null
-
-        val problems = buildUnmappedInspectionFallbackProblems(
-            project = projectWithoutBasePath,
-            captureScope = InspectionCaptureScope(scopeParam = "whole_project"),
-            diagnostic = mapOf("observed_non_empty_inspection_tree" to true),
-        )
-
-        assertEquals(1, problems.size)
-        assertEquals("unknown", problems.single()["file"])
-        assertEquals(false, problems.single()["locationKnown"])
     }
 
     @Test
@@ -1695,6 +1760,85 @@ class InspectionSnapshotStateTest {
                 bestResultsEmpty = true,
                 observedNonEmptyInspectionTree = true,
                 stableForMs = 5000L,
+                pollingElapsedMs = 30000L,
+            )
+        )
+    }
+
+    @Test
+    @DisplayName("Clean model can override stale non-empty inspection tree residue")
+    fun testCleanModelOverridesStaleNonEmptyInspectionTreeResidue() {
+        assertTrue(
+            shouldTreatNonEmptyInspectionTreeAsStaleCleanEvidence(
+                observedNonEmptyInspectionTree = true,
+                modelExtractionClean = true,
+                modelProblemDescriptorCount = 0,
+                bestResultsEmpty = true,
+                extractionFailureCount = 0,
+                lastExtractionCycleSucceeded = true,
+                lastToolExtractionSucceeded = true,
+                inspectionViewUpdating = false,
+                stableForMs = 5000L,
+                pollingElapsedMs = 30000L,
+            )
+        )
+
+        assertFalse(
+            shouldTreatNonEmptyInspectionTreeAsStaleCleanEvidence(
+                observedNonEmptyInspectionTree = true,
+                modelExtractionClean = false,
+                modelProblemDescriptorCount = 1,
+                bestResultsEmpty = true,
+                extractionFailureCount = 0,
+                lastExtractionCycleSucceeded = true,
+                lastToolExtractionSucceeded = true,
+                inspectionViewUpdating = false,
+                stableForMs = 5000L,
+                pollingElapsedMs = 30000L,
+            )
+        )
+
+        assertFalse(
+            shouldTreatNonEmptyInspectionTreeAsStaleCleanEvidence(
+                observedNonEmptyInspectionTree = true,
+                modelExtractionClean = true,
+                modelProblemDescriptorCount = 0,
+                bestResultsEmpty = false,
+                extractionFailureCount = 0,
+                lastExtractionCycleSucceeded = true,
+                lastToolExtractionSucceeded = true,
+                inspectionViewUpdating = false,
+                stableForMs = 5000L,
+                pollingElapsedMs = 30000L,
+            )
+        )
+
+        assertFalse(
+            shouldTreatNonEmptyInspectionTreeAsStaleCleanEvidence(
+                observedNonEmptyInspectionTree = true,
+                modelExtractionClean = true,
+                modelProblemDescriptorCount = 0,
+                bestResultsEmpty = true,
+                extractionFailureCount = 1,
+                lastExtractionCycleSucceeded = false,
+                lastToolExtractionSucceeded = true,
+                inspectionViewUpdating = false,
+                stableForMs = 5000L,
+                pollingElapsedMs = 30000L,
+            )
+        )
+
+        assertFalse(
+            shouldTreatNonEmptyInspectionTreeAsStaleCleanEvidence(
+                observedNonEmptyInspectionTree = true,
+                modelExtractionClean = true,
+                modelProblemDescriptorCount = 0,
+                bestResultsEmpty = true,
+                extractionFailureCount = 0,
+                lastExtractionCycleSucceeded = true,
+                lastToolExtractionSucceeded = true,
+                inspectionViewUpdating = false,
+                stableForMs = 4999L,
                 pollingElapsedMs = 30000L,
             )
         )

--- a/test-fixtures/inspection-red-lane-pycharm/.idea/inspectionProfiles/RedLane.xml
+++ b/test-fixtures/inspection-red-lane-pycharm/.idea/inspectionProfiles/RedLane.xml
@@ -1,6 +1,6 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0" is_locked="false">
     <option name="myName" value="RedLane" />
-    <inspection_tool class="UnusedDeclaration" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="PyStatementEffectInspection" enabled="true" level="ERROR" enabled_by_default="true" />
   </profile>
 </component>

--- a/test-fixtures/inspection-red-lane-pycharm/.idea/inspectionProfiles/profiles_settings.xml
+++ b/test-fixtures/inspection-red-lane-pycharm/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="PROJECT_PROFILE" value="RedLane" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/test-fixtures/inspection-red-lane-pycharm/.idea/misc.xml
+++ b/test-fixtures/inspection-red-lane-pycharm/.idea/misc.xml
@@ -1,0 +1,3 @@
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.13" project-jdk-type="Python SDK" />
+</project>

--- a/test-fixtures/inspection-red-lane-pycharm/.idea/modules.xml
+++ b/test-fixtures/inspection-red-lane-pycharm/.idea/modules.xml
@@ -1,0 +1,7 @@
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/inspection-red-lane-pycharm.iml" filepath="$PROJECT_DIR$/inspection-red-lane-pycharm.iml" />
+    </modules>
+  </component>
+</project>

--- a/test-fixtures/inspection-red-lane-pycharm/FIXTURE.md
+++ b/test-fixtures/inspection-red-lane-pycharm/FIXTURE.md
@@ -1,0 +1,6 @@
+# PyCharm Red-Lane Fixture
+
+This project is intentionally broken. Do not remove the statement with no
+effect; the fixture must keep producing current PyCharm inspection findings so
+`dogfood-red-lane-smoke.sh --product pycharm` can prove the helper reports
+`RED`.

--- a/test-fixtures/inspection-red-lane-pycharm/inspection-red-lane-pycharm.iml
+++ b/test-fixtures/inspection-red-lane-pycharm/inspection-red-lane-pycharm.iml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/test-fixtures/inspection-red-lane-pycharm/pyproject.toml
+++ b/test-fixtures/inspection-red-lane-pycharm/pyproject.toml
@@ -1,0 +1,5 @@
+[project]
+name = "inspection-red-lane-pycharm"
+version = "0.0.0"
+requires-python = ">=3.11"
+description = "Intentional PyCharm inspection red-lane fixture"

--- a/test-fixtures/inspection-red-lane-pycharm/src/definitely_red.py
+++ b/test-fixtures/inspection-red-lane-pycharm/src/definitely_red.py
@@ -1,0 +1,7 @@
+def main() -> None:
+    # INTENTIONAL RED-LANE FIXTURE: keep these PyCharm inspection findings.
+    1 + 1
+
+
+if __name__ == "__main__":
+    main()

--- a/test-fixtures/inspection-red-lane-webstorm/.idea/inspectionProfiles/RedLane.xml
+++ b/test-fixtures/inspection-red-lane-webstorm/.idea/inspectionProfiles/RedLane.xml
@@ -1,0 +1,7 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0" is_locked="false">
+    <option name="myName" value="RedLane" />
+    <inspection_tool class="JsonDuplicatePropertyKeys" enabled="true" level="ERROR" enabled_by_default="true" />
+    <inspection_tool class="JsonStandardCompliance" enabled="true" level="ERROR" enabled_by_default="true" />
+  </profile>
+</component>

--- a/test-fixtures/inspection-red-lane-webstorm/.idea/inspectionProfiles/profiles_settings.xml
+++ b/test-fixtures/inspection-red-lane-webstorm/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="PROJECT_PROFILE" value="RedLane" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/test-fixtures/inspection-red-lane-webstorm/.idea/modules.xml
+++ b/test-fixtures/inspection-red-lane-webstorm/.idea/modules.xml
@@ -1,0 +1,7 @@
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/inspection-red-lane-webstorm.iml" filepath="$PROJECT_DIR$/inspection-red-lane-webstorm.iml" />
+    </modules>
+  </component>
+</project>

--- a/test-fixtures/inspection-red-lane-webstorm/FIXTURE.md
+++ b/test-fixtures/inspection-red-lane-webstorm/FIXTURE.md
@@ -1,0 +1,6 @@
+# WebStorm Red-Lane Fixture
+
+This project is intentionally broken. Do not remove the duplicate JSON property;
+the fixture must keep producing current WebStorm inspection findings so
+`dogfood-red-lane-smoke.sh --product webstorm` can prove the helper reports
+`RED`.

--- a/test-fixtures/inspection-red-lane-webstorm/inspection-red-lane-webstorm.iml
+++ b/test-fixtures/inspection-red-lane-webstorm/inspection-red-lane-webstorm.iml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/test-fixtures/inspection-red-lane-webstorm/package.json
+++ b/test-fixtures/inspection-red-lane-webstorm/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "inspection-red-lane-webstorm",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Intentional WebStorm inspection red-lane fixture",
+  "type": "module"
+}

--- a/test-fixtures/inspection-red-lane-webstorm/src/definitely-red.json
+++ b/test-fixtures/inspection-red-lane-webstorm/src/definitely-red.json
@@ -1,0 +1,5 @@
+{
+  "intentional": "INTENTIONAL RED-LANE FIXTURE: keep these WebStorm inspection findings.",
+  "duplicate": "first",
+  "duplicate": "second"
+}

--- a/test-fixtures/inspection-red-lane/FIXTURE.md
+++ b/test-fixtures/inspection-red-lane/FIXTURE.md
@@ -1,9 +1,10 @@
 # Inspection Red Lane Fixture
 
-This project is intentionally broken. `DefinitelyRed.java` must reference the
-unresolved `MissingType` symbol so `scripts/dogfood-red-lane-smoke.sh` can prove
+This project intentionally keeps an actionable Java inspection finding.
+`DefinitelyRed.redLaneField` must stay non-final while the `RedLane` profile
+enables `UnusedDeclaration`, so `scripts/dogfood-red-lane-smoke.sh` can prove
 the live IDE, plugin, and helper report `VERDICT=RED` with `total_problems > 0`.
 
-Do not add `MissingType` or otherwise make this project compile. If the fixture changes, run
-`./scripts/test-red-lane-smoke-script.sh` and, when a local IntelliJ IDEA with
-the plugin is available, `./scripts/dogfood-red-lane-smoke.sh`.
+Do not add `final` to `redLaneField` in this fixture. If the fixture changes,
+run `./scripts/test-red-lane-smoke-script.sh` and, when a local IntelliJ IDEA
+with the plugin is available, `./scripts/dogfood-red-lane-smoke.sh`.

--- a/test-fixtures/inspection-red-lane/src/main/java/com/example/redlane/DefinitelyRed.java
+++ b/test-fixtures/inspection-red-lane/src/main/java/com/example/redlane/DefinitelyRed.java
@@ -1,15 +1,14 @@
 package com.example.redlane;
 
 public class DefinitelyRed {
-    private String unusedField = "unused";
+    private String redLaneField = "red lane";
 
     public static void main(String[] args) {
-        // INTENTIONAL RED-LANE FIXTURE: MissingType must remain unresolved.
-        MissingType value = MissingType.create();
-        System.out.println(value);
+        // INTENTIONAL RED-LANE FIXTURE: redLaneField must stay non-final.
+        new DefinitelyRed().print();
     }
 
-    private void unusedMethod() {
-        System.out.println(unusedField);
+    private void print() {
+        System.out.println(redLaneField);
     }
 }


### PR DESCRIPTION
## Summary

- enforce explicit `GREEN` / `RED` / `UNKNOWN` inspection verdict semantics in the plugin
- add product red-lane fixtures and smoke-script coverage for IntelliJ IDEA, PyCharm, and WebStorm
- classify suspicious empty WebStorm RedLane models, missing profiles, and unresolved capture states as `UNKNOWN` with diagnostics instead of false clean results
- handle fixed-after-red stale inspection UI residue when the current model proves clean

## Validation

- `./scripts/test-all.sh`
- JetBrains helper closeout on this branch: `GREEN`, zero findings, cleanup `closed`
- live installed-plugin dogfood: disposable worktree returned `RED` on a non-final field, then `GREEN` after adding `final`, both with cleanup `closed`
- final read-only agent reviews: no blockers
