### PR TITLE
Retry and verify helper-opened project cleanup

### DIFF
--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -720,14 +720,23 @@ class InspectionHandler : HttpRequestHandler() {
         val projectRoot: Path,
         val key: String,
     )
+
+    private data class LifecycleCloseAttempt(
+        val attempt: Int,
+        val save: Boolean,
+        val forceCloseReturned: Boolean,
+        val closedVerified: Boolean,
+        val projectDisposed: Boolean,
+    )
     
     private val runIdSequence = AtomicLong()
     private val inspectionRunStatesByProject = java.util.concurrent.ConcurrentHashMap<String, InspectionRunState>()
     private val leasesByProjectInstance = java.util.concurrent.ConcurrentHashMap<String, InspectionProjectLease>()
     private val openingProjectPaths = java.util.concurrent.ConcurrentHashMap.newKeySet<String>()
-    internal var forceCloseProject: (Project) -> Boolean = { project ->
-        ProjectManagerEx.getInstanceEx().forceCloseProject(project, true)
+    internal var forceCloseProject: (Project, Boolean) -> Boolean = { project, save ->
+        ProjectManagerEx.getInstanceEx().forceCloseProject(project, save)
     }
+    internal var closeVerificationSleep: (Long) -> Unit = { millis -> Thread.sleep(millis) }
     internal var trustProjectPath: (Path) -> Unit = { path ->
         TrustedProjects.setProjectTrusted(path, true)
     }
@@ -1429,21 +1438,16 @@ class InspectionHandler : HttpRequestHandler() {
             return lifecycleCloseSkipped("project_mismatch", "Claimed project key no longer matches the lifecycle claim.", HttpResponseStatus.CONFLICT)
         }
 
-        val closed = runCatching {
-            val application = ApplicationManager.getApplication()
-            if (application.isDispatchThread) {
-                forceCloseProject(project)
-            } else {
-                val closeResult = AtomicReference<Boolean>()
-                application.invokeAndWait {
-                    closeResult.set(forceCloseProject(project))
-                }
-                closeResult.get() == true
-            }
-        }.getOrDefault(false)
+        val closeAttempts = closeClaimedProject(project, expectedProjectInstanceId)
+        val closed = closeAttempts.any { attempt -> attempt.closedVerified }
 
         if (!closed) {
-            return lifecycleCloseSkipped("close_failed", "JetBrains IDE declined or failed to close the claimed project.", HttpResponseStatus.CONFLICT)
+            return lifecycleCloseSkipped(
+                "close_failed",
+                "JetBrains IDE declined or failed to close the claimed project.",
+                HttpResponseStatus.CONFLICT,
+                closeAttempts,
+            )
         }
         leasesByProjectInstance.remove(expectedProjectInstanceId, lease)
         return mapOf(
@@ -1453,13 +1457,79 @@ class InspectionHandler : HttpRequestHandler() {
             "lease_id" to lease.leaseId,
             "session_id" to InspectionIdeSession.sessionId,
             "closed_at_ms" to System.currentTimeMillis(),
+            "close_attempts" to closeAttemptPayload(closeAttempts),
         ).filterValues { value -> value != null } to HttpResponseStatus.OK
+    }
+
+    private fun closeClaimedProject(project: Project, projectInstanceId: String): List<LifecycleCloseAttempt> {
+        val attempts = mutableListOf<LifecycleCloseAttempt>()
+        val saveModes = listOf(true, false, false)
+        for ((index, save) in saveModes.withIndex()) {
+            val forceCloseReturned = closeProjectOnEdt(project, save)
+            val closedVerified = waitForProjectClosed(project, projectInstanceId)
+            attempts.add(
+                LifecycleCloseAttempt(
+                    attempt = index + 1,
+                    save = save,
+                    forceCloseReturned = forceCloseReturned,
+                    closedVerified = closedVerified,
+                    projectDisposed = project.isDisposed,
+                )
+            )
+            if (closedVerified) {
+                break
+            }
+        }
+        return attempts
+    }
+
+    private fun closeProjectOnEdt(project: Project, save: Boolean): Boolean {
+        return runCatching {
+            val application = ApplicationManager.getApplication()
+            if (application.isDispatchThread) {
+                forceCloseProject(project, save)
+            } else {
+                val closeResult = AtomicReference<Boolean>()
+                application.invokeAndWait {
+                    closeResult.set(forceCloseProject(project, save))
+                }
+                closeResult.get() == true
+            }
+        }.getOrDefault(false)
+    }
+
+    private fun waitForProjectClosed(project: Project, projectInstanceId: String): Boolean {
+        if (ApplicationManager.getApplication().isDispatchThread) {
+            return project.isDisposed || findOpenProjectByInstanceId(projectInstanceId) == null
+        }
+        repeat(10) { attempt ->
+            if (project.isDisposed || findOpenProjectByInstanceId(projectInstanceId) == null) {
+                return true
+            }
+            if (attempt < 9) {
+                closeVerificationSleep(100)
+            }
+        }
+        return project.isDisposed || findOpenProjectByInstanceId(projectInstanceId) == null
+    }
+
+    private fun closeAttemptPayload(attempts: List<LifecycleCloseAttempt>): List<Map<String, Any?>> {
+        return attempts.map { attempt ->
+            mapOf(
+                "attempt" to attempt.attempt,
+                "save" to attempt.save,
+                "force_close_returned" to attempt.forceCloseReturned,
+                "closed_verified" to attempt.closedVerified,
+                "project_disposed" to attempt.projectDisposed,
+            )
+        }
     }
 
     private fun lifecycleCloseSkipped(
         reason: String,
         message: String,
         status: HttpResponseStatus = HttpResponseStatus.OK,
+        closeAttempts: List<LifecycleCloseAttempt> = emptyList(),
     ): Pair<Map<String, Any?>, HttpResponseStatus> {
         return mapOf(
             "status" to "skipped",
@@ -1467,6 +1537,7 @@ class InspectionHandler : HttpRequestHandler() {
             "reason" to reason,
             "message" to message,
             "session_id" to InspectionIdeSession.sessionId,
+            "close_attempts" to closeAttemptPayload(closeAttempts).takeIf { it.isNotEmpty() },
         ) to status
     }
 

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -1512,8 +1512,9 @@ class InspectionHandlerTest {
         assertNotNull(token)
         every { mockApplication.isDispatchThread } returns true
         var closedProject: Project? = null
-        handler.forceCloseProject = { project ->
+        handler.forceCloseProject = { project, _ ->
             closedProject = project
+            every { mockProjectManager.openProjects } returns arrayOf(mainProject)
             true
         }
 
@@ -1552,7 +1553,7 @@ class InspectionHandlerTest {
     }
 
     @Test
-    fun `test lifecycle close keeps lease when close fails`() {
+    fun `test lifecycle close verifies closed project after false close result`() {
         every { mockProject.basePath } returns "/repo/app"
         every { mockProject.projectFilePath } returns "/repo/app/.idea/misc.xml"
         val instanceId = projectInstanceId(mockProject)
@@ -1562,7 +1563,105 @@ class InspectionHandlerTest {
         val token = Regex("\"close_token\": \"([^\"]+)\"").find(claim)?.groupValues?.get(1)
         assertNotNull(token)
         every { mockApplication.isDispatchThread } returns true
-        handler.forceCloseProject = { false }
+        handler.forceCloseProject = { _, _ ->
+            every { mockProjectManager.openProjects } returns emptyArray()
+            false
+        }
+
+        val first = processGetRequest(
+            "/api/inspection/lifecycle/close?worktree_path=/repo/app&project_instance_id=$instanceId&close_token=$token"
+        )
+        val second = processGetRequest(
+            "/api/inspection/lifecycle/close?worktree_path=/repo/app&project_instance_id=$instanceId&close_token=$token"
+        )
+        val body = first.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, first.status())
+        assertTrue(body.contains("\"status\": \"closed\""))
+        assertTrue(body.contains("\"force_close_returned\": false"))
+        assertTrue(body.contains("\"closed_verified\": true"))
+        assertTrue(second.content().toString(Charsets.UTF_8).contains("\"reason\": \"not_claimed\""))
+    }
+
+    @Test
+    fun `test lifecycle close retries no-save fallback after transient refusal`() {
+        every { mockProject.basePath } returns "/repo/app"
+        every { mockProject.projectFilePath } returns "/repo/app/.idea/misc.xml"
+        val instanceId = projectInstanceId(mockProject)
+        val claim = processGetRequest(
+            "/api/inspection/lifecycle/claim?worktree_path=/repo/app&project_instance_id=$instanceId&lease_id=test-lease"
+        ).content().toString(Charsets.UTF_8)
+        val token = Regex("\"close_token\": \"([^\"]+)\"").find(claim)?.groupValues?.get(1)
+        assertNotNull(token)
+        every { mockApplication.isDispatchThread } returns false
+        every { mockApplication.invokeAndWait(any()) } answers { firstArg<Runnable>().run() }
+        handler.closeVerificationSleep = {}
+        val saveModes = mutableListOf<Boolean>()
+        handler.forceCloseProject = { _, save ->
+            saveModes.add(save)
+            if (!save) {
+                every { mockProjectManager.openProjects } returns emptyArray()
+                true
+            } else {
+                false
+            }
+        }
+
+        val response = processGetRequest(
+            "/api/inspection/lifecycle/close?worktree_path=/repo/app&project_instance_id=$instanceId&close_token=$token"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"status\": \"closed\""))
+        assertEquals(listOf(true, false), saveModes)
+        assertTrue(body.contains("\"attempt\": 2"))
+        assertTrue(body.contains("\"save\": false"))
+    }
+
+    @Test
+    fun `test lifecycle close does not poll for close verification on dispatch thread`() {
+        every { mockProject.basePath } returns "/repo/app"
+        every { mockProject.projectFilePath } returns "/repo/app/.idea/misc.xml"
+        val instanceId = projectInstanceId(mockProject)
+        val claim = processGetRequest(
+            "/api/inspection/lifecycle/claim?worktree_path=/repo/app&project_instance_id=$instanceId&lease_id=test-lease"
+        ).content().toString(Charsets.UTF_8)
+        val token = Regex("\"close_token\": \"([^\"]+)\"").find(claim)?.groupValues?.get(1)
+        assertNotNull(token)
+        every { mockApplication.isDispatchThread } returns true
+        var sleepCount = 0
+        handler.closeVerificationSleep = { sleepCount++ }
+        handler.forceCloseProject = { _, _ -> false }
+
+        val response = processGetRequest(
+            "/api/inspection/lifecycle/close?worktree_path=/repo/app&project_instance_id=$instanceId&close_token=$token"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.CONFLICT, response.status())
+        assertTrue(body.contains("\"reason\": \"close_failed\""))
+        assertEquals(0, sleepCount)
+    }
+
+    @Test
+    fun `test lifecycle close keeps lease when close fails after retries`() {
+        every { mockProject.basePath } returns "/repo/app"
+        every { mockProject.projectFilePath } returns "/repo/app/.idea/misc.xml"
+        val instanceId = projectInstanceId(mockProject)
+        val claim = processGetRequest(
+            "/api/inspection/lifecycle/claim?worktree_path=/repo/app&project_instance_id=$instanceId&lease_id=test-lease"
+        ).content().toString(Charsets.UTF_8)
+        val token = Regex("\"close_token\": \"([^\"]+)\"").find(claim)?.groupValues?.get(1)
+        assertNotNull(token)
+        every { mockApplication.isDispatchThread } returns false
+        every { mockApplication.invokeAndWait(any()) } answers { firstArg<Runnable>().run() }
+        handler.closeVerificationSleep = {}
+        val saveModes = mutableListOf<Boolean>()
+        handler.forceCloseProject = { _, save ->
+            saveModes.add(save)
+            false
+        }
 
         val first = processGetRequest(
             "/api/inspection/lifecycle/close?worktree_path=/repo/app&project_instance_id=$instanceId&close_token=$token"
@@ -1575,6 +1674,8 @@ class InspectionHandlerTest {
         assertEquals(HttpResponseStatus.CONFLICT, second.status())
         assertTrue(first.content().toString(Charsets.UTF_8).contains("\"reason\": \"close_failed\""))
         assertTrue(second.content().toString(Charsets.UTF_8).contains("\"reason\": \"close_failed\""))
+        assertEquals(listOf(true, false, false, true, false, false), saveModes)
+        assertTrue(first.content().toString(Charsets.UTF_8).contains("\"closed_verified\": false"))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- make lifecycle close evidence-based: verify the claimed project is gone/disposed instead of trusting one force-close boolean
- retry helper-opened project close with save/no-save attempts before reporting close_failed
- include close_attempts diagnostics in lifecycle close responses
- add regression tests for false-but-closed, no-save fallback retry, and persistent close failure

## Validation
- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test --tests com.shiny.inspectionmcp.InspectionHandlerTest
- commit hook / broader Gradle test/buildPlugin run passed during commit
- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew buildPlugin
- installed built plugin into IntelliJIdea2026.1 and dogfooded cold inspect-closeout with --timeout-ms 300000

## Dogfood
- Stable IntelliJ IDEA 2026.1.3 selected via repo metadata
- plugin 1.13.4 build fingerprint d670bad7b2d8-dirty loaded
- helper opened exact repo from cold IDE state
- inspection completed with fresh RED findings
- cleanup now returned status=closed, cleanup_failed=false, cleanup_skipped=false

## Notes
The dogfood run still returned RED due existing IntelliJ declaration-redundancy warnings in InspectionHandler.kt. The cleanup regression itself is fixed: helper-opened project cleanup closed successfully.

Closes #133