### PR TITLE
Harden 262 gate cleanup and exact IDE smokes

### DIFF
--- a/scripts/dogfood-red-lane-smoke.sh
+++ b/scripts/dogfood-red-lane-smoke.sh
@@ -17,6 +17,8 @@ fi
 PRODUCT="intellij"
 IDE=""
 IDE_APP=""
+IDE_CHANNEL=""
+IDE_VERSION=""
 TIMEOUT_MS=180000
 PREPARE_TIMEOUT_MS=180000
 WORK_ROOT="$HOME/.code/working/jetbrains-inspection-api/red-lane-smoke"
@@ -36,6 +38,8 @@ Options:
   --product NAME             Fixture product: intellij, pycharm, webstorm. Default: intellij.
   --ide NAME                 IDE selector. Defaults from --product.
   --ide-app NAME             Exact macOS app bundle name to launch. Defaults to --ide.
+  --ide-channel CHANNEL      IDE channel selector: stable, eap, or any.
+  --ide-version VERSION      Exact IDE version selector, e.g. 2026.2.
   --timeout-ms MS            Helper wait timeout. Default: 180000.
   --prepare-timeout-ms MS    Helper prepare/open timeout. Default: 180000.
   --work-root PATH           Parent directory for disposable fixture copies.
@@ -82,6 +86,16 @@ while [ $# -gt 0 ]; do
 	--ide-app)
 		[ $# -ge 2 ] || die "--ide-app requires a value"
 		IDE_APP=$2
+		shift 2
+		;;
+	--ide-channel)
+		[ $# -ge 2 ] || die "--ide-channel requires a value"
+		IDE_CHANNEL=$2
+		shift 2
+		;;
+	--ide-version)
+		[ $# -ge 2 ] || die "--ide-version requires a value"
+		IDE_VERSION=$2
 		shift 2
 		;;
 	--timeout-ms)
@@ -184,7 +198,14 @@ for tool in "${REQUIRED_PROFILE_TOOLS[@]}"; do
 		die "fixture profile does not enable required inspection tool: $tool"
 done
 
-CMD=(uv run "$HELPER" --json inspect-closeout --repo "$PROJECT" --ide "$IDE" --ide-app "$IDE_APP" --scope whole_project --profile RedLane --timeout-ms "$TIMEOUT_MS" --prepare-timeout-ms "$PREPARE_TIMEOUT_MS")
+CMD=(uv run "$HELPER" --json inspect-closeout --repo "$PROJECT" --ide "$IDE" --ide-app "$IDE_APP")
+if [ -n "$IDE_CHANNEL" ]; then
+	CMD+=(--ide-channel "$IDE_CHANNEL")
+fi
+if [ -n "$IDE_VERSION" ]; then
+	CMD+=(--ide-version "$IDE_VERSION")
+fi
+CMD+=(--scope whole_project --profile RedLane --timeout-ms "$TIMEOUT_MS" --prepare-timeout-ms "$PREPARE_TIMEOUT_MS")
 jq -n '$ARGS.positional' --args -- "${CMD[@]}" >"$COMMAND_FILE"
 
 "${CMD[@]}" >"$RAW_OUT" 2>"$ERR_OUT"
