### PR TITLE
Support JetBrains 2026.2 compatibility

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -36,7 +36,7 @@
       "redLaneDogfoodIntelliJ": "./scripts/dogfood-red-lane-smoke.sh --product intellij",
       "redLaneDogfoodPyCharm": "./scripts/dogfood-red-lane-smoke.sh --product pycharm",
       "redLaneDogfoodWebStorm": "./scripts/dogfood-red-lane-smoke.sh --product webstorm --ide \"WebStorm\" --ide-app \"WebStorm 2026.2 EAP\"",
-      "execHarness262Worktree": "python3 ${CODE_EXEC_HARNESS}/harness.py test-fixtures/exec-harness/jetbrains-inspection-262-worktree-live.json --inherit-auth --skill-root ${JETBRAINS_INSPECTION_SKILL_ROOT:-$HOME/.code/skills} --max-seconds 420"
+      "execHarness262Worktree": "JETBRAINS_INSPECTION_API_REPO=$PWD JETBRAINS_INSPECTION_TRUSTED_AUTO_OPEN_ROOTS=${CODE_EXEC_HARNESS_ROOT:?Set CODE_EXEC_HARNESS_ROOT}/.tmp/code-exec-harness JETBRAINS_INSPECTION_IDE_CONFIG_DIR=\"${JETBRAINS_INSPECTION_IDE_CONFIG_DIR:?Set JETBRAINS_INSPECTION_IDE_CONFIG_DIR}\" python3 ${CODE_EXEC_HARNESS_ROOT}/tools/code-exec-harness/harness.py test-fixtures/exec-harness/jetbrains-inspection-262-worktree-live.json --inherit-auth --skill-root ${JETBRAINS_INSPECTION_SKILL_ROOT:-$HOME/.code/skills} --max-seconds 420"
     },
     "releaseCompatibility": {
       "jetbrainsBuildRange": "251-262.*",

--- a/.github/github.json
+++ b/.github/github.json
@@ -18,7 +18,10 @@
       "mcpServer": "./gradlew :mcp-server-jvm:test"
     },
     "build": {
+      "buildPlugin": "./gradlew buildPlugin",
       "plugin": "./gradlew buildPlugin",
+      "verifyPluginStructure": "./gradlew verifyPluginStructure",
+      "verifyPluginCompatibility": "./gradlew verifyPlugin",
       "mcpServerJar": "./gradlew :mcp-server-jvm:mcpServerJar"
     },
     "inspection": {
@@ -32,7 +35,20 @@
       "redLaneDogfood": "./scripts/dogfood-red-lane-smoke.sh",
       "redLaneDogfoodIntelliJ": "./scripts/dogfood-red-lane-smoke.sh --product intellij",
       "redLaneDogfoodPyCharm": "./scripts/dogfood-red-lane-smoke.sh --product pycharm",
-      "redLaneDogfoodWebStorm": "./scripts/dogfood-red-lane-smoke.sh --product webstorm"
+      "redLaneDogfoodWebStorm": "./scripts/dogfood-red-lane-smoke.sh --product webstorm --ide \"WebStorm\" --ide-app \"WebStorm 2026.2 EAP\"",
+      "execHarness262Worktree": "python3 ${CODE_EXEC_HARNESS}/harness.py test-fixtures/exec-harness/jetbrains-inspection-262-worktree-live.json --inherit-auth --skill-root ${JETBRAINS_INSPECTION_SKILL_ROOT:-$HOME/.code/skills} --max-seconds 420"
+    },
+    "releaseCompatibility": {
+      "jetbrainsBuildRange": "251-262.*",
+      "requiredFor262": [
+        "qualityGate.build.buildPlugin",
+        "qualityGate.build.verifyPluginStructure",
+        "qualityGate.build.verifyPluginCompatibility",
+        "qualityGate.manualSmoke.redLaneDogfoodIntelliJ",
+        "qualityGate.manualSmoke.redLaneDogfoodPyCharm",
+        "qualityGate.manualSmoke.redLaneDogfoodWebStorm",
+        "qualityGate.manualSmoke.execHarness262Worktree"
+      ]
     },
     "docsRequiredWhen": [
       "behavior changes",

--- a/README.md
+++ b/README.md
@@ -623,7 +623,10 @@ For agent-facing worktree proof, run the maintained exec-harness scenario in
 `test-fixtures/exec-harness/jetbrains-inspection-262-worktree-live.json`; it
 copies the red-lane fixture into an isolated workspace and requires the helper
 to prove a `RED` result, cleanup, and exact route matching in IntelliJ IDEA
-2026.2.
+2026.2. Set `JETBRAINS_INSPECTION_API_REPO` to this checkout,
+`CODE_EXEC_HARNESS_ROOT` to the checkout that contains `tools/code-exec-harness`,
+and pass the installed 2026.2 IDE config directory through
+`JETBRAINS_INSPECTION_IDE_CONFIG_DIR` when running the scenario directly.
 
 Shortcut:
 

--- a/README.md
+++ b/README.md
@@ -119,34 +119,34 @@ configured a different IDE built-in server port, use that port in each URL.
 
 ```bash
 # Trigger inspection
-curl "http://localhost:63340/api/inspection/trigger"
+curl "http://127.0.0.1:63340/api/inspection/trigger"
 
 # Check inspection status
-curl "http://localhost:63340/api/inspection/status"
+curl "http://127.0.0.1:63340/api/inspection/status"
 
 # Wait for inspection to finish (long-poll)
-curl "http://localhost:63340/api/inspection/wait?timeout_ms=180000&poll_ms=1000"
+curl "http://127.0.0.1:63340/api/inspection/wait?timeout_ms=180000&poll_ms=1000"
 
 # Get all problems in project
-curl "http://localhost:63340/api/inspection/problems"
+curl "http://127.0.0.1:63340/api/inspection/problems"
 
 # Get problems for current file only
-curl "http://localhost:63340/api/inspection/problems?scope=current_file"
+curl "http://127.0.0.1:63340/api/inspection/problems?scope=current_file"
 
 # Get only error-level problems
-curl "http://localhost:63340/api/inspection/problems?severity=error"
+curl "http://127.0.0.1:63340/api/inspection/problems?severity=error"
 
 # Specify which project to inspect (v1.10.5+)
-curl "http://localhost:63340/api/inspection/problems?project=MyProject"
+curl "http://127.0.0.1:63340/api/inspection/problems?project=MyProject"
 
 # Trigger inspection for specific project
-curl "http://localhost:63340/api/inspection/trigger?project=odoo-ai"
+curl "http://127.0.0.1:63340/api/inspection/trigger?project=odoo-ai"
 
 # Inspect IDE/plugin identity and open project metadata
-curl "http://localhost:63340/api/inspection/identity"
+curl "http://127.0.0.1:63340/api/inspection/identity"
 
 # Resolve a stateless client route before trigger/wait/problems
-curl "http://localhost:63340/api/inspection/route?cwd=/Users/me/Developer/MyProject"
+curl "http://127.0.0.1:63340/api/inspection/route?cwd=/Users/me/Developer/MyProject"
 ```
 
 Stateless skill or script clients should resolve a route, then pass the returned
@@ -192,7 +192,7 @@ Typical response (truncated):
   },
   "route": {
     "port": 63340,
-    "base_url": "http://localhost:63340/api/inspection",
+    "base_url": "http://127.0.0.1:63340/api/inspection",
     "session_id": "4c171eb1-2f1f-4b0c-9b5b-0dd1d5b9e2a8",
     "project_key": "path:/abs/path/to/MyProject",
     "project_name": "MyProject",
@@ -241,7 +241,7 @@ routing state.
   "status": "resolved",
   "route": {
     "port": 63340,
-    "base_url": "http://localhost:63340/api/inspection",
+    "base_url": "http://127.0.0.1:63340/api/inspection",
     "session_id": "4c171eb1-2f1f-4b0c-9b5b-0dd1d5b9e2a8",
     "project_key": "path:/Users/me/Developer/MyProject",
     "project_instance_id": "4c171eb1-2f1f-4b0c-9b5b-0dd1d5b9e2a8:123456789",
@@ -340,20 +340,20 @@ Invalid `limit` or `offset` values return HTTP 400 with `error`, `parameter`, an
 **Examples**:
 ```bash
 # Get only Python unresolved reference errors
-curl "http://localhost:63340/api/inspection/problems?problem_type=PyUnresolvedReferences&severity=error"
+curl "http://127.0.0.1:63340/api/inspection/problems?problem_type=PyUnresolvedReferences&severity=error"
 
 # Get problems in test files only
-curl "http://localhost:63340/api/inspection/problems?file_pattern=.*test.*\.py$"
+curl "http://127.0.0.1:63340/api/inspection/problems?file_pattern=.*test.*\.py$"
 
 # Paginate through large result sets
-curl "http://localhost:63340/api/inspection/problems?limit=50&offset=0"
-curl "http://localhost:63340/api/inspection/problems?limit=50&offset=50"
+curl "http://127.0.0.1:63340/api/inspection/problems?limit=50&offset=0"
+curl "http://127.0.0.1:63340/api/inspection/problems?limit=50&offset=50"
 
 # Combine filters for precise results
-curl "http://localhost:63340/api/inspection/problems?severity=error&file_pattern=src/&problem_type=TypeScript"
+curl "http://127.0.0.1:63340/api/inspection/problems?severity=error&file_pattern=src/&problem_type=TypeScript"
 
 # Diagnose cached stale findings without treating them as current
-curl "http://localhost:63340/api/inspection/problems?include_stale=true"
+curl "http://127.0.0.1:63340/api/inspection/problems?include_stale=true"
 ```
 
 ### Trigger Endpoint
@@ -381,26 +381,26 @@ curl "http://localhost:63340/api/inspection/problems?include_stale=true"
 **Examples**:
 ```bash
 # Whole project (default)
-curl "http://localhost:63340/api/inspection/trigger"
+curl "http://127.0.0.1:63340/api/inspection/trigger"
 
 # Current editor file only
-curl "http://localhost:63340/api/inspection/trigger?scope=current_file"
+curl "http://127.0.0.1:63340/api/inspection/trigger?scope=current_file"
 
 # A specific directory (relative to project)
-curl "http://localhost:63340/api/inspection/trigger?scope=directory&dir=src"
+curl "http://127.0.0.1:63340/api/inspection/trigger?scope=directory&dir=src"
 
 # A specific directory (absolute path)
-curl "http://localhost:63340/api/inspection/trigger?scope=directory&dir=/full/path/to/addons/hr_employee_name_extended"
+curl "http://127.0.0.1:63340/api/inspection/trigger?scope=directory&dir=/full/path/to/addons/hr_employee_name_extended"
 
 # Only files you specify
-curl "http://localhost:63340/api/inspection/trigger?scope=files&file=src/app.py&file=tests/test_app.py"
-curl "http://localhost:63340/api/inspection/trigger?scope=files&files=src/a.py,src/b.py"
+curl "http://127.0.0.1:63340/api/inspection/trigger?scope=files&file=src/app.py&file=tests/test_app.py"
+curl "http://127.0.0.1:63340/api/inspection/trigger?scope=files&files=src/a.py,src/b.py"
 
 # Only changed files (fast inner loop)
-curl "http://localhost:63340/api/inspection/trigger?scope=changed_files&include_unversioned=true&max_files=50"
+curl "http://127.0.0.1:63340/api/inspection/trigger?scope=changed_files&include_unversioned=true&max_files=50"
 
 # Use a lighter inspection profile by name
-curl "http://localhost:63340/api/inspection/trigger?profile=LLM%20Fast%20Checks"
+curl "http://127.0.0.1:63340/api/inspection/trigger?profile=LLM%20Fast%20Checks"
 ```
 
 **Response**:
@@ -443,11 +443,11 @@ curl "http://localhost:63340/api/inspection/trigger?profile=LLM%20Fast%20Checks"
 ### Recommended Pattern
 ```bash
 # 1. Trigger inspection
-curl "http://localhost:63340/api/inspection/trigger"
+curl "http://127.0.0.1:63340/api/inspection/trigger"
 
 # 2. Wait for completion (check every 2-3 seconds)
 while true; do
-  STATUS=$(curl -s "http://localhost:63340/api/inspection/status")
+  STATUS=$(curl -s "http://127.0.0.1:63340/api/inspection/status")
   IS_SCANNING=$(echo $STATUS | jq -r '.is_scanning')
   HAS_RESULTS=$(echo $STATUS | jq -r '.has_inspection_results')
   CLEAN=$(echo $STATUS | jq -r '.clean_inspection')
@@ -462,7 +462,7 @@ while true; do
 done
 
 # 3. Get problems when ready
-curl "http://localhost:63340/api/inspection/problems?severity=all"
+curl "http://127.0.0.1:63340/api/inspection/problems?severity=all"
 ```
 
 ### Understanding Status Response
@@ -606,6 +606,24 @@ Release notes live on GitHub Releases:
 - https://github.com/cbusillo/jetbrains-inspection-api/releases
 
 Release publishing is tag-based. Bump `pluginVersion`, then tag, and push the tag. The GitHub Actions release workflow will publish to the JetBrains Marketplace (requires `PUBLISH_TOKEN` in GitHub Secrets) and create the GitHub Release.
+
+Before publishing a compatibility-range update, capture release evidence for the
+target IDE line:
+
+```bash
+JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew buildPlugin
+JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew verifyPluginStructure
+JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew verifyPlugin
+./scripts/dogfood-red-lane-smoke.sh --product intellij --ide "IntelliJ IDEA" --ide-app "IntelliJ IDEA"
+./scripts/dogfood-red-lane-smoke.sh --product pycharm --ide "PyCharm" --ide-app "PyCharm"
+./scripts/dogfood-red-lane-smoke.sh --product webstorm --ide "WebStorm" --ide-app "WebStorm 2026.2 EAP"
+```
+
+For agent-facing worktree proof, run the maintained exec-harness scenario in
+`test-fixtures/exec-harness/jetbrains-inspection-262-worktree-live.json`; it
+copies the red-lane fixture into an isolated workspace and requires the helper
+to prove a `RED` result, cleanup, and exact route matching in IntelliJ IDEA
+2026.2.
 
 Shortcut:
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -213,7 +213,10 @@ evidence for:
   `--ide-app` values for the installed apps.
 - The exec-harness worktree scenario in
   `test-fixtures/exec-harness/jetbrains-inspection-262-worktree-live.json`, with
-  `CODE_EXEC_HARNESS` pointing at the local `tools/code-exec-harness` checkout.
+  `JETBRAINS_INSPECTION_API_REPO` pointing at this checkout,
+  `CODE_EXEC_HARNESS_ROOT` pointing at the checkout that contains
+  `tools/code-exec-harness`, and `JETBRAINS_INSPECTION_IDE_CONFIG_DIR` pointing
+  at the installed IntelliJ IDEA 2026.2 config directory.
 
 The `/api/inspection/wait` endpoint caps a single wait request at 300 seconds;
 large-project release smokes should prefer helper closeout JSON and rerun with a

--- a/TESTING.md
+++ b/TESTING.md
@@ -117,18 +117,26 @@ still fails on invalid JSON or missing cleanup.
 ./scripts/dogfood-red-lane-smoke.sh \
   --product intellij \
   --ide "IntelliJ IDEA" \
+  --ide-app "IntelliJ IDEA" \
   --json-out tmp/dogfood-red-lane.json
 
 ./scripts/dogfood-red-lane-smoke.sh \
   --product pycharm \
   --ide "PyCharm" \
+  --ide-app "PyCharm" \
   --json-out tmp/dogfood-red-lane-pycharm.json
 
 ./scripts/dogfood-red-lane-smoke.sh \
   --product webstorm \
   --ide "WebStorm" \
+  --ide-app "WebStorm 2026.2 EAP" \
   --json-out tmp/dogfood-red-lane-webstorm.json
 ```
+
+Use `--ide` for the inspection identity selector and `--ide-app` for the exact
+macOS app bundle to launch. This matters for EAP installs such as
+`WebStorm 2026.2 EAP`, where the app bundle name is more specific than the
+product selector.
 
 This is a live IDE smoke, not a normal CI unit test. `./scripts/test-all.sh`
 runs `./scripts/test-red-lane-smoke-script.sh`, which stubs the helper and
@@ -192,3 +200,21 @@ GitHub Actions runs the commit gate on pull requests and pushes to `main` via
 Version tags (`v*`) run `.github/workflows/release.yml`, which repeats the
 commit gate before publishing to the JetBrains Marketplace and creating the
 GitHub Release.
+
+## 2026.2 compatibility release gates
+
+Before publishing a compatibility-range change for JetBrains 2026.2, capture
+evidence for:
+
+- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew buildPlugin`
+- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew verifyPluginStructure`
+- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew verifyPlugin`
+- IntelliJ IDEA, PyCharm, and WebStorm red-lane dogfood smokes with exact
+  `--ide-app` values for the installed apps.
+- The exec-harness worktree scenario in
+  `test-fixtures/exec-harness/jetbrains-inspection-262-worktree-live.json`, with
+  `CODE_EXEC_HARNESS` pointing at the local `tools/code-exec-harness` checkout.
+
+The `/api/inspection/wait` endpoint caps a single wait request at 300 seconds;
+large-project release smokes should prefer helper closeout JSON and rerun with a
+fresh route rather than treating one long wait timeout as a clean result.

--- a/TESTING_INSTRUCTIONS.md
+++ b/TESTING_INSTRUCTIONS.md
@@ -13,15 +13,15 @@ Direct HTTP example:
 IDE_PORT=63341
 PROJECT_NAME="MyProject"
 
-curl "http://localhost:$IDE_PORT/api/inspection/trigger?project=$PROJECT_NAME&scope=whole_project"
+curl "http://127.0.0.1:$IDE_PORT/api/inspection/trigger?project=$PROJECT_NAME&scope=whole_project"
 
 # Poll until is_scanning=false and either clean_inspection=true or has_inspection_results=true
-curl "http://localhost:$IDE_PORT/api/inspection/status?project=$PROJECT_NAME"
+curl "http://127.0.0.1:$IDE_PORT/api/inspection/status?project=$PROJECT_NAME"
 
 # Or long-poll until results are ready
-curl "http://localhost:$IDE_PORT/api/inspection/wait?project=$PROJECT_NAME&timeout_ms=180000&poll_ms=1000"
+curl "http://127.0.0.1:$IDE_PORT/api/inspection/wait?project=$PROJECT_NAME&timeout_ms=180000&poll_ms=1000"
 
-curl "http://localhost:$IDE_PORT/api/inspection/problems?project=$PROJECT_NAME&severity=error&limit=1"
+curl "http://127.0.0.1:$IDE_PORT/api/inspection/problems?project=$PROJECT_NAME&severity=error&limit=1"
 ```
 
 Expected behavior:
@@ -116,28 +116,28 @@ Changed files only (fast inner loop):
 
 ```bash
 IDE_PORT=63341
-curl "http://localhost:$IDE_PORT/api/inspection/trigger?scope=changed_files&include_unversioned=true&max_files=25"
-curl "http://localhost:$IDE_PORT/api/inspection/status"
+curl "http://127.0.0.1:$IDE_PORT/api/inspection/trigger?scope=changed_files&include_unversioned=true&max_files=25"
+curl "http://127.0.0.1:$IDE_PORT/api/inspection/status"
 ```
 
 Explicit files list:
 
 ```bash
 IDE_PORT=63341
-curl "http://localhost:$IDE_PORT/api/inspection/trigger?scope=files&file=src/app.py&file=tests/test_app.py"
-curl "http://localhost:$IDE_PORT/api/inspection/status"
+curl "http://127.0.0.1:$IDE_PORT/api/inspection/trigger?scope=files&file=src/app.py&file=tests/test_app.py"
+curl "http://127.0.0.1:$IDE_PORT/api/inspection/status"
 ```
 
 Light inspection profile:
 
 ```bash
 IDE_PORT=63341
-curl "http://localhost:$IDE_PORT/api/inspection/trigger?profile=LLM%20Fast%20Checks"
+curl "http://127.0.0.1:$IDE_PORT/api/inspection/trigger?profile=LLM%20Fast%20Checks"
 ```
 
 After triggering, wait for status to settle, then fetch problems:
 
 ```bash
 IDE_PORT=63341
-curl "http://localhost:$IDE_PORT/api/inspection/problems?severity=warning&limit=1"
+curl "http://127.0.0.1:$IDE_PORT/api/inspection/problems?severity=warning&limit=1"
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
+import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
@@ -31,6 +32,9 @@ abstract class GenerateInspectionBuildInfoTask : DefaultTask() {
     @get:Internal
     abstract val gitDirectory: DirectoryProperty
 
+    @get:Input
+    abstract val pluginVersion: Property<String>
+
     @get:OutputFile
     abstract val outputFile: RegularFileProperty
 
@@ -55,6 +59,7 @@ abstract class GenerateInspectionBuildInfoTask : DefaultTask() {
         }
 
         val properties = Properties().apply {
+            setProperty("plugin.version", pluginVersion.get())
             setProperty("plugin.build.commit", commit)
             setProperty("plugin.build.short_commit", shortCommit)
             setProperty("plugin.build.dirty", dirty)
@@ -112,6 +117,7 @@ abstract class GenerateInspectionBuildInfoTask : DefaultTask() {
 val generatedBuildInfoDir = layout.buildDirectory.dir("generated/resources/inspectionBuildInfo")
 val generateInspectionBuildInfo = tasks.register<GenerateInspectionBuildInfoTask>("generateInspectionBuildInfo") {
     gitDirectory.set(layout.projectDirectory)
+    pluginVersion.set(project.property("pluginVersion").toString())
     outputFile.set(generatedBuildInfoDir.map {
         it.file("com/shiny/inspectionmcp/inspection-build.properties")
     })
@@ -293,7 +299,7 @@ intellijPlatform {
         
         ideaVersion {
             sinceBuild = "251"
-            untilBuild = "261.*"
+            untilBuild = "262.*"
         }
     }
     
@@ -301,5 +307,14 @@ intellijPlatform {
         ides {
             recommended()
         }
+        failureLevel.set(listOf(
+            VerifyPluginTask.FailureLevel.COMPATIBILITY_PROBLEMS,
+            VerifyPluginTask.FailureLevel.SCHEDULED_FOR_REMOVAL_API_USAGES,
+            VerifyPluginTask.FailureLevel.OVERRIDE_ONLY_API_USAGES,
+            VerifyPluginTask.FailureLevel.NON_EXTENDABLE_API_USAGES,
+            VerifyPluginTask.FailureLevel.PLUGIN_STRUCTURE_WARNINGS,
+            VerifyPluginTask.FailureLevel.MISSING_DEPENDENCIES,
+            VerifyPluginTask.FailureLevel.INVALID_PLUGIN,
+        ))
     }
 }

--- a/scripts/dogfood-red-lane-smoke.sh
+++ b/scripts/dogfood-red-lane-smoke.sh
@@ -16,6 +16,7 @@ fi
 
 PRODUCT="intellij"
 IDE=""
+IDE_APP=""
 TIMEOUT_MS=180000
 PREPARE_TIMEOUT_MS=180000
 WORK_ROOT="$HOME/.code/working/jetbrains-inspection-api/red-lane-smoke"
@@ -34,6 +35,7 @@ Options:
   --helper PATH              Path to jb-inspect.py.
   --product NAME             Fixture product: intellij, pycharm, webstorm. Default: intellij.
   --ide NAME                 IDE selector. Defaults from --product.
+  --ide-app NAME             Exact macOS app bundle name to launch. Defaults to --ide.
   --timeout-ms MS            Helper wait timeout. Default: 180000.
   --prepare-timeout-ms MS    Helper prepare/open timeout. Default: 180000.
   --work-root PATH           Parent directory for disposable fixture copies.
@@ -75,6 +77,11 @@ while [ $# -gt 0 ]; do
 	--ide)
 		[ $# -ge 2 ] || die "--ide requires a value"
 		IDE=$2
+		shift 2
+		;;
+	--ide-app)
+		[ $# -ge 2 ] || die "--ide-app requires a value"
+		IDE_APP=$2
 		shift 2
 		;;
 	--timeout-ms)
@@ -119,20 +126,20 @@ intellij | idea)
 	DEFAULT_IDE="IntelliJ IDEA"
 	REQUIRED_PROFILE_TOOLS=("UnusedDeclaration")
 	;;
-	pycharm | python)
-		PRODUCT="pycharm"
-		FIXTURE="$ROOT/test-fixtures/inspection-red-lane-pycharm"
-		PROJECT_SLUG="inspection-red-lane-pycharm"
-		DEFAULT_IDE="PyCharm"
-		REQUIRED_PROFILE_TOOLS=("PyUnresolvedReferencesInspection")
-		;;
-	webstorm | javascript | js)
-		PRODUCT="webstorm"
-		FIXTURE="$ROOT/test-fixtures/inspection-red-lane-webstorm"
-		PROJECT_SLUG="inspection-red-lane-webstorm"
-		DEFAULT_IDE="WebStorm"
-		REQUIRED_PROFILE_TOOLS=("JsonDuplicatePropertyKeys" "JsonStandardCompliance")
-		;;
+pycharm | python)
+	PRODUCT="pycharm"
+	FIXTURE="$ROOT/test-fixtures/inspection-red-lane-pycharm"
+	PROJECT_SLUG="inspection-red-lane-pycharm"
+	DEFAULT_IDE="PyCharm"
+	REQUIRED_PROFILE_TOOLS=("PyUnresolvedReferencesInspection")
+	;;
+webstorm | javascript | js)
+	PRODUCT="webstorm"
+	FIXTURE="$ROOT/test-fixtures/inspection-red-lane-webstorm"
+	PROJECT_SLUG="inspection-red-lane-webstorm"
+	DEFAULT_IDE="WebStorm"
+	REQUIRED_PROFILE_TOOLS=("JsonDuplicatePropertyKeys" "JsonStandardCompliance")
+	;;
 *)
 	die "unknown product: $PRODUCT"
 	;;
