### PR TITLE
Release 1.13.3 inspection verdict fixes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion=1.13.2
+pluginVersion=1.13.3
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
 kotlin.stdlib.default.dependency=false
 # Enable Gradle Configuration Cache -> https://docs.gradle.org/current/userguide/configuration_cache.html

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.shiny.inspection.api</id>
     <name>Inspection API</name>
-    <version>1.13.2</version>
+    <version>1.13.3</version>
     <vendor email="info@shinycomputers.com" url="https://github.com/cbusillo/jetbrains-inspection-api">Shiny Computers (Chris Busillo)</vendor>
     <resource-bundle>messages.InspectionApiBundle</resource-bundle>
     


### PR DESCRIPTION
## Summary

- Bump plugin version to `1.13.3` so the merged inspection verdict, worktree routing, WebStorm, and PyCharm red-lane fixes can be released.
- Refs #119.

## Validation

- `./scripts/commit-gate.sh`
- Re-ran `./scripts/commit-gate.sh` after the version bump.

## Release Notes

This release packages the post-`v1.13.2` fixes for exact worktree routing, compact inspection proof, GREEN/RED/UNKNOWN verdict handling, WebStorm red-lane diagnostics/fallback, and PyCharm red-lane proof.
