### PR TITLE
Fix profile resolution inspection verdict

### DIFF
--- a/.code/skills/jetbrains-inspection-workflow/SKILL.md
+++ b/.code/skills/jetbrains-inspection-workflow/SKILL.md
@@ -57,7 +57,7 @@ Keep exact command matrices, environment setup, and troubleshooting in
    below and open `TESTING_INSTRUCTIONS.md` for the exact manual sequence.
 5. For lifecycle, capture, routing, or dogfood-exit readiness, run the dogfood
    smoke matrix (`./scripts/dogfood-smoke-matrix.sh`) when local IDEs are
-   available; it exercises preexisting and helper-opened closeout paths and
+   available; it exercises preexisting and helper-opened readiness inspection paths and
    records cleanup evidence.
 6. For verdict or extraction changes that must prove the red lane, run
    `./scripts/dogfood-red-lane-smoke.sh --product intellij|pycharm|webstorm`
@@ -114,7 +114,7 @@ unit tests.
 6. For stateless HTTP clients, resolve `/api/inspection/route` first and pass
    the returned `project_key` and `session_id` through trigger, wait, status,
    and problems calls.
-7. When validating agent closeout behavior across IDEs or repos, run
+7. When validating agent readiness inspection behavior across IDEs or repos, run
    `./scripts/dogfood-smoke-matrix.sh` and inspect its JSON artifact for
    cleanup `closed`/`not_needed`, IDE identity, plugin version, and failure
    buckets.

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Typical response (truncated):
 Notes:
 - `locationKnown=false` means the IDE did not provide a stable file/line (often stale results). Use `locationNote` and re-run inspection.
 - `status: "no_results"` uses the same pagination, filters, `total_problems`, `problems_shown`, and `problems` fields as result responses, with an empty problems list.
-- `status: "capture_incomplete"` means an inspection finished, but the plugin could not conclusively capture the IDE results. Re-run the inspection or open the Problems/Inspection Results view before treating the project as clean. `capture_incomplete_reason` is a stable machine-readable bucket: `view_not_ready`, `view_updating_unreadable`, `unreadable_tree`, `extractor_failure`, `non_empty_unmapped_tree`, `current_run_psi_churn`, `timeout`, `helper_plugin_error`, or `unknown`. Use `capture_diagnostic` for the detailed counters and booleans behind the classification.
+- `status: "capture_incomplete"` means an inspection finished, but the plugin could not conclusively capture the IDE results. Re-run the inspection or open the Problems/Inspection Results view before treating the project as clean. `capture_incomplete_reason` is a stable machine-readable bucket: `view_not_ready`, `view_updating_unreadable`, `unreadable_tree`, `extractor_failure`, `non_empty_unmapped_tree`, `current_run_psi_churn`, `timeout`, `profile_resolution_error`, `helper_plugin_error`, or `unknown`. Use `capture_diagnostic` for the detailed counters and booleans behind the classification.
 - `status: "stale_results"` means project files changed after the last inspection. It is not a clean result. Cached findings are withheld by default; call `/problems?include_stale=true` only when explicitly diagnosing cached data.
 - `snapshot_change_kind` explains freshness classification when present. `snapshot_predates_current_trigger` and `unsaved_documents` are stale; `current_run_psi_churn` is a fresh-run PSI tick that the plugin attempts to reconcile before returning results.
 - `session_drift: true` means the client sent an old `session_id`; the IDE/plugin session restarted or the port was reused.
@@ -314,7 +314,7 @@ clients should keep using `/route`, `/trigger`, `/wait`, `/status`, and
 
 This contract lets script helpers preserve projects that were already open
 before automation started while cleaning up helper-opened worktrees after
-closeout.
+readiness inspection.
 
 ### Problems Endpoint
 **URL**: `GET /api/inspection/problems`
@@ -482,7 +482,7 @@ The status endpoint includes a `clean_inspection` field that makes the outcome e
 - `is_scanning: true` → Inspection running, wait
 - `results_may_be_stale: true` → Project changed after the last inspection; trigger again before trusting results
 - `snapshot_change_kind: "current_run_psi_churn"` → The latest run's snapshot saw a PSI modification-count tick after capture; the plugin keeps waiting instead of treating the snapshot as stale cached data.