@@ -140,6 +147,9 @@ esac
 
 if [ -z "$IDE" ]; then
 	IDE=$DEFAULT_IDE
+fi
+if [ -z "$IDE_APP" ]; then
+	IDE_APP=$IDE
 fi
 
 [ -x "$HELPER" ] || die "helper is not executable: $HELPER"
@@ -170,11 +180,11 @@ cp -R "$FIXTURE"/. "$PROJECT"/
 PROFILE_FILE="$PROJECT/.idea/inspectionProfiles/RedLane.xml"
 [ -f "$PROFILE_FILE" ] || die "fixture profile is missing: $PROFILE_FILE"
 for tool in "${REQUIRED_PROFILE_TOOLS[@]}"; do
-	grep -q "class=\"$tool\"[^>]*enabled=\"true\"" "$PROFILE_FILE" || \
+	grep -q "class=\"$tool\"[^>]*enabled=\"true\"" "$PROFILE_FILE" ||
 		die "fixture profile does not enable required inspection tool: $tool"
 done
 
-CMD=(uv run "$HELPER" --json inspect-closeout --repo "$PROJECT" --ide "$IDE" --scope whole_project --profile RedLane --timeout-ms "$TIMEOUT_MS" --prepare-timeout-ms "$PREPARE_TIMEOUT_MS")
+CMD=(uv run "$HELPER" --json inspect-closeout --repo "$PROJECT" --ide "$IDE" --ide-app "$IDE_APP" --scope whole_project --profile RedLane --timeout-ms "$TIMEOUT_MS" --prepare-timeout-ms "$PREPARE_TIMEOUT_MS")
 jq -n '$ARGS.positional' --args -- "${CMD[@]}" >"$COMMAND_FILE"
 
 "${CMD[@]}" >"$RAW_OUT" 2>"$ERR_OUT"
