### PR TITLE
Release 1.13.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion=1.13.3
+pluginVersion=1.13.4
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
 kotlin.stdlib.default.dependency=false
 # Enable Gradle Configuration Cache -> https://docs.gradle.org/current/userguide/configuration_cache.html

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.shiny.inspection.api</id>
     <name>Inspection API</name>
-    <version>1.13.3</version>
+    <version>1.13.4</version>
     <vendor email="info@shinycomputers.com" url="https://github.com/cbusillo/jetbrains-inspection-api">Shiny Computers (Chris Busillo)</vendor>
     <resource-bundle>messages.InspectionApiBundle</resource-bundle>
     


### PR DESCRIPTION
## Summary
- Bump plugin version to 1.13.4 for the 2026.2 compatibility release.
- Publishes the merged 251-262.* compatibility metadata from PR #126.

## Validation
- ./scripts/test-all.sh passed in the release worktree.
- ./scripts/test-automated.sh passed with PyCharm 2026.2 EAP against the red-lane fixture.
- ./scripts/commit-gate.sh passed before the release commit.
- Commit hook passed while creating the release bump commit.

After this PR merges, tag the resulting main commit as v1.13.4 to trigger the Release workflow.