@@ -216,6 +237,8 @@ REPORT=$(
 		--arg helper "$HELPER" \
 		--arg product "$PRODUCT" \
 		--arg ide "$IDE" \
+		--arg ide_channel "$IDE_CHANNEL" \
+		--arg ide_version "$IDE_VERSION" \
 		--arg fixture "$FIXTURE" \
 		--arg project "$PROJECT" \
 		--argjson exit_code "$EXIT_CODE" \
@@ -231,6 +254,8 @@ REPORT=$(
         helper: $helper,
         product: $product,
         ide: $ide,
+        ide_channel: (if $ide_channel == "" then null else $ide_channel end),
+        ide_version: (if $ide_version == "" then null else $ide_version end),
         fixture: $fixture,
         project: $project,
         exit_code: $exit_code,

--- a/scripts/test-red-lane-smoke-script.sh
+++ b/scripts/test-red-lane-smoke-script.sh
@@ -10,6 +10,8 @@ grep -q -- 'inspection-red-lane-pycharm' scripts/dogfood-red-lane-smoke.sh
 grep -q -- 'inspection-red-lane-webstorm' scripts/dogfood-red-lane-smoke.sh
 grep -q -- '--scope whole_project' scripts/dogfood-red-lane-smoke.sh
 grep -q -- '--profile RedLane' scripts/dogfood-red-lane-smoke.sh
+grep -q -- '--ide-channel' scripts/dogfood-red-lane-smoke.sh
+grep -q -- '--ide-version' scripts/dogfood-red-lane-smoke.sh
 
 assert_fixture_intellij() {
 	local fixture_source="test-fixtures/inspection-red-lane/src/main/java/com/example/redlane/DefinitelyRed.java"
@@ -58,6 +60,8 @@ from pathlib import Path
 
 repo = ""
 ide = ""
+ide_channel = ""
+ide_version = ""
 args = sys.argv[1:]
 while args:
     arg = args.pop(0)
@@ -65,6 +69,10 @@ while args:
         repo = args.pop(0)
     elif arg == "--ide" and args:
         ide = args.pop(0)
+    elif arg == "--ide-channel" and args:
+        ide_channel = args.pop(0)
+    elif arg == "--ide-version" and args:
+        ide_version = args.pop(0)
 
 fixtures = [
     ("IntelliJ IDEA", "src/main/java/com/example/redlane/DefinitelyRed.java", "redLaneField"),
@@ -97,6 +105,7 @@ print(json.dumps({
     "problems_shown": 1,
     "clean": False,
     "cleanup": {"status": "closed"},
+    "ide_selection": {"channel": ide_channel or None, "version": ide_version or None},
     "route": {"base_path": repo, "project_name": Path(repo).name, "ide": {"name": ide}},
     "problems": [{"severity": "error", "file": str(fixture), "line": 1, "description": f"Cannot resolve symbol {marker}"}],
 }))
@@ -113,6 +122,8 @@ run_case() {
 		--product "$product" \
 		--helper "$HELPER" \
 		--work-root "$TMP_DIR/work" \
+		--ide-channel eap \
+		--ide-version 2026.2 \
 		--json-out "$json_out"
 
 	jq -e \
@@ -123,6 +134,8 @@ run_case() {
     .bucket == "red_confirmed" and
     .product == $product and
     .ide == $expected_ide and
+    .ide_channel == "eap" and
+    .ide_version == "2026.2" and
     .verdict == "RED" and
     .total_problems == 1 and
     .cleanup.status == "closed" and

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -736,6 +736,9 @@ class InspectionHandler : HttpRequestHandler() {
     internal var forceCloseProject: (Project, Boolean) -> Boolean = { project, save ->
         ProjectManagerEx.getInstanceEx().forceCloseProject(project, save)
     }
+    internal var closeVerificationTimeoutMs: Long = 10_000
+    internal var closeVerificationPollMs: Long = 100
+    internal var closeVerificationNow: () -> Long = { System.currentTimeMillis() }
     internal var closeVerificationSleep: (Long) -> Unit = { millis -> Thread.sleep(millis) }
     internal var trustProjectPath: (Path) -> Unit = { path ->
         TrustedProjects.setProjectTrusted(path, true)
@@ -1463,10 +1466,11 @@ class InspectionHandler : HttpRequestHandler() {
 
     private fun closeClaimedProject(project: Project, projectInstanceId: String): List<LifecycleCloseAttempt> {
         val attempts = mutableListOf<LifecycleCloseAttempt>()
+        val verificationDeadline = closeVerificationNow() + closeVerificationTimeoutMs
         val saveModes = listOf(true, false, false)
         for ((index, save) in saveModes.withIndex()) {
             val forceCloseReturned = closeProjectOnEdt(project, save)
-            val closedVerified = waitForProjectClosed(project, projectInstanceId)
+            val closedVerified = waitForProjectClosed(project, projectInstanceId, verificationDeadline)
             attempts.add(
                 LifecycleCloseAttempt(
                     attempt = index + 1,
@@ -1498,18 +1502,19 @@ class InspectionHandler : HttpRequestHandler() {
         }.getOrDefault(false)
     }
 
-    private fun waitForProjectClosed(project: Project, projectInstanceId: String): Boolean {
+    private fun waitForProjectClosed(project: Project, projectInstanceId: String, deadline: Long): Boolean {
         if (ApplicationManager.getApplication().isDispatchThread) {
             return project.isDisposed || findOpenProjectByInstanceId(projectInstanceId) == null
         }
-        repeat(10) { attempt ->
+        do {
             if (project.isDisposed || findOpenProjectByInstanceId(projectInstanceId) == null) {
                 return true
             }
-            if (attempt < 9) {
-                closeVerificationSleep(100)
+            val remainingMs = deadline - closeVerificationNow()
+            if (remainingMs > 0) {
+                closeVerificationSleep(minOf(closeVerificationPollMs, remainingMs))
             }
-        }
+        } while (closeVerificationNow() < deadline)
         return project.isDisposed || findOpenProjectByInstanceId(projectInstanceId) == null
     }
 

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -1595,7 +1595,10 @@ class InspectionHandlerTest {
         assertNotNull(token)
         every { mockApplication.isDispatchThread } returns false
         every { mockApplication.invokeAndWait(any()) } answers { firstArg<Runnable>().run() }
-        handler.closeVerificationSleep = {}
+        var nowMs = 0L
+        handler.closeVerificationTimeoutMs = 300
+        handler.closeVerificationNow = { nowMs }
+        handler.closeVerificationSleep = { millis -> nowMs += millis }
         val saveModes = mutableListOf<Boolean>()
         handler.forceCloseProject = { _, save ->
             saveModes.add(save)
@@ -1617,6 +1620,39 @@ class InspectionHandlerTest {
         assertEquals(listOf(true, false), saveModes)
         assertTrue(body.contains("\"attempt\": 2"))
         assertTrue(body.contains("\"save\": false"))
+    }
+
+    @Test
+    fun `test lifecycle close waits beyond short fixed window for slow verified close`() {
+        every { mockProject.basePath } returns "/repo/app"
+        every { mockProject.projectFilePath } returns "/repo/app/.idea/misc.xml"
+        val instanceId = projectInstanceId(mockProject)
+        val claim = processGetRequest(
+            "/api/inspection/lifecycle/claim?worktree_path=/repo/app&project_instance_id=$instanceId&lease_id=test-lease"
+        ).content().toString(Charsets.UTF_8)
+        val token = Regex("\"close_token\": \"([^\"]+)\"").find(claim)?.groupValues?.get(1)
+        assertNotNull(token)
+        every { mockApplication.isDispatchThread } returns false
+        every { mockApplication.invokeAndWait(any()) } answers { firstArg<Runnable>().run() }
+        handler.closeVerificationTimeoutMs = 2_000
+        handler.closeVerificationPollMs = 100
+        var nowMs = 0L
+        handler.closeVerificationNow = { nowMs }
+        handler.closeVerificationSleep = { millis -> nowMs += millis }
+        handler.forceCloseProject = { _, _ -> true }
+        every { mockProjectManager.openProjects } answers {
+            if (nowMs >= 1_200) emptyArray() else arrayOf(mockProject)
+        }
+
+        val response = processGetRequest(
+            "/api/inspection/lifecycle/close?worktree_path=/repo/app&project_instance_id=$instanceId&close_token=$token"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"status\": \"closed\""))
+        assertTrue(body.contains("\"closed_verified\": true"))
+        assertTrue(nowMs >= 1_200)
     }
 
     @Test
@@ -1656,7 +1692,10 @@ class InspectionHandlerTest {
         assertNotNull(token)
         every { mockApplication.isDispatchThread } returns false
         every { mockApplication.invokeAndWait(any()) } answers { firstArg<Runnable>().run() }
-        handler.closeVerificationSleep = {}
+        var nowMs = 0L
+        handler.closeVerificationTimeoutMs = 300
+        handler.closeVerificationNow = { nowMs }
+        handler.closeVerificationSleep = { millis -> nowMs += millis }
         val saveModes = mutableListOf<Boolean>()
         handler.forceCloseProject = { _, save ->
             saveModes.add(save)

--- a/test-fixtures/exec-harness/jetbrains-inspection-262-worktree-live.json
+++ b/test-fixtures/exec-harness/jetbrains-inspection-262-worktree-live.json
@@ -1,6 +1,6 @@
 {
   "name": "jetbrains-inspection-262-worktree-live",
-  "prompt": "Run this exact helper command before answering: `uv run \"$CODE_HOME/skills/jetbrains-inspection/scripts/jb-inspect.py\" --json inspect-closeout --repo \"$PWD/project\" --ide \"IntelliJ IDEA\" --ide-app \"IntelliJ IDEA\" --scope whole_project --profile RedLane --timeout-ms 240000 --prepare-timeout-ms 240000`. Then decide whether the inspected worktree is clean or has findings. Do not modify files. Your final answer must include the IDE name, verdict, total problems, cleanup status, and whether the route base path matched `$PWD/project`.",
+  "prompt": "Run this exact helper command before answering: `uv run \"$CODE_HOME/skills/jetbrains-inspection/scripts/jb-inspect.py\" --json inspect-closeout --repo \"$PWD/project\" --ide \"IntelliJ IDEA\" --ide-app \"IntelliJ IDEA\" --ide-channel eap --ide-version 2026.2 --scope whole_project --profile RedLane --timeout-ms 240000 --prepare-timeout-ms 240000`. Then decide whether the inspected worktree is clean or has findings. Do not modify files. Your final answer must include the IDE name, verdict, total problems, cleanup status, and whether the route base path matched `$PWD/project`.",
   "copy": [
     {
       "source": "${JETBRAINS_INSPECTION_API_REPO}/test-fixtures/inspection-red-lane",
@@ -11,7 +11,15 @@
   "inherit_auth": true,
   "expect": {
     "returncode": 0,
-    "command_contains": ["jb-inspect.py", "inspect-closeout", "--ide-app"],
+    "command_contains": [
+      "jb-inspect.py",
+      "inspect-closeout",
+      "--ide-app",
+      "--ide-channel",
+      "eap",
+      "--ide-version",
+      "2026.2"
+    ],
     "assistant_contains": [
       "IntelliJ IDEA 2026.2 EAP",
       "RED",


### PR DESCRIPTION
## Summary

- Bound lifecycle close verification with a shared 10s deadline so slow JetBrains project disposal does not create false cleanup failures.
- Add `--ide-channel` and `--ide-version` passthrough to red-lane dogfood smokes for exact 2026.2 EAP release-gate runs.
- Assert the exact IDE selector flags in the smoke-script contract test and 262 exec-harness fixture.

Refs #125

## Validation

- `JAVA_HOME=$(/usr/libexec/java_home -v 21 2>/dev/null || printf '%s' "$JAVA_HOME_21") ./scripts/commit-gate.sh --ci`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21 2>/dev/null || printf '%s' "$JAVA_HOME_21") ./gradlew verifyPlugin`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test --tests 'com.shiny.inspectionmcp.InspectionHandlerTest.test lifecycle close*'`
- `./scripts/test-red-lane-smoke-script.sh`
- `npx prettier --check test-fixtures/exec-harness/jetbrains-inspection-262-worktree-live.json`
- Commit hook reran plugin/core/MCP/build gates successfully while creating `575beae2`.

## Dogfood Evidence

- IntelliJ IDEA 2026.2 EAP red lane: `.code/262-gate/red-lane-intellij-262-eap.json` (`RED`, cleanup `closed`).
- PyCharm 2026.2 EAP red lane rerun: `.code/262-gate/red-lane-pycharm-262-eap-rerun.json` (`RED`, cleanup `closed`).
- WebStorm 2026.2 EAP red lane: `.code/262-gate/red-lane-webstorm-262-eap.json` (`RED`, cleanup `closed`).
- Closed-IDE dogfood matrix: `.code/262-gate/dogfood-matrix.json` (`status=ok`, helper-opened stable WebStorm route closed cleanly).
- Code exec harness false-green proof passed: `/Users/cbusillo/Developer/code-prealign-new-skills/.tmp/code-exec-harness/20260701-140650-jetbrains-inspection-false-green-proof/artifacts/summary.json`.
