### PR TITLE
Harden PyCharm red-lane proof

### DIFF
--- a/scripts/dogfood-red-lane-smoke.sh
+++ b/scripts/dogfood-red-lane-smoke.sh
@@ -124,7 +124,7 @@ intellij | idea)
 		FIXTURE="$ROOT/test-fixtures/inspection-red-lane-pycharm"
 		PROJECT_SLUG="inspection-red-lane-pycharm"
 		DEFAULT_IDE="PyCharm"
-		REQUIRED_PROFILE_TOOLS=("PyStatementEffectInspection")
+		REQUIRED_PROFILE_TOOLS=("PyUnresolvedReferencesInspection")
 		;;
 	webstorm | javascript | js)
 		PRODUCT="webstorm"

--- a/scripts/test-red-lane-smoke-script.sh
+++ b/scripts/test-red-lane-smoke-script.sh
@@ -26,9 +26,9 @@ assert_fixture_pycharm() {
 	local fixture_profile="test-fixtures/inspection-red-lane-pycharm/.idea/inspectionProfiles/RedLane.xml"
 
 	grep -q 'INTENTIONAL RED-LANE FIXTURE' "$fixture_source"
-	grep -q '1 + 1' "$fixture_source"
+	grep -q 'definitely_missing_symbol()' "$fixture_source"
 	test -f test-fixtures/inspection-red-lane-pycharm/pyproject.toml
-	grep -q 'PyStatementEffectInspection' "$fixture_profile"
+	grep -q 'PyUnresolvedReferencesInspection' "$fixture_profile"
 }
 
 assert_fixture_webstorm() {
@@ -68,7 +68,7 @@ while args:
 
 fixtures = [
     ("IntelliJ IDEA", "src/main/java/com/example/redlane/DefinitelyRed.java", "redLaneField"),
-    ("PyCharm", "src/definitely_red.py", "1 + 1"),
+    ("PyCharm", "src/definitely_red.py", "definitely_missing_symbol"),
     ("WebStorm", "src/definitely-red.json", "duplicate"),
 ]
 
@@ -135,7 +135,7 @@ assert_fixture_pycharm
 assert_fixture_webstorm
 
 run_case intellij "IntelliJ IDEA" redLaneField
-run_case pycharm PyCharm '1 + 1'
+run_case pycharm PyCharm definitely_missing_symbol
 run_case webstorm WebStorm duplicate
 
 echo "red-lane smoke script contract passed"

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -355,10 +355,10 @@ internal fun suspiciousEmptyInspectionModelReason(
     bestResultsEmpty: Boolean,
     observedNonEmptyInspectionTree: Boolean,
 ): String? {
-    val isWebStorm = ideProductCode.equals("WS", ignoreCase = true)
+    val isSupportedProofLane = ideProductCode.equals("WS", ignoreCase = true) || isPyCharmProductCode(ideProductCode)
     val isRedLaneProof = requestedProfileName.equals("RedLane", ignoreCase = true)
     return if (
-        isWebStorm &&
+        isSupportedProofLane &&
             isRedLaneProof &&
             bestResultsEmpty &&
             !observedNonEmptyInspectionTree &&
@@ -369,6 +369,10 @@ internal fun suspiciousEmptyInspectionModelReason(
     } else {
         null
     }
+}
+
+internal fun isPyCharmProductCode(ideProductCode: String?): Boolean {
+    return ideProductCode.equals("PY", ignoreCase = true) || ideProductCode.equals("PC", ignoreCase = true)
 }
 
 internal fun isSettledCleanInspectionView(observation: InspectionViewObservation): Boolean {
@@ -2663,8 +2667,9 @@ class InspectionHandler : HttpRequestHandler() {
                 "profile_available_names" to profileNames?.take(25),
                 "profile_source" to if (requestedProfileName != null) "request" else "current",
             ).filterValues { it != null }
+            val ideProductCode = safeInspectionIdentity()["ide_product_code"]?.toString()
             val targetToolShortNames = expectedProofToolShortNames(
-                ideProductCode = safeInspectionIdentity()["ide_product_code"]?.toString(),
+                ideProductCode = ideProductCode,
                 requestedProfileName = requestedProfileName,
             )
 
@@ -2708,6 +2713,7 @@ class InspectionHandler : HttpRequestHandler() {
                                 resolvedCurrentFile,
                                 resolvedChangedFiles = changedFilesScopeFiles,
                                 scopeDiagnostics["scope_file_diagnostics"] as? List<*>,
+                                ideProductCode = ideProductCode,
                             )
                             extractProblemsFromContextSafe(
                                 globalContext,
@@ -4376,6 +4382,7 @@ class InspectionHandler : HttpRequestHandler() {
         resolvedCurrentFile: String?,
         resolvedChangedFiles: List<VirtualFile>?,
         targetScopeFileDiagnostics: List<*>?,
+        ideProductCode: String?,
     ): List<com.intellij.psi.PsiFile> {
         val scopeLower = scopeParam?.lowercase()?.trim()
         val paths = when {
@@ -4417,7 +4424,7 @@ class InspectionHandler : HttpRequestHandler() {
             val index = ProjectFileIndex.getInstance(project)
             val psiManager = PsiManager.getInstance(project)
             val collectFile: (VirtualFile) -> Unit = { file ->
-                if (!file.isDirectory && index.isInSourceContent(file) && shouldRunWebStormRedLaneFallbackOnFile(file)) {
+                if (!file.isDirectory && index.isInSourceContent(file) && shouldRunRedLaneFallbackOnFile(file, ideProductCode)) {
                     psiManager.findFile(file)?.let { files += it }
                 }
             }
@@ -4442,17 +4449,27 @@ class InspectionHandler : HttpRequestHandler() {
         return files
     }
 
-    private fun shouldRunWebStormRedLaneFallbackOnFile(file: VirtualFile): Boolean {
-        return file.extension?.lowercase() in setOf("js", "jsx", "ts", "tsx", "json", "json5")
+    private fun shouldRunRedLaneFallbackOnFile(file: VirtualFile, ideProductCode: String?): Boolean {
+        val extension = file.extension?.lowercase() ?: return false
+        return when {
+            ideProductCode.equals("WS", ignoreCase = true) -> extension in setOf("js", "jsx", "ts", "tsx", "json", "json5")
+            isPyCharmProductCode(ideProductCode) -> extension == "py"
+            else -> false
+        }
     }
 
     private fun expectedProofToolShortNames(
         ideProductCode: String?,
         requestedProfileName: String?,
     ): Set<String> {
-        if (!ideProductCode.equals("WS", ignoreCase = true)) return emptySet()
         if (!requestedProfileName.equals("RedLane", ignoreCase = true)) return emptySet()
-        return linkedSetOf("JSUnresolvedReference", "JsonDuplicatePropertyKeys", "JsonStandardCompliance")
+        return when {
+            ideProductCode.equals("WS", ignoreCase = true) ->
+                linkedSetOf("JSUnresolvedReference", "JsonDuplicatePropertyKeys", "JsonStandardCompliance")
+            isPyCharmProductCode(ideProductCode) ->
+                linkedSetOf("PyUnresolvedReferencesInspection")
+            else -> emptySet()
+        }
     }
 
     private fun formatModelUnreadableReason(stage: String, exception: Exception): String {

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
@@ -1447,12 +1447,36 @@ class InspectionSnapshotStateTest {
     }
 
     @Test
-    @DisplayName("Suspicious WebStorm RedLane empty model is not treated as clean")
-    fun testSuspiciousWebStormRedLaneEmptyModelReason() {
+    @DisplayName("Suspicious product RedLane empty model is not treated as clean")
+    fun testSuspiciousProductRedLaneEmptyModelReason() {
         assertEquals(
             CaptureIncompleteReason.INSPECTION_TRIGGER_EMPTY_MODEL.apiValue,
             suspiciousEmptyInspectionModelReason(
                 ideProductCode = "WS",
+                requestedProfileName = "RedLane",
+                modelVerdict = InspectionModelVerdict.CLEAN,
+                problemDescriptorCount = 0,
+                bestResultsEmpty = true,
+                observedNonEmptyInspectionTree = false,
+            ),
+        )
+
+        assertEquals(
+            CaptureIncompleteReason.INSPECTION_TRIGGER_EMPTY_MODEL.apiValue,
+            suspiciousEmptyInspectionModelReason(
+                ideProductCode = "PY",
+                requestedProfileName = "RedLane",
+                modelVerdict = InspectionModelVerdict.CLEAN,
+                problemDescriptorCount = 0,
+                bestResultsEmpty = true,
+                observedNonEmptyInspectionTree = false,
+            ),
+        )
+
+        assertEquals(
+            CaptureIncompleteReason.INSPECTION_TRIGGER_EMPTY_MODEL.apiValue,
+            suspiciousEmptyInspectionModelReason(
+                ideProductCode = "PC",
                 requestedProfileName = "RedLane",
                 modelVerdict = InspectionModelVerdict.CLEAN,
                 problemDescriptorCount = 0,

--- a/test-fixtures/inspection-red-lane-pycharm/.idea/inspectionProfiles/RedLane.xml
+++ b/test-fixtures/inspection-red-lane-pycharm/.idea/inspectionProfiles/RedLane.xml
@@ -1,6 +1,6 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0" is_locked="false">
     <option name="myName" value="RedLane" />
-    <inspection_tool class="PyStatementEffectInspection" enabled="true" level="ERROR" enabled_by_default="true" />
+    <inspection_tool class="PyUnresolvedReferencesInspection" enabled="true" level="ERROR" enabled_by_default="true" />
   </profile>
 </component>

--- a/test-fixtures/inspection-red-lane-pycharm/FIXTURE.md
+++ b/test-fixtures/inspection-red-lane-pycharm/FIXTURE.md
@@ -1,6 +1,6 @@
 # PyCharm Red-Lane Fixture
 
-This project is intentionally broken. Do not remove the statement with no
-effect; the fixture must keep producing current PyCharm inspection findings so
+This project is intentionally broken. Do not resolve the missing symbol;
+the fixture must keep producing current PyCharm inspection findings so
 `dogfood-red-lane-smoke.sh --product pycharm` can prove the helper reports
 `RED`.

--- a/test-fixtures/inspection-red-lane-pycharm/src/definitely_red.py
+++ b/test-fixtures/inspection-red-lane-pycharm/src/definitely_red.py
@@ -1,6 +1,6 @@
 def main() -> None:
     # INTENTIONAL RED-LANE FIXTURE: keep these PyCharm inspection findings.
-    1 + 1
+    definitely_missing_symbol()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- replace the PyCharm red-lane fixture with a deterministic unresolved-reference inspection
- add PyCharm Pro/Community RedLane proof targets, `.py` fallback files, and suspicious-empty-model fail-closed handling
- update script/unit contracts so PyCharm RedLane cannot silently regress to false GREEN

## Why

Issue #117 showed PyCharm 2026.1 could run the maintained RedLane fixture and report `GREEN`/0. The route, profile, session, indexing, and cleanup were coherent; the weak `PyStatementEffectInspection` fixture simply did not produce a descriptor, and the plugin only had WebStorm-specific proof-lane guards.

This patch makes PyCharm use `PyUnresolvedReferencesInspection` on `definitely_missing_symbol()` and gives PyCharm the same proof-lane shape WebStorm already needed: expected target tool tracking, targeted `InspectionEngine.runInspectionOnFile` fallback, and capture-incomplete/UNKNOWN instead of clean when an empty model appears in the proof lane.

## Validation

```text
./scripts/test-red-lane-smoke-script.sh
JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test --tests com.shiny.inspectionmcp.InspectionSnapshotStateTest
JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew buildPlugin
```

Commit hook also ran broader checks successfully:

```text
JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test
JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :inspection-core:test
JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :mcp-server-jvm:test
JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew buildPlugin
```

Live IDE proof after installing the patched plugin and restarting IDEs:

```text
IntelliJ: status=ok bucket=red_confirmed verdict=RED total=1 cleanup=closed product=IU fingerprint=91ace601dbf7-dirty
PyCharm:  status=ok bucket=red_confirmed verdict=RED total=1 cleanup=closed product=PY fingerprint=91ace601dbf7-dirty
WebStorm: status=ok bucket=red_confirmed verdict=RED total=2 cleanup=closed product=WS fingerprint=91ace601dbf7-dirty
```

PyCharm finding evidence:

```json
{
  "inspectionType": "PyUnresolvedReferencesInspection",
  "severity": "error",
  "description": "Unresolved reference 'definitely_missing_symbol'",
  "source": "inspection_context"
}
```

Note: the first local PyCharm run after installing the zip still served the old in-memory plugin fingerprint and stayed GREEN/0. After restarting PyCharm, it loaded the patched plugin and produced RED. That is expected JetBrains plugin lifecycle behavior for local validation.

Refs #117
Refs #113
Refs #114