-- `capture_incomplete_reason: "..."` → The subsystem bucket behind an inconclusive capture. IDE-state/retry buckets are `view_not_ready`, `view_updating_unreadable`, `unreadable_tree`, `current_run_psi_churn`, and `timeout`; plugin/helper investigation buckets are `extractor_failure`, `non_empty_unmapped_tree`, `helper_plugin_error`, and `unknown`.
+- `capture_incomplete_reason: "..."` → The subsystem bucket behind an inconclusive capture. IDE-state/retry buckets are `view_not_ready`, `view_updating_unreadable`, `unreadable_tree`, `current_run_psi_churn`, and `timeout`; profile configuration bucket is `profile_resolution_error`; plugin/helper investigation buckets are `extractor_failure`, `non_empty_unmapped_tree`, `helper_plugin_error`, and `unknown`.
 - `clean_inspection: true` → Inspection complete; `inspection_verdict` is `GREEN` for the selected scope/filter
 - `has_inspection_results: true` → Problems found, retrieve with `/problems`
 - If all three are false and `time_since_last_trigger_ms` is recent, the inspection finished but results were not captured. Re-run the inspection or open the Inspection Results tool window.

--- a/TESTING.md
+++ b/TESTING.md
@@ -54,24 +54,24 @@ installed or checked-out skill when validating behavior the agents rely on:
 
 ```bash
 HELPER="${CODE_HOME:-${CODEX_HOME:-$HOME/.code}}/skills/jetbrains-inspection/scripts/jb-inspect.py"
-uv run "$HELPER" run \
+uv run "$HELPER" inspect \
   --repo "$PWD" \
   --scope changed_files
 ```
 
-For agent closeout/readiness, prefer `closeout` instead of plain `run`:
+For agent readiness, use `inspect-closeout` so cleanup status is explicit:
 
 ```bash
-uv run "$HELPER" closeout \
+uv run "$HELPER" inspect-closeout \
   --repo "$PWD" \
   --scope changed_files
 ```
 
-`closeout` serializes helper-owned IDE opens, requires an exact current-worktree
+`inspect-closeout` serializes helper-owned IDE opens, requires an exact current-worktree
 route, runs inspection, and calls the plugin lifecycle close endpoint only for
 projects opened by the helper. Projects that were open before the helper started
 are left open. On macOS, lifecycle opens use `open -g` by default so the IDE should
-not take focus while a closeout is preparing a worktree. Auto-open requires a
+not take focus while readiness inspection is preparing a worktree. Auto-open requires a
 global trusted-root policy in
 `${CODE_HOME:-${CODEX_HOME:-$HOME/.code}}/jetbrains-inspection.json`; test worktrees should be
 created under those roots, not random temp directories.
@@ -106,9 +106,9 @@ workstream.
 ### Red lane dogfood
 
 Use `./scripts/dogfood-red-lane-smoke.sh` when changing verdict semantics,
-capture behavior, extraction, helper closeout, or release readiness. It copies a
+capture behavior, extraction, helper readiness inspection, or release readiness. It copies a
 maintained known-bad project fixture to a disposable local project, runs the
-external `jb-inspect.py closeout`, and requires `VERDICT=RED`,
+external `jb-inspect.py inspect-closeout`, and requires `VERDICT=RED`,
 `total_problems > 0`, and cleanup `closed`. The helper may exit non-zero because
 `RED` is not readiness-clean; the smoke trusts the structured JSON verdict and
 still fails on invalid JSON or missing cleanup.
@@ -147,7 +147,7 @@ validation.
 
 Use `./scripts/dogfood-smoke-matrix.sh` before release, after lifecycle or
 capture behavior changes, and when closing a dogfood session that should prove
-agent closeout behavior. The matrix wraps `jb-inspect.py closeout`, includes
+agent readiness inspection behavior. The matrix wraps `jb-inspect.py inspect-closeout`, includes
 this repo by default, includes `~/Developer/mediaforce` when present, and runs
 both preexisting-project and helper-opened worktree cases.
 

--- a/TESTING_INSTRUCTIONS.md
+++ b/TESTING_INSTRUCTIONS.md
@@ -51,7 +51,7 @@ Expected behavior:
 
 ## Helper lifecycle smoke
 
-Use this when validating worktree closeout behavior from the external helper.
+Use this when validating worktree readiness inspection behavior from the external helper.
 For release, merge-readiness, or dogfood-exit validation, prefer the repeatable
 matrix runner first:
 
@@ -63,7 +63,7 @@ Use the manual sequence below when debugging one matrix row or a
 product-specific IDE failure.
 
 1. Pick a repo worktree that is not currently open in the target IDE.
-2. Run `jb-inspect.py closeout --repo <worktree> --scope changed_files`.
+2. Run `jb-inspect.py inspect-closeout --repo <worktree> --scope changed_files`.
 3. Confirm the helper reports an exact route with `opened_by_helper=true` and a
    cleanup status of `closed` after inspection.
 4. Confirm no Trust Project, Safe Mode, or Open Project mode prompt appears; the
@@ -75,7 +75,7 @@ product-specific IDE failure.
 6. If debugging a product-specific failure, call `/api/inspection/lifecycle/open`
    directly and confirm the endpoint returns `status=opening` quickly; the
    helper polling loop must then prove the project appears in `/list`.
-7. Open the same worktree manually in the IDE and rerun closeout.
+7. Open the same worktree manually in the IDE and rerun `inspect-closeout`.
 8. Confirm cleanup reports `not_needed` and the manually opened project remains
    open.
 9. For linked worktrees, confirm the route `base_path` exactly equals the linked
@@ -83,7 +83,7 @@ product-specific IDE failure.
 
 ## Red lane live smoke
 
-Use this when changing verdict classification, extraction, or helper closeout
+Use this when changing verdict classification, extraction, or helper readiness inspection
 behavior and you need to prove a real IDE finding reaches agents as `RED`:
 
 ```bash
@@ -105,7 +105,7 @@ behavior and you need to prove a real IDE finding reaches agents as `RED`:
 
 The command copies the selected `test-fixtures/inspection-red-lane*` fixture to a
 disposable project under
-`~/.code/working/jetbrains-inspection-api/red-lane-smoke`, runs helper closeout
+`~/.code/working/jetbrains-inspection-api/red-lane-smoke`, runs helper `inspect-closeout`
 with `scope=whole_project`, and passes only when the structured helper JSON
 reports `VERDICT=RED`, reports `total_problems > 0`, and closes the helper-owned
 project. The helper may exit non-zero because `RED` is not readiness-clean.

--- a/scripts/dogfood-red-lane-smoke.sh
+++ b/scripts/dogfood-red-lane-smoke.sh
@@ -27,7 +27,7 @@ usage() {
 Usage: ./scripts/dogfood-red-lane-smoke.sh [options]
 
 Copies the maintained inspection-red-lane fixture to a disposable local project,
-runs the JetBrains inspection helper closeout, and requires a RED verdict.
+runs the JetBrains inspection helper readiness inspection, and requires a RED verdict.
 This is a live IDE dogfood smoke, not a normal CI unit test.
 
 Options:
@@ -174,7 +174,7 @@ for tool in "${REQUIRED_PROFILE_TOOLS[@]}"; do
 		die "fixture profile does not enable required inspection tool: $tool"
 done
 
-CMD=(uv run "$HELPER" --json closeout --repo "$PROJECT" --ide "$IDE" --scope whole_project --profile RedLane --timeout-ms "$TIMEOUT_MS" --prepare-timeout-ms "$PREPARE_TIMEOUT_MS")
+CMD=(uv run "$HELPER" --json inspect-closeout --repo "$PROJECT" --ide "$IDE" --scope whole_project --profile RedLane --timeout-ms "$TIMEOUT_MS" --prepare-timeout-ms "$PREPARE_TIMEOUT_MS")
 jq -n '$ARGS.positional' --args -- "${CMD[@]}" >"$COMMAND_FILE"
 
 "${CMD[@]}" >"$RAW_OUT" 2>"$ERR_OUT"

--- a/scripts/dogfood-smoke-matrix.sh
+++ b/scripts/dogfood-smoke-matrix.sh
@@ -30,16 +30,16 @@ usage() {
 	cat <<'USAGE'
 Usage: ./scripts/dogfood-smoke-matrix.sh [options]
 
-Runs a local dogfood matrix around the jetbrains-inspection helper closeout
-flow. The matrix records IDE identity, plugin version, cleanup evidence, and a
-failure bucket linked to the current hardening issue.
+Runs a local dogfood matrix around the jetbrains-inspection helper readiness
+inspection flow. The matrix records IDE identity, plugin version, cleanup
+evidence, and a failure bucket linked to the current hardening issue.
 
 Options:
   --helper PATH              Path to jb-inspect.py.
   --repo [LABEL=]PATH        Repo/worktree to inspect. Repeatable.
   --ide NAME                 IDE selector, e.g. "IntelliJ IDEA". Repeatable.
   --case NAME                all, preexisting, or helper-opened. Default: all.
-  --scope SCOPE              Helper closeout scope. Default: changed_files.
+  --scope SCOPE              Helper readiness inspection scope. Default: changed_files.
   --timeout-ms MS            Helper wait timeout. Default: 180000.
   --prepare-timeout-ms MS    Helper prepare/open timeout. Default: 180000.
   --worktree-root PATH       Parent directory for disposable worktrees.
@@ -472,7 +472,7 @@ run_case() {
 		target_repo=$worktree_path
 	fi
 
-	local cmd=(uv run "$HELPER" --json closeout --repo "$target_repo" --ide "$ide" --scope "$SCOPE" --timeout-ms "$TIMEOUT_MS" --prepare-timeout-ms "$PREPARE_TIMEOUT_MS")
+	local cmd=(uv run "$HELPER" --json inspect-closeout --repo "$target_repo" --ide "$ide" --scope "$SCOPE" --timeout-ms "$TIMEOUT_MS" --prepare-timeout-ms "$PREPARE_TIMEOUT_MS")
 	if [ "$scenario" = "preexisting" ]; then
 		cmd+=(--no-open)
 	fi

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -84,6 +84,7 @@ internal enum class CaptureIncompleteReason(val apiValue: String) {
     CURRENT_RUN_PSI_CHURN("current_run_psi_churn"),
     INSPECTION_TRIGGER_EMPTY_MODEL("inspection_trigger_empty_model"),
     TIMEOUT("timeout"),
+    PROFILE_RESOLUTION_ERROR("profile_resolution_error"),
     HELPER_PLUGIN_ERROR("helper_plugin_error"),
     UNKNOWN("unknown"),
 }
@@ -847,6 +848,8 @@ class InspectionHandler : HttpRequestHandler() {
                 "Wait for indexing/scanning to finish, then rerun inspection."
             "inspection_api_unavailable" ->
                 "Open the exact worktree in the configured JetBrains IDE with the inspection plugin installed."
+            "profile_resolution_error" ->
+                "Check that the requested inspection profile exists and is loaded in the target IDE project, then rerun inspection."
             "ambiguous_route" ->
                 "Pass project_key, project_path, or worktree_path so the plugin can inspect the exact project."
             "session_drift" ->
@@ -2444,7 +2447,7 @@ class InspectionHandler : HttpRequestHandler() {
                             "profile_source" to "request",
                             "exit_reason" to exitReason,
                         ).filterValues { it != null },
-                        captureIncompleteReason = CaptureIncompleteReason.HELPER_PLUGIN_ERROR,
+                        captureIncompleteReason = CaptureIncompleteReason.PROFILE_RESOLUTION_ERROR,
                         runId = runId,
                         triggerTimeMs = inspectionRunStatesByProject[key]?.triggerTimeMs,
                     )

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -204,9 +204,9 @@ class InspectionHandlerTest {
         assertEquals("capture_incomplete", status["snapshot_outcome"])
         assertEquals("profile_resolution", status["results_source"])
         assertEquals(true, status["capture_incomplete"])
-        assertEquals("helper_plugin_error", status["capture_incomplete_reason"])
+        assertEquals("profile_resolution_error", status["capture_incomplete_reason"])
         assertEquals("UNKNOWN", status["inspection_verdict"])
-        assertEquals("helper_plugin_error", status["inspection_verdict_reason"])
+        assertEquals("profile_resolution_error", status["inspection_verdict_reason"])
         @Suppress("UNCHECKED_CAST")
         val diagnostic = status["capture_diagnostic"] as Map<String, Any?>
         assertEquals("RedLane", diagnostic["profile_requested"])
@@ -239,7 +239,7 @@ class InspectionHandlerTest {
         assertEquals("profile_resolution", status["results_source"])
         assertEquals(true, status["capture_incomplete"])
         assertEquals("UNKNOWN", status["inspection_verdict"])
-        assertEquals("helper_plugin_error", status["inspection_verdict_reason"])
+        assertEquals("profile_resolution_error", status["inspection_verdict_reason"])
         @Suppress("UNCHECKED_CAST")
         val diagnostic = status["capture_diagnostic"] as Map<String, Any?>
         assertEquals("RedLane", diagnostic["profile_requested"])
@@ -269,8 +269,9 @@ class InspectionHandlerTest {
         val status = buildInspectionStatus()
         assertEquals("capture_incomplete", status["snapshot_outcome"])
         assertEquals("profile_resolution", status["results_source"])
+        assertEquals("profile_resolution_error", status["capture_incomplete_reason"])
         assertEquals("UNKNOWN", status["inspection_verdict"])
-        assertEquals("helper_plugin_error", status["inspection_verdict_reason"])
+        assertEquals("profile_resolution_error", status["inspection_verdict_reason"])
         @Suppress("UNCHECKED_CAST")
         val diagnostic = status["capture_diagnostic"] as Map<String, Any?>
         assertEquals("RedLane", diagnostic["profile_requested"])


### PR DESCRIPTION
## Summary
- Preserve profile-resolution failures as profile_resolution_error instead of helper_plugin_error
- Add regression assertions for missing and unreadable explicit inspection profiles
- Update helper-facing docs and dogfood scripts to use inspect/inspect-closeout command names

## Validation
- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test --tests com.shiny.inspectionmcp.InspectionHandlerTest
- ./scripts/test-red-lane-smoke-script.sh
- commit hook: ./gradlew :test, :inspection-core:test, :mcp-server-jvm:test, buildPlugin

Fixes the active auto-review P1 for explicit profile lookup failures.