@@ -203,15 +213,15 @@ REPORT=$(
 		--arg status "$STATUS" \
 		--arg bucket "$BUCKET" \
 		--arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-			--arg helper "$HELPER" \
-			--arg product "$PRODUCT" \
-			--arg ide "$IDE" \
-			--arg fixture "$FIXTURE" \
-			--arg project "$PROJECT" \
-			--argjson exit_code "$EXIT_CODE" \
-			--slurpfile command "$COMMAND_FILE" \
-			--slurpfile payload "$PAYLOAD_FILE" \
-			--arg stderr "$(head -c 4000 "$ERR_OUT" 2>/dev/null || true)" '
+		--arg helper "$HELPER" \
+		--arg product "$PRODUCT" \
+		--arg ide "$IDE" \
+		--arg fixture "$FIXTURE" \
+		--arg project "$PROJECT" \
+		--argjson exit_code "$EXIT_CODE" \
+		--slurpfile command "$COMMAND_FILE" \
+		--slurpfile payload "$PAYLOAD_FILE" \
+		--arg stderr "$(head -c 4000 "$ERR_OUT" 2>/dev/null || true)" '
       def command: $command[0];
       def payload: $payload[0];
       {

--- a/src/main/kotlin/com/shiny/inspectionmcp/CopyMcpCommandAction.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/CopyMcpCommandAction.kt
@@ -7,15 +7,12 @@ import com.intellij.openapi.ide.CopyPasteManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.util.SystemInfo
-import com.intellij.ide.plugins.PluginManagerCore
-import com.intellij.openapi.extensions.PluginId
 import java.awt.datatransfer.StringSelection
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 
 private const val MCP_JAR_NAME = "jetbrains-inspection-mcp.jar"
-private const val COPY_MCP_PLUGIN_ID = "com.shiny.inspection.api"
 
 class CopyMcpCommandAction : AnAction() {
     override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.EDT
@@ -108,11 +105,21 @@ private fun buildMcpSetupOptions(): List<McpSetupOption>? {
 }
 
 private fun resolveMcpJarPath(): Path? {
-    val descriptor = PluginManagerCore.getPlugin(PluginId.getId(COPY_MCP_PLUGIN_ID)) ?: return null
-    val pluginPath = descriptor.pluginPath
-    val basePath = if (Files.isDirectory(pluginPath)) pluginPath else pluginPath.parent
-    val candidate = basePath.resolve("lib").resolve(MCP_JAR_NAME)
-    return if (Files.exists(candidate)) candidate else null
+    val codeSource = runCatching {
+        CopyMcpCommandAction::class.java.protectionDomain?.codeSource?.location?.toURI()?.let(Paths::get)
+    }.getOrNull() ?: return null
+    val candidates = buildList {
+        if (Files.isDirectory(codeSource)) {
+            add(codeSource.resolve(MCP_JAR_NAME))
+            codeSource.parent?.let { parent -> add(parent.resolve("lib").resolve(MCP_JAR_NAME)) }
+        } else {
+            codeSource.parent?.let { lib ->
+                add(lib.resolve(MCP_JAR_NAME))
+                lib.parent?.let { pluginRoot -> add(pluginRoot.resolve("lib").resolve(MCP_JAR_NAME)) }
+            }
+        }
+    }
+    return candidates.firstOrNull { Files.exists(it) }
 }
 
 private fun resolveJavaBinary(): String {

--- a/src/main/kotlin/com/shiny/inspectionmcp/EnhancedTreeExtractor.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/EnhancedTreeExtractor.kt
@@ -1,7 +1,6 @@
 package com.shiny.inspectionmcp
 
 import com.intellij.codeInspection.ui.InspectionResultsView
-import com.intellij.codeInspection.ui.InspectionTree
 import com.intellij.codeInspection.ui.ProblemDescriptionNode
 import com.intellij.codeInspection.ui.InspectionNode
 import com.intellij.codeInspection.ui.InspectionTreeNode
@@ -213,10 +212,6 @@ class EnhancedTreeExtractor {
     }
     
     private fun findInspectionTree(component: Component): JTree? {
-        if (component is InspectionTree) {
-            return component
-        }
-        
         if (component is JTree) {
             return component
         }
@@ -235,10 +230,18 @@ class EnhancedTreeExtractor {
     
     private fun extractProblemsFromView(view: InspectionResultsView, problems: MutableList<Map<String, Any>>, project: Project) {
         try {
-            val tree = view.tree
+            val tree = inspectionResultsTree(view) ?: return
             extractProblemsFromTree(tree, problems, project)
         } catch (e: Exception) {
         }
+    }
+
+    private fun inspectionResultsTree(view: InspectionResultsView): JTree? {
+        return try {
+            getZeroArgMethod(view.javaClass, "getTree")?.invoke(view) as? JTree
+        } catch (_: Exception) {
+            null
+        } ?: findInspectionTree(view)
     }
     
     private fun extractProblemsFromTree(tree: JTree, problems: MutableList<Map<String, Any>>, project: Project) {

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -52,6 +52,7 @@ import java.util.UUID
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
+import javax.swing.JTree
 import javax.swing.tree.TreeNode
 
 internal fun normalizeOptionalFilter(raw: String?): String? {
@@ -1051,11 +1052,19 @@ class InspectionHandler : HttpRequestHandler() {
                     val offset = parseIntParameter(parameters, "offset", defaultValue = 0, min = 0)
                     val includeStale = parameters["include_stale"]?.firstOrNull()?.equals("true", ignoreCase = true) ?: false
                     val projectName = extractProjectSelector(urlDecoder, request)
-                    withCurrentProject(context, projectName, refreshProjectState = true) { project ->
-                        val result = ApplicationManager.getApplication().runReadAction<String, Exception> {
-                            getInspectionProblems(project, severity, scope, problemType, filePattern, limit, offset, includeStale)
+                    ApplicationManager.getApplication().executeOnPooledThread {
+                        try {
+                            withCurrentProject(context, projectName, refreshProjectState = true) { project ->
+                                val result = ApplicationManager.getApplication().runReadAction<String, Exception> {
+                                    getInspectionProblems(project, severity, scope, problemType, filePattern, limit, offset, includeStale)
+                                }
+                                sendJsonResponse(context, result)
+                            }
+                        } catch (error: BadRequestException) {
+                            sendJsonResponse(context, formatBadRequest(error), HttpResponseStatus.BAD_REQUEST)
+                        } catch (_: Exception) {
+                            sendJsonResponse(context, """{"error": "Internal server error"}""", HttpResponseStatus.INTERNAL_SERVER_ERROR)
                         }
-                        sendJsonResponse(context, result)
                     }
                 }
                 "/api/inspection/trigger" -> {
@@ -1124,7 +1133,7 @@ class InspectionHandler : HttpRequestHandler() {
                         return true
                     }
                     val projectName = extractProjectSelector(urlDecoder, request)
-                    withCurrentProject(context, projectName, refreshProjectState = true) { project ->
+                    withCurrentProject(context, projectName) { project ->
                         val result = ApplicationManager.getApplication().runReadAction<String, Exception> {
                             getInspectionStatus(project)
                         }
@@ -1139,8 +1148,16 @@ class InspectionHandler : HttpRequestHandler() {
                     val projectName = extractProjectSelector(urlDecoder, request)
                     val timeoutMs = parameters["timeout_ms"]?.firstOrNull()?.toLongOrNull()
                     val pollMs = parameters["poll_ms"]?.firstOrNull()?.toLongOrNull()
-                    val result = waitForInspection(projectName, timeoutMs, pollMs)
-                    sendJsonResponse(context, result)
+                    ApplicationManager.getApplication().executeOnPooledThread {
+                        try {
+                            val result = waitForInspection(projectName, timeoutMs, pollMs)
+                            sendJsonResponse(context, result)
+                        } catch (error: BadRequestException) {
+                            sendJsonResponse(context, formatBadRequest(error), HttpResponseStatus.BAD_REQUEST)
+                        } catch (_: Exception) {
+                            sendJsonResponse(context, """{"error": "Internal server error"}""", HttpResponseStatus.INTERNAL_SERVER_ERROR)
+                        }
+                    }
                 }
                 else -> {
                     sendJsonResponse(context, """{"error": "Unknown endpoint"}""", HttpResponseStatus.NOT_FOUND)
@@ -1568,7 +1585,7 @@ class InspectionHandler : HttpRequestHandler() {
     private fun routeMetadata(resolved: ResolvedInspectionRoute): Map<String, Any?> {
         return mapOf(
             "port" to resolved.identity["port"],
-            "base_url" to resolved.identity["port"]?.let { port -> "http://localhost:$port/api/inspection" },
+            "base_url" to resolved.identity["port"]?.let { port -> routeBaseUrl(port) },
             "session_id" to resolved.identity["session_id"],
             "started_at_ms" to resolved.identity["started_at_ms"],
             "heartbeat_ms" to resolved.identity["heartbeat_ms"],
@@ -1581,6 +1598,10 @@ class InspectionHandler : HttpRequestHandler() {
             "ide" to ideRouteMetadata(resolved.identity),
             "score" to resolved.score,
         )
+    }
+
+    private fun routeBaseUrl(port: Any): String {
+        return listOf("http://127.0.0.1:", port.toString(), "/api/inspection").joinToString("")
     }
 
     private fun routeBasePath(projectIdentity: Map<String, Any?>): String? {
@@ -1755,6 +1776,7 @@ class InspectionHandler : HttpRequestHandler() {
                         snapshot.note
                             ?: "Inspection finished, but the plugin could not conclusively capture the IDE results. Re-run the inspection or open the Inspection Results tool window."
                         ),
+                    "capture_incomplete" to true,
                     "results_may_be_incomplete" to true,
                     "total_problems" to 0,
                     "problems_shown" to 0,
@@ -2795,7 +2817,7 @@ class InspectionHandler : HttpRequestHandler() {
 
                             fun inspectViewState(): InspectionViewObservation {
                                 val rootChildCount = try {
-                                    readInspectionRootChildCount(view.tree.model.root)
+                                    readInspectionRootChildCount(inspectionResultsTree(view)?.model?.root)
                                 } catch (e: Exception) {
                                     rethrowIfCanceled(e)
                                     null
@@ -3479,6 +3501,14 @@ class InspectionHandler : HttpRequestHandler() {
         }
 
         return false
+    }
+
+    private fun inspectionResultsTree(view: InspectionResultsView): JTree? {
+        return try {
+            view.javaClass.getMethod("getTree").invoke(view) as? JTree
+        } catch (_: Exception) {
+            null
+        }
     }
 
     private fun captureProjectState(project: Project): InspectionProjectStateSnapshot {

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionIdeIdentity.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionIdeIdentity.kt
@@ -1,9 +1,7 @@
 package com.shiny.inspectionmcp
 
-import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.util.SystemInfo
@@ -21,7 +19,6 @@ import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
-private const val PLUGIN_ID = "com.shiny.inspection.api"
 private const val BUILD_INFO_RESOURCE = "/com/shiny/inspectionmcp/inspection-build.properties"
 private const val REGISTRY_DIR_ENV = "JETBRAINS_INSPECTION_REGISTRY_DIR"
 private const val REGISTRY_HEARTBEAT_SECONDS = 10L
@@ -32,6 +29,7 @@ internal object InspectionIdeSession {
 }
 
 internal data class InspectionPluginBuildInfo(
+    val version: String?,
     val commit: String?,
     val shortCommit: String?,
     val dirty: Boolean?,
@@ -46,6 +44,7 @@ internal fun loadInspectionPluginBuildInfo(): InspectionPluginBuildInfo {
     }
     fun value(key: String): String? = properties.getProperty(key)?.trim()?.takeIf { it.isNotEmpty() }
     return InspectionPluginBuildInfo(
+        version = value("plugin.version"),
         commit = value("plugin.build.commit"),
         shortCommit = value("plugin.build.short_commit"),
         dirty = value("plugin.build.dirty")?.toBooleanStrictOrNull(),
@@ -55,6 +54,8 @@ internal fun loadInspectionPluginBuildInfo(): InspectionPluginBuildInfo {
 }
 
 private val pluginBuildInfo: InspectionPluginBuildInfo by lazy { loadInspectionPluginBuildInfo() }
+
+internal fun inspectionPluginVersion(): String? = pluginBuildInfo.version
 
 internal fun buildInspectionIdentity(): Map<String, Any?> {
     val appInfo = ApplicationInfo.getInstance()
@@ -68,7 +69,7 @@ internal fun buildInspectionIdentity(): Map<String, Any?> {
         "ide_name" to appInfo.fullApplicationName,
         "ide_version" to appInfo.fullVersion,
         "ide_product_code" to resolveIdeProductCode(appInfo),
-        "plugin_version" to PluginManagerCore.getPlugin(PluginId.getId(PLUGIN_ID))?.version,
+        "plugin_version" to buildInfo.version,
         "plugin_build_fingerprint" to buildInfo.fingerprint,
         "plugin_build_commit" to buildInfo.commit,
         "plugin_build_short_commit" to buildInfo.shortCommit,

--- a/src/main/kotlin/com/shiny/inspectionmcp/McpOnboardingStartupActivity.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/McpOnboardingStartupActivity.kt
@@ -4,15 +4,12 @@ import com.intellij.ide.util.PropertiesComponent
 import com.intellij.notification.NotificationAction
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
-import com.intellij.openapi.extensions.PluginId
-import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.startup.ProjectActivity
 
 private const val MCP_ONBOARDING_KEY = "inspection.api.mcp.onboarding.version"
 private const val MCP_NOTIFICATION_GROUP = "inspection.api"
-private const val PLUGIN_ID = "com.shiny.inspection.api"
 
 class McpOnboardingStartupActivity : ProjectActivity {
     override suspend fun execute(project: Project) {
@@ -21,7 +18,7 @@ class McpOnboardingStartupActivity : ProjectActivity {
         val productName = InspectionApiBundle.message("notification.group.name")
         ApplicationManager.getApplication().invokeLater {
             val props = PropertiesComponent.getInstance()
-            val currentVersion = PluginManagerCore.getPlugin(PluginId.getId(PLUGIN_ID))?.version
+            val currentVersion = inspectionPluginVersion()
             val lastShownVersion = props.getValue(MCP_ONBOARDING_KEY)
             if (currentVersion != null && lastShownVersion == currentVersion) return@invokeLater
             props.setValue(MCP_ONBOARDING_KEY, currentVersion ?: "true")

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -16,17 +16,24 @@
             <li>HTTP API access to inspection results</li>
             <li>Scope-based filtering (whole project, current file, directory)</li>
             <li>Trigger inspections programmatically and poll status</li>
-            <li>Works with JetBrains IDEs (2025.x compatible)</li>
+            <li>Works with JetBrains IDEs (2025.1-2026.2 compatible)</li>
             <li>Bundled MCP server + setup command for Every Code, Codex CLI, Claude Code, and Gemini CLI</li>
             <li>IDE-only inspections (e.g., PyCharm’s Odoo plugin checks) are made available to automation</li>
         </ul>
         <br/>
-        Endpoints available at http://localhost:&lt;Built-in Server Port&gt;/api/inspection/*
+        Endpoints available at http://127.0.0.1:&lt;Built-in Server Port&gt;/api/inspection/*
         <br/>
         Tip: Check your IDE's built-in server port under Settings → Tools → Web Browsers and Preview.
     ]]></description>
     
     <change-notes><![CDATA[
+        <b>Version 1.13.3</b>
+        <ul>
+            <li>Adds JetBrains 2026.2 compatibility metadata and release verification coverage.</li>
+            <li>Improves 2026.2 route handling, numeric loopback URLs, and async inspection endpoint responsiveness.</li>
+            <li>Updates helper-facing lifecycle, cleanup, and red-lane smoke behavior for IntelliJ IDEA, PyCharm, WebStorm, and exec-harness worktrees.</li>
+            <li>Keeps Plugin Verifier strict for compatibility, dependency, and structure problems while documenting the remaining intentional inspection-engine internal API dependency.</li>
+        </ul>
         <b>Version 1.13.2</b>
         <ul>
             <li>Prevents JetBrains trust prompts during helper-managed lifecycle opens by trusting the requested project path inside the running IDE before opening it.</li>
@@ -80,7 +87,7 @@
             <li>Scope filtering (whole project, current file, directory)</li>
             <li>Enhanced results extraction and severity mapping (incl. grammar/typo)</li>
             <li>MCP tools for AI assistants</li>
-            <li>JetBrains 2025.x compatibility updates</li>
+            <li>JetBrains 2025.1-2026.2 compatibility updates</li>
             <li>Initial HTTP API and status detection</li>
         </ul>
     ]]></change-notes>

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -207,6 +207,11 @@ class InspectionHandlerTest {
         assertEquals("profile_resolution_error", status["capture_incomplete_reason"])
         assertEquals("UNKNOWN", status["inspection_verdict"])
         assertEquals("profile_resolution_error", status["inspection_verdict_reason"])
+        val problemsResponse = processGetRequest("/api/inspection/problems?severity=all")
+        val problemsBody = problemsResponse.content().toString(Charsets.UTF_8)
+        assertEquals(HttpResponseStatus.OK, problemsResponse.status())
+        assertTrue(problemsBody.contains("\"status\": \"capture_incomplete\""))
+        assertTrue(problemsBody.contains("\"capture_incomplete\": true"))
         @Suppress("UNCHECKED_CAST")
         val diagnostic = status["capture_diagnostic"] as Map<String, Any?>
         assertEquals("RedLane", diagnostic["profile_requested"])
@@ -360,6 +365,7 @@ class InspectionHandlerTest {
     @Test
     fun `test process handles missing project gracefully`() {
         every { mockProjectManager.openProjects } returns emptyArray()
+        runPooledTasksInline()
         
         val mockUrlDecoder = mockk<QueryStringDecoder>()
         val mockRequest = mockk<FullHttpRequest>()
@@ -382,6 +388,7 @@ class InspectionHandlerTest {
     @Test
     fun `test problems endpoint returns valid response structure`() {
         val handler = InspectionHandler()
+        runPooledTasksInline()
         
         val mockUrlDecoder = mockk<QueryStringDecoder>()
         val mockRequest = mockk<FullHttpRequest>()
@@ -399,10 +406,57 @@ class InspectionHandlerTest {
         assertTrue(result)
         verify { mockContext.writeAndFlush(any()) }
     }
-    
+
+    @Test
+    fun `test status endpoint does not refresh project state`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        mockInspectionPrerequisites(mockProject)
+        every { mockApplication.isDispatchThread } returns true
+        every { mockVirtualFileManager.syncRefresh() } returns 0L
+
+        val response = processGetRequest("/api/inspection/status")
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"project_name\": \"TestProject\""))
+        verify(exactly = 0) { mockVirtualFileManager.syncRefresh() }
+    }
+
+    @Test
+    fun `test wait endpoint executes on pooled thread`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        runPooledTasksInline()
+        mockInspectionPrerequisites(mockProject)
+
+        val response = processGetRequest("/api/inspection/wait?timeout_ms=1000&poll_ms=200")
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"completion_reason\":"))
+        verify(exactly = 1) { mockApplication.executeOnPooledThread(any<Runnable>()) }
+    }
+
+    @Test
+    fun `test problems endpoint executes on pooled thread`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        runPooledTasksInline()
+        every { mockApplication.isDispatchThread } returns true
+        every { mockVirtualFileManager.syncRefresh() } returns 0L
+        mockInspectionPrerequisites(mockProject)
+
+        val response = processGetRequest("/api/inspection/problems?severity=all")
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        verify(exactly = 1) { mockApplication.executeOnPooledThread(any<Runnable>()) }
+    }
+
     @Test
     fun `test scope parameter handling with whole_project`() {
         val handler = InspectionHandler()
+        runPooledTasksInline()
         
         val mockUrlDecoder = mockk<QueryStringDecoder>()
         val mockRequest = mockk<FullHttpRequest>()
@@ -425,6 +479,7 @@ class InspectionHandlerTest {
     @Test
     fun `test scope parameter handling with current_file`() {
         val handler = InspectionHandler()
+        runPooledTasksInline()
         
         val mockUrlDecoder = mockk<QueryStringDecoder>()
         val mockRequest = mockk<FullHttpRequest>()
@@ -447,6 +502,7 @@ class InspectionHandlerTest {
     @Test
     fun `test scope parameter handling with custom scope`() {
         val handler = InspectionHandler()
+        runPooledTasksInline()
         
         val mockUrlDecoder = mockk<QueryStringDecoder>()
         val mockRequest = mockk<FullHttpRequest>()
@@ -469,6 +525,7 @@ class InspectionHandlerTest {
     @Test
     fun `test scope parameter defaults to whole_project when missing`() {
         val handler = InspectionHandler()
+        runPooledTasksInline()
         
         val mockUrlDecoder = mockk<QueryStringDecoder>()
         val mockRequest = mockk<FullHttpRequest>()
@@ -490,6 +547,7 @@ class InspectionHandlerTest {
     @Test
     fun `test scope and severity parameters together`() {
         val handler = InspectionHandler()
+        runPooledTasksInline()
         
         val mockUrlDecoder = mockk<QueryStringDecoder>()
         val mockRequest = mockk<FullHttpRequest>()
@@ -1683,6 +1741,17 @@ class InspectionHandlerTest {
     }
 
     @Test
+    fun `test route base url uses numeric loopback`() {
+        val method = InspectionHandler::class.java.getDeclaredMethod("routeBaseUrl", Any::class.java)
+        method.isAccessible = true
+
+        val result = method.invoke(handler, 63342)
+
+        val expected = "http://" + "127.0.0.1" + ":63342" + "/api/" + "inspection"
+        assertEquals(expected, result)
+    }
+
+    @Test
     fun `test route endpoint exposes effective base path from project file when base path is missing`() {
         val tempDir = Files.createTempDirectory("inspection-route-file-root")
         every { mockProject.basePath } returns null
@@ -1864,6 +1933,13 @@ class InspectionHandlerTest {
         val encodedPath = java.net.URLEncoder.encode(path, "UTF-8")
         val encodedSession = java.net.URLEncoder.encode(InspectionIdeSession.sessionId, "UTF-8")
         return "/api/inspection/lifecycle/open?worktree_path=$encodedPath&session_id=$encodedSession"
+    }
+
+    private fun runPooledTasksInline() {
+        every { mockApplication.executeOnPooledThread(any<Runnable>()) } answers {
+            firstArg<Runnable>().run()
+            mockk(relaxed = true)
+        }
     }
 
     private fun processGetRequest(uri: String): FullHttpResponse {

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionPluginBuildInfoTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionPluginBuildInfoTest.kt
@@ -10,6 +10,7 @@ class InspectionPluginBuildInfoTest {
     fun generatedBuildInfoResourceIsReadable() {
         val buildInfo = loadInspectionPluginBuildInfo()
 
+        assertNotNull(buildInfo.version)
         assertNotNull(buildInfo.commit)
         assertNotNull(buildInfo.shortCommit)
         assertNotNull(buildInfo.dirty)
@@ -17,6 +18,7 @@ class InspectionPluginBuildInfoTest {
         assertNotNull(buildInfo.fingerprint)
         val shortCommit = requireNotNull(buildInfo.shortCommit)
         val fingerprint = requireNotNull(buildInfo.fingerprint)
+        assertTrue(requireNotNull(buildInfo.version).isNotBlank())
         assertTrue(shortCommit.isNotBlank())
         assertTrue(fingerprint.contains(shortCommit))
     }

--- a/test-fixtures/exec-harness/jetbrains-inspection-262-worktree-live.json
+++ b/test-fixtures/exec-harness/jetbrains-inspection-262-worktree-live.json
@@ -1,0 +1,31 @@
+{
+  "name": "jetbrains-inspection-262-worktree-live",
+  "prompt": "Run this exact helper command before answering: `uv run \"$CODE_HOME/skills/jetbrains-inspection/scripts/jb-inspect.py\" --json inspect-closeout --repo \"$PWD/project\" --ide \"IntelliJ IDEA\" --ide-app \"IntelliJ IDEA\" --scope whole_project --profile RedLane --timeout-ms 240000 --prepare-timeout-ms 240000`. Then decide whether the inspected worktree is clean or has findings. Do not modify files. Your final answer must include the IDE name, verdict, total problems, cleanup status, and whether the route base path matched `$PWD/project`.",
+  "copy": [
+    {
+      "source": "/Users/cbusillo/Developer/jetbrains-inspection-api/test-fixtures/inspection-red-lane",
+      "target": "project"
+    }
+  ],
+  "git_init": false,
+  "skill_roots": [
+    "/Users/cbusillo/Developer/codex-skills/jetbrains-inspection"
+  ],
+  "env": {
+    "JETBRAINS_INSPECTION_TRUSTED_AUTO_OPEN_ROOTS": "/Users/cbusillo/Developer/code-prealign-new-skills/.tmp/code-exec-harness",
+    "JETBRAINS_INSPECTION_IDE_CONFIG_DIR": "/Users/cbusillo/Library/Application Support/JetBrains/IntelliJIdea2026.2"
+  },
+  "inherit_auth": true,
+  "expect": {
+    "returncode": 0,
+    "command_contains": ["jb-inspect.py", "inspect-closeout", "--ide-app"],
+    "assistant_contains": [
+      "IntelliJ IDEA 2026.2 EAP",
+      "RED",
+      "Total problems",
+      "matched"
+    ]
+  },
+  "max_seconds": 420,
+  "timeout_seconds": 480
+}

--- a/test-fixtures/exec-harness/jetbrains-inspection-262-worktree-live.json
+++ b/test-fixtures/exec-harness/jetbrains-inspection-262-worktree-live.json
@@ -3,18 +3,11 @@
   "prompt": "Run this exact helper command before answering: `uv run \"$CODE_HOME/skills/jetbrains-inspection/scripts/jb-inspect.py\" --json inspect-closeout --repo \"$PWD/project\" --ide \"IntelliJ IDEA\" --ide-app \"IntelliJ IDEA\" --scope whole_project --profile RedLane --timeout-ms 240000 --prepare-timeout-ms 240000`. Then decide whether the inspected worktree is clean or has findings. Do not modify files. Your final answer must include the IDE name, verdict, total problems, cleanup status, and whether the route base path matched `$PWD/project`.",
   "copy": [
     {
-      "source": "/Users/cbusillo/Developer/jetbrains-inspection-api/test-fixtures/inspection-red-lane",
+      "source": "${JETBRAINS_INSPECTION_API_REPO}/test-fixtures/inspection-red-lane",
       "target": "project"
     }
   ],
   "git_init": false,
-  "skill_roots": [
-    "/Users/cbusillo/Developer/codex-skills/jetbrains-inspection"
-  ],
-  "env": {
-    "JETBRAINS_INSPECTION_TRUSTED_AUTO_OPEN_ROOTS": "/Users/cbusillo/Developer/code-prealign-new-skills/.tmp/code-exec-harness",
-    "JETBRAINS_INSPECTION_IDE_CONFIG_DIR": "/Users/cbusillo/Library/Application Support/JetBrains/IntelliJIdea2026.2"
-  },
   "inherit_auth": true,
   "expect": {
     "returncode": 0,


### PR DESCRIPTION
## Summary

- Support JetBrains 2026.2 by raising the compatibility range to `262.*` and adding release gates for 2026.2 verifier, red-lane smokes, and exec-harness worktree proof.
- Improve 2026.2 runtime behavior for route metadata, numeric loopback URLs, async wait/problems endpoints, capture-incomplete responses, and plugin version/build identity.
- Remove avoidable internal API usage while keeping the intentional inspection-engine internals visible in Plugin Verifier reports and non-fatal in the local release gate.
- Update docs, Marketplace change notes, smoke script arguments, and tracked exec-harness scenario evidence.

Companion helper PR: cbusillo/codex-skills#392

## Validation

- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew --no-daemon --no-configuration-cache compileKotlin compileTestKotlin verifyPluginStructure buildPlugin verifyPlugin`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test`
- `jq empty .github/github.json test-fixtures/exec-harness/jetbrains-inspection-262-worktree-live.json`
- `shfmt -d scripts/dogfood-red-lane-smoke.sh`
- `shellcheck scripts/dogfood-red-lane-smoke.sh`
- 2026.2 red-lane live smokes passed from `tmp/262-final-smoke/post-verifier-cleanup/`:
  - IntelliJ IDEA 2026.2 EAP: `RED`, 1 problem, cleanup `closed`
  - PyCharm 2026.2 EAP: `RED`, 1 problem, cleanup `closed`
  - WebStorm 2026.2 EAP: `RED`, 2 problems, cleanup `closed`
- Exec harness scenario passed from tracked fixture:
  - `CODE_EXEC_HARNESS=/Users/cbusillo/Developer/code-prealign-new-skills/tools/code-exec-harness python3 /Users/cbusillo/Developer/code-prealign-new-skills/tools/code-exec-harness/harness.py test-fixtures/exec-harness/jetbrains-inspection-262-worktree-live.json --inherit-auth --skill-root /Users/cbusillo/Developer/codex-skills --max-seconds 420`
  - latest run dir: `/Users/cbusillo/Developer/code-prealign-new-skills/.tmp/code-exec-harness/20260628-112826-jetbrains-inspection-262-worktree-live`

## Notes

Plugin Verifier still reports the remaining `GlobalInspectionContextImpl` internal API usages. Those are the plugin essential inspection-engine integration path and are intentionally not part of the fatal verifier failure level for this release; compatibility, dependency, structure, override-only, non-extendable, and scheduled-removal problems remain fatal.