### PR TITLE
Add compact inspection proof contract

### DIFF
--- a/mcp-server-jvm/src/main/kotlin/com/shiny/inspectionmcp/mcpserver/Main.kt
+++ b/mcp-server-jvm/src/main/kotlin/com/shiny/inspectionmcp/mcpserver/Main.kt
@@ -294,7 +294,7 @@ internal class ToolExecutor(
             ensurePinnedSessionStillValid("inspection_get_problems", target)
 
             val guidance = buildProblemsGuidance(result)
-            val text = prettyJson.encodeToString(JsonElement.serializer(), result) + guidance + buildRouteGuidance(target)
+            val text = renderInspectionResult(result, guidance, buildRouteGuidance(target))
             toolText(text)
         } catch (error: Exception) {
             toolError("Error getting problems: ${error.message}")
@@ -348,7 +348,8 @@ internal class ToolExecutor(
             val (result, target) = routeAndGet(autoPinnedArgs(args), "status", params)
             ensurePinnedSessionStillValid("inspection_get_status", target)
 
-            val text = prettyJson.encodeToString(JsonElement.serializer(), result) + buildStatusGuidance(result) + buildRouteGuidance(target)
+            val guidance = buildStatusGuidance(result)
+            val text = renderInspectionResult(result, guidance, buildRouteGuidance(target))
             toolText(text)
         } catch (error: Exception) {
             toolError("Error getting status: ${error.message}")
@@ -369,7 +370,8 @@ internal class ToolExecutor(
             val (result, target) = routeAndGet(autoPinnedArgs(args), "wait", params, requestTimeoutSeconds)
             ensurePinnedSessionStillValid("inspection_wait", target)
 
-            val text = prettyJson.encodeToString(JsonElement.serializer(), result) + buildWaitGuidance(result) + buildRouteGuidance(target)
+            val guidance = buildWaitGuidance(result)
+            val text = renderInspectionResult(result, guidance, buildRouteGuidance(target))
             toolText(text)
         } catch (error: Exception) {
             toolError("Error waiting for inspection: ${error.message}")
@@ -670,6 +672,34 @@ internal class ToolExecutor(
         return "\n\n$prefix: capture_incomplete$reasonText do not treat as clean. Retry once, preferably with a narrower scope; if it repeats, report the reason and capture_diagnostic."
     }
 
+    private fun renderInspectionResult(result: JsonElement, guidance: String, routeGuidance: String): String {
+        val payload = sanitizeInspectionPayloadForAgent(result)
+        val jsonText = prettyJson.encodeToString(JsonElement.serializer(), payload)
+        val leadingGuidance = guidance.trim()
+        val leading = if (leadingGuidance.isEmpty()) "" else "$leadingGuidance\n\n"
+        return leading + jsonText + routeGuidance
+    }
+
+    private fun sanitizeInspectionPayloadForAgent(result: JsonElement): JsonElement {
+        val obj = result as? JsonObject ?: return result
+        val verdict = blockerVerdict(obj)?.verdict
+            ?: obj["inspection_verdict"]?.jsonPrimitive?.contentOrNull
+        val keep = obj.toMutableMap()
+        keep.remove("capture_diagnostic")
+        val includeStale = obj["include_stale"]?.jsonPrimitive?.booleanOrNull == true
+        if (verdict == "UNKNOWN" && !includeStale) {
+            keep.remove("total_problems")
+            keep.remove("problems_shown")
+            keep.remove("problems")
+            keep.remove("pagination")
+            keep.remove("inspection_verdict")
+            keep.remove("inspection_verdict_reason")
+            keep.remove("inspection_verdict_message")
+            keep.remove("inspection_verdict_next_action")
+        }
+        return JsonObject(keep)
+    }
+
     private data class McpInspectionVerdict(
         val verdict: String,
         val reason: String,
@@ -770,8 +800,27 @@ internal class ToolExecutor(
                 "Inspection wait was interrupted.",
                 "Try again.",
             )
+            proofFailures(obj).isNotEmpty() -> {
+                val proofFailures = proofFailures(obj)
+                McpInspectionVerdict(
+                    "UNKNOWN",
+                    "inspection_proof_failed",
+                    "Inspection returned contradictory proof and did not establish a trustworthy GREEN or RED result.",
+                    "Resolve the proof failure (${proofFailures.joinToString(", ")}), then trigger and wait for a fresh inspection before reporting GREEN or RED.",
+                )
+            }
             else -> null
         }
+    }
+
+    private fun proofFailures(obj: JsonObject): List<String> {
+        val topLevel = (obj["proof_failures"] as? JsonArray)
+            ?.mapNotNull { it.jsonPrimitive.contentOrNull }
+            ?: emptyList()
+        val nested = ((obj["inspection_proof"] as? JsonObject)?.get("proof_failures") as? JsonArray)
+            ?.mapNotNull { it.jsonPrimitive.contentOrNull }
+            ?: emptyList()
+        return (topLevel + nested).distinct()
     }
 
     private fun unknownCaptureVerdict(reason: String?): McpInspectionVerdict {

--- a/mcp-server-jvm/src/test/kotlin/com/shiny/inspectionmcp/mcpserver/McpServerTest.kt
+++ b/mcp-server-jvm/src/test/kotlin/com/shiny/inspectionmcp/mcpserver/McpServerTest.kt
@@ -237,7 +237,7 @@ class McpServerTest {
 
     @Test
     fun inspectionGetProblemsWarnsWhenCaptureIncomplete() {
-        val response = """{"status":"capture_incomplete","capture_incomplete_reason":"extractor_failure","capture_diagnostic":{"exit_reason":"deadline"},"total_problems":0,"problems_shown":0,"problems":[]}"""
+        val response = """{"status":"capture_incomplete","capture_incomplete_reason":"extractor_failure","proof_failures":["extractor_failure"],"capture_diagnostic":{"exit_reason":"deadline"},"total_problems":0,"problems_shown":0,"problems":[]}"""
         MockIdeServer(mapOf("/api/inspection/problems" to MockResponse(response))).use { server ->
             server.start()
             val executor = ToolExecutor(server.baseUrl, HttpClient.newHttpClient(), server.port.toString())
@@ -247,8 +247,27 @@ class McpServerTest {
             assertTrue(text.contains("VERDICT: UNKNOWN"))
             assertTrue(text.contains("NEXT_ACTION"))
             assertTrue(text.contains("reason=extractor_failure"))
-            assertTrue(text.contains("capture_diagnostic"))
+            assertTrue(text.contains("capture_incomplete_reason"))
+            assertFalse(text.contains("capture_diagnostic"))
             assertFalse(text.contains("OK: No problems found matching filters"))
+        }
+    }
+
+    @Test
+    fun inspectionGetProblemsKeepsExplicitStaleDiagnostics() {
+        val response = """{"status":"stale_results","results_may_be_stale":true,"include_stale":true,"cached_total_problems":1,"cached_problems_shown":1,"problems":[{"description":"Cached warning"}],"pagination":{"limit":100,"offset":0,"has_more":false},"inspection_verdict":"UNKNOWN","inspection_verdict_reason":"stale_results"}"""
+        MockIdeServer(mapOf("/api/inspection/problems" to MockResponse(response))).use { server ->
+            server.start()
+            val executor = ToolExecutor(server.baseUrl, HttpClient.newHttpClient(), server.port.toString())
+
+            val result = executor.handleToolCall(
+                buildToolCall("inspection_get_problems", buildJsonObject { put("include_stale", JsonPrimitive(true)) })
+            )
+            val text = result.firstText()
+            assertTrue(text.startsWith("VERDICT: UNKNOWN"))
+            assertTrue(text.contains("reason=stale_results"))
+            assertTrue(text.contains("Cached warning"))
+            assertTrue(text.contains("\"problems\""))
         }
     }
 
@@ -446,6 +465,23 @@ class McpServerTest {
     }
 
     @Test
+    fun inspectionGetStatusProofFailureOverridesPluginGreenVerdict() {
+        val response = """{"status":"results_available","clean_inspection":true,"total_problems":0,"problems_shown":0,"problems":[],"proof_failures":["profile_mismatch"],"inspection_proof":{"status":"failed","proof_failures":["profile_mismatch"]},"inspection_verdict":"GREEN","inspection_verdict_reason":"clean_confirmed"}"""
+        MockIdeServer(mapOf("/api/inspection/status" to MockResponse(response))).use { server ->
+            server.start()
+            val executor = ToolExecutor(server.baseUrl, HttpClient.newHttpClient(), server.port.toString())
+
+            val result = executor.handleToolCall(buildToolCall("inspection_get_status", buildJsonObject { }))
+            val text = result.firstText()
+            assertTrue(text.startsWith("VERDICT: UNKNOWN"))
+            assertTrue(text.contains("reason=inspection_proof_failed"))
+            assertFalse(text.contains("VERDICT: GREEN"))
+            assertFalse(text.contains("\"total_problems\": 0"))
+            assertFalse(text.contains("\"problems\""))
+        }
+    }
+
+    @Test
     fun inspectionGetStatusHandlesCleanInspection() {
         val response = """{"clean_inspection":true}"""
         MockIdeServer(mapOf("/api/inspection/status" to MockResponse(response))).use { server ->
@@ -639,6 +675,23 @@ class McpServerTest {
             assertTrue(text.contains("VERDICT: UNKNOWN"))
             assertTrue(text.contains("reason=timeout"))
             assertFalse(text.contains("VERDICT: GREEN"))
+        }
+    }
+
+    @Test
+    fun inspectionWaitProofFailureOverridesPluginGreenVerdict() {
+        val response = """{"wait_completed":true,"completion_reason":"clean","total_problems":0,"problems_shown":0,"problems":[],"proof_failures":["run_mismatch"],"inspection_verdict":"GREEN","inspection_verdict_reason":"clean_confirmed"}"""
+        MockIdeServer(mapOf("/api/inspection/wait" to MockResponse(response))).use { server ->
+            server.start()
+            val executor = ToolExecutor(server.baseUrl, HttpClient.newHttpClient(), server.port.toString())
+
+            val result = executor.handleToolCall(buildToolCall("inspection_wait", buildJsonObject { }))
+            val text = result.firstText()
+            assertTrue(text.startsWith("VERDICT: UNKNOWN"))
+            assertTrue(text.contains("reason=inspection_proof_failed"))
+            assertFalse(text.contains("VERDICT: GREEN"))
+            assertFalse(text.contains("\"total_problems\": 0"))
+            assertFalse(text.contains("\"problems\""))
         }
     }
 

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -174,6 +174,11 @@ internal data class InspectionRunState(
     val inProgress: Boolean,
 )
 
+private data class InspectionProof(
+    val summary: Map<String, Any?>,
+    val failures: List<String>,
+)
+
 internal data class InspectionProjectLease(
     val closeToken: String,
     val leaseId: String?,
@@ -745,11 +750,24 @@ class InspectionHandler : HttpRequestHandler() {
     }
 
     private fun addInspectionVerdict(target: MutableMap<String, Any?>) {
+        addInspectionProof(target)
         target.putAll(inspectionVerdictFields(target))
     }
 
     private fun addStatusInspectionVerdict(target: MutableMap<String, Any>) {
+        @Suppress("UNCHECKED_CAST")
+        addInspectionProof(target as MutableMap<String, Any?>)
         target.putAll(inspectionVerdictFields(target))
+    }
+
+    private fun addInspectionProof(target: MutableMap<String, Any?>) {
+        val proof = inspectionProof(target)
+        target["inspection_proof"] = proof.summary.filterValues { it != null }
+        if (proof.failures.isNotEmpty()) {
+            target["proof_failures"] = proof.failures
+        } else {
+            target.remove("proof_failures")
+        }
     }
 
     private fun inspectionVerdictFields(payload: Map<String, Any?>): Map<String, String> {
@@ -772,6 +790,14 @@ class InspectionHandler : HttpRequestHandler() {
                 reason = unknownReason,
                 message = "Inspection did not produce a trustworthy GREEN or RED result.",
                 nextAction = unknownVerdictNextAction(unknownReason, payload),
+            )
+        }
+        if ((payload["proof_failures"] as? List<*>)?.isNotEmpty() == true) {
+            return InspectionVerdict(
+                verdict = "UNKNOWN",
+                reason = "inspection_proof_failed",
+                message = "Inspection returned contradictory proof and did not establish a trustworthy GREEN or RED result.",
+                nextAction = unknownVerdictNextAction("inspection_proof_failed", payload),
             )
         }
         val totalProblems = (payload["total_problems"] as? Number)?.toInt()
@@ -850,6 +876,8 @@ class InspectionHandler : HttpRequestHandler() {
                 "Open the exact worktree in the configured JetBrains IDE with the inspection plugin installed."
             "profile_resolution_error" ->
                 "Check that the requested inspection profile exists and is loaded in the target IDE project, then rerun inspection."
+            "inspection_proof_failed" ->
+                "Resolve the route/profile/scope proof failure, then trigger and wait for a fresh inspection before reporting GREEN or RED."
             "ambiguous_route" ->
                 "Pass project_key, project_path, or worktree_path so the plugin can inspect the exact project."
             "session_drift" ->
@@ -859,6 +887,73 @@ class InspectionHandler : HttpRequestHandler() {
             else ->
                 "Do not report GREEN or RED. Rerun inspection and include diagnostics if it remains UNKNOWN."
         }
+    }
+
+    private fun inspectionProof(payload: Map<String, Any?>): InspectionProof {
+        val status = payload["status"] as? String
+        val completionReason = payload["completion_reason"] as? String
+        val route = payload["route"] as? Map<*, *>
+        val diagnostic = payload["capture_diagnostic"] as? Map<*, *>
+        val filters = payload["filters"] as? Map<*, *>
+        val captureScope = payload["capture_scope"] as? Map<*, *>
+        val snapshotRunId = (payload["snapshot_run_id"] as? Number)?.toLong()
+        val inspectionRunId = (payload["inspection_run_id"] as? Number)?.toLong()
+        val currentRunId = inspectionRunId ?: (payload["run_id"] as? Number)?.toLong()
+        val captureIncompleteReason = payload["capture_incomplete_reason"] as? String
+        val proofStatus = when {
+            payload["session_drift"] == true -> "failed"
+            payload["ambiguous"] == true -> "failed"
+            payload["unavailable"] == true -> "failed"
+            status == "no_project" || completionReason == "no_project" -> "failed"
+            payload["results_may_be_stale"] == true -> "failed"
+            payload["capture_incomplete"] == true -> "failed"
+            payload["timed_out"] == true -> "failed"
+            payload["indexing"] == true || payload["is_scanning"] == true || payload["inspection_in_progress"] == true -> "pending"
+            payload["clean_inspection"] == true -> "complete"
+            status == "results_available" || status == "clean" || completionReason == "clean" || completionReason == "results" -> "complete"
+            else -> "unknown"
+        }
+        val scope = (filters?.get("scope") as? String)
+            ?: (captureScope?.get("scope") as? String)
+            ?: (diagnostic?.get("scope") as? String)
+        val profileRequested = diagnostic?.get("profile_requested") as? String
+        val profileResolved = diagnostic?.get("profile_resolved_name") as? String
+            ?: payload["profile"] as? String
+        val proof = mapOf(
+            "status" to proofStatus,
+            "project_key" to payload["project_key"],
+            "route_base_path" to route?.get("base_path"),
+            "project_instance_id" to route?.get("project_instance_id"),
+            "session_id" to payload["session_id"],
+            "scope" to scope,
+            "profile" to profileResolved,
+            "expected_profile" to profileRequested,
+            "snapshot_outcome" to payload["snapshot_outcome"],
+            "capture_complete" to (payload["capture_incomplete"] != true && status != "capture_incomplete"),
+            "inspection_completed" to (payload["inspection_in_progress"] != true && payload["is_scanning"] != true),
+            "indexing_complete" to (payload["indexing"] != true),
+            "session_fresh" to (payload["session_drift"] != true),
+            "results_fresh" to (payload["results_may_be_stale"] != true),
+            "snapshot_run_id" to snapshotRunId,
+            "inspection_run_id" to currentRunId,
+            "capture_incomplete_reason" to captureIncompleteReason,
+        )
+
+        val failures = mutableListOf<String>()
+        if (payload["session_drift"] == true) failures.add("session_drift")
+        if (payload["ambiguous"] == true) failures.add("ambiguous_route")
+        if (payload["unavailable"] == true) failures.add("inspection_api_unavailable")
+        if (payload["results_may_be_stale"] == true || status == "stale_results" || completionReason == "stale_results") failures.add("stale_results")
+        if (payload["capture_incomplete"] == true || status == "capture_incomplete" || completionReason == "capture_incomplete") failures.add(captureIncompleteReason ?: "capture_incomplete")
+        if (payload["timed_out"] == true || completionReason == "timeout") failures.add("timeout")
+        if (payload["indexing"] == true) failures.add("indexing")
+        if (payload["is_scanning"] == true || payload["inspection_in_progress"] == true) failures.add("inspection_still_running")
+        if (status == "no_results" || completionReason == "no_results") failures.add("no_results")
+        if (status == "no_recent_inspection" || completionReason == "no_recent_inspection") failures.add("no_recent_inspection")
+        if (diagnostic?.get("profile_missing") == true || diagnostic?.get("profile_unverified") == true) failures.add("profile_mismatch")
+        if (snapshotRunId != null && currentRunId != null && snapshotRunId != currentRunId) failures.add("run_mismatch")
+
+        return InspectionProof(proof, failures.distinct())
     }
 
     override fun isSupported(request: FullHttpRequest): Boolean {
@@ -1553,6 +1648,7 @@ class InspectionHandler : HttpRequestHandler() {
             val key = projectKey(project)
             var snapshot = resultsStore.getSnapshot(key)
             val hasSnapshot = snapshot != null
+            val runState = inspectionRunStatesByProject[key]
             var staleness = resolveSnapshotStaleness(project, snapshot)
             if (staleness.changeKind == "current_run_psi_churn") {
                 val reconciliation = reconcileCurrentRunPsiChurn(project, snapshot)
@@ -1582,6 +1678,8 @@ class InspectionHandler : HttpRequestHandler() {
                     "project_key" to key,
                     "session_id" to InspectionIdeSession.sessionId,
                     "route" to routeMetadata(project),
+                    "inspection_in_progress" to (runState?.inProgress == true),
+                    "inspection_run_id" to runState?.runId,
                     "timestamp" to (resultsStore.getTimestamp(key) ?: System.currentTimeMillis()),
                     "message" to "Project files changed since the last inspection. Trigger a new inspection before trusting these results.",
                     "results_may_be_stale" to true,
@@ -1625,6 +1723,8 @@ class InspectionHandler : HttpRequestHandler() {
                     "project_key" to key,
                     "session_id" to InspectionIdeSession.sessionId,
                     "route" to routeMetadata(project),
+                    "inspection_in_progress" to (runState?.inProgress == true),
+                    "inspection_run_id" to runState?.runId,
                     "timestamp" to snapshot.timestamp,
                     "message" to (
                         snapshot.note
@@ -1681,6 +1781,8 @@ class InspectionHandler : HttpRequestHandler() {
                     "project_key" to key,
                     "session_id" to InspectionIdeSession.sessionId,
                     "route" to routeMetadata(project),
+                    "inspection_in_progress" to (runState?.inProgress == true),
+                    "inspection_run_id" to runState?.runId,
                     "timestamp" to (resultsStore.getTimestamp(key) ?: System.currentTimeMillis()),
                     "total_problems" to page.total,
                     "problems_shown" to page.shown,
@@ -1713,6 +1815,8 @@ class InspectionHandler : HttpRequestHandler() {
                     "project_key" to key,
                     "session_id" to InspectionIdeSession.sessionId,
                     "route" to routeMetadata(project),
+                    "inspection_in_progress" to (runState?.inProgress == true),
+                    "inspection_run_id" to runState?.runId,
                     "timestamp" to System.currentTimeMillis(),
                     "message" to "No trustworthy inspection result was captured. Trigger and wait for a fresh inspection, or open the Inspection Results view for the exact worktree.",
                     "total_problems" to 0,

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
@@ -145,6 +145,11 @@ class InspectionSnapshotStateTest {
         assertEquals(false, status["capture_incomplete"])
         assertEquals("GREEN", status["inspection_verdict"])
         assertEquals("clean_confirmed", status["inspection_verdict_reason"])
+        @Suppress("UNCHECKED_CAST")
+        val proof = status["inspection_proof"] as Map<String, Any?>
+        assertEquals("complete", proof["status"])
+        assertEquals(true, proof["capture_complete"])
+        assertFalse(status.containsKey("proof_failures"))
     }
 
     @Test
@@ -529,6 +534,9 @@ class InspectionSnapshotStateTest {
         assertTrue(response.contains("\"capture_incomplete_reason\": \"timeout\""))
         assertTrue(response.contains("\"inspection_verdict\": \"UNKNOWN\""))
         assertTrue(response.contains("\"inspection_verdict_reason\": \"timeout\""))
+        assertTrue(response.contains("\"inspection_proof\""))
+        assertTrue(response.contains("\"proof_failures\": ["))
+        assertTrue(response.contains("\"timeout\""))
         assertTrue(response.contains("\"capture_diagnostic\""))
         assertTrue(response.contains("\"exit_reason\": \"timeout\""))
         assertTrue(response.contains("\"view_ready_ok\": false"))
@@ -554,6 +562,31 @@ class InspectionSnapshotStateTest {
         assertTrue(response.contains("\"problems\": []"))
         assertTrue(response.contains("\"pagination\":"))
         assertTrue(response.contains("\"filters\":"))
+    }
+
+    @Test
+    @DisplayName("Problems endpoint does not report old clean snapshot green during newer run")
+    fun testProblemsEndpointDoesNotReportOldCleanSnapshotGreenDuringNewerRun() {
+        InspectionResultsStore.setSnapshot(
+            snapshotKey(),
+            InspectionResultsSnapshot(
+                problems = emptyList(),
+                timestamp = System.currentTimeMillis() - 120000L,
+                projectState = InspectionProjectStateSnapshot(psiModificationCount = 7L, unsavedProjectDocuments = 0),
+                outcome = InspectionSnapshotOutcome.CLEAN_CONFIRMED,
+                source = "inspection_view",
+                runId = 1L,
+                triggerTimeMs = System.currentTimeMillis() - 120000L,
+            ),
+        )
+        beginInspectionRun()
+
+        val response = getInspectionProblems()
+
+        assertTrue(response.contains("\"inspection_verdict\": \"UNKNOWN\""))
+        assertTrue(response.contains("\"inspection_verdict_reason\": \"inspection_still_running\""))
+        assertTrue(response.contains("\"inspection_in_progress\": true"))
+        assertFalse(response.contains("\"inspection_verdict\": \"GREEN\""))
     }
 
     @Test


### PR DESCRIPTION
## Summary

Adds a compact inspection proof contract to JetBrains inspection HTTP responses and hardens MCP output so ambiguous or contradictory inspection states do not look like clean readiness evidence.

## What changed

- Adds `inspection_proof` and `proof_failures` to plugin/API verdict-bearing responses.
- Makes proof failures block `GREEN` inside the plugin verdict path.
- Carries current run state into `/api/inspection/problems` so an older clean snapshot cannot be reported green while a newer inspection run is active.
- Keeps specific UNKNOWN reasons such as `timeout`, `stale_results`, `capture_incomplete`, and `inspection_still_running` ahead of generic proof-failure messaging.
- Changes MCP inspection outputs to put verdict guidance before JSON.
- Sanitizes MCP UNKNOWN payloads by removing misleading zero-result fields, while preserving explicit `include_stale=true` cached diagnostics.
- Keeps verbose `capture_diagnostic` in raw HTTP responses, but removes it from normal MCP text output to reduce agent-context noise.

## Validation

Commit hook / local validation passed:

```text
JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew test :mcp-server-jvm:test --tests com.shiny.inspectionmcp.InspectionSnapshotStateTest --tests com.shiny.inspectionmcp.InspectionHandlerTest --tests com.shiny.inspectionmcp.mcpserver.McpServerTest
# BUILD SUCCESSFUL

JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test
# BUILD SUCCESSFUL

JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :inspection-core:test
# BUILD SUCCESSFUL

JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :mcp-server-jvm:test
# BUILD SUCCESSFUL

JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew buildPlugin
# BUILD SUCCESSFUL
```

## Review Notes

A review-agent pass found real issues before this PR was opened. This branch includes fixes for them:

- `/problems` now includes current run state before proof/verdict calculation.
- MCP specific UNKNOWN reasons take precedence over generic `inspection_proof_failed`.
- `include_stale=true` keeps requested cached findings visible for explicit diagnostics.

Refs #113
Refs #114
Refs cbusillo/codex-skills#388
