### PR TITLE
Document 262 EAP smoke gate timeouts

### DIFF
--- a/.code/skills/jetbrains-inspection-workflow/SKILL.md
+++ b/.code/skills/jetbrains-inspection-workflow/SKILL.md
@@ -64,6 +64,9 @@ Keep exact command matrices, environment setup, and troubleshooting in
    with the matching local IDE and the current plugin installed; it copies the
    maintained known-bad fixture and requires structured JSON with `RED`,
    `total_problems > 0`, and cleanup `closed`.
+   For 2026.2 EAP release gates, pass `--ide-channel eap --ide-version 2026.2`
+   and use `--timeout-ms 300000 --prepare-timeout-ms 300000`; this matches the
+   plugin wait cap and avoids treating a slow EAP inspection as release evidence.
 7. For release readiness, run `./scripts/test-all.sh` or the commit gate before
    build/release commands, and confirm CI status when GitHub state matters.
 

--- a/.github/github.json
+++ b/.github/github.json
@@ -33,9 +33,9 @@
       "automatedIde": "./scripts/test-automated.sh",
       "dogfoodMatrix": "./scripts/dogfood-smoke-matrix.sh",
       "redLaneDogfood": "./scripts/dogfood-red-lane-smoke.sh",
-      "redLaneDogfoodIntelliJ": "./scripts/dogfood-red-lane-smoke.sh --product intellij",
-      "redLaneDogfoodPyCharm": "./scripts/dogfood-red-lane-smoke.sh --product pycharm",
-      "redLaneDogfoodWebStorm": "./scripts/dogfood-red-lane-smoke.sh --product webstorm --ide \"WebStorm\" --ide-app \"WebStorm 2026.2 EAP\"",
+      "redLaneDogfoodIntelliJ": "./scripts/dogfood-red-lane-smoke.sh --product intellij --ide \"IntelliJ IDEA\" --ide-app \"IntelliJ IDEA\" --ide-channel eap --ide-version 2026.2 --timeout-ms 300000 --prepare-timeout-ms 300000",
+      "redLaneDogfoodPyCharm": "./scripts/dogfood-red-lane-smoke.sh --product pycharm --ide \"PyCharm\" --ide-app \"PyCharm\" --ide-channel eap --ide-version 2026.2 --timeout-ms 300000 --prepare-timeout-ms 300000",
+      "redLaneDogfoodWebStorm": "./scripts/dogfood-red-lane-smoke.sh --product webstorm --ide \"WebStorm\" --ide-app \"WebStorm\" --ide-channel eap --ide-version 2026.2 --timeout-ms 300000 --prepare-timeout-ms 300000",
       "execHarness262Worktree": "JETBRAINS_INSPECTION_API_REPO=$PWD JETBRAINS_INSPECTION_TRUSTED_AUTO_OPEN_ROOTS=${CODE_EXEC_HARNESS_ROOT:?Set CODE_EXEC_HARNESS_ROOT}/.tmp/code-exec-harness JETBRAINS_INSPECTION_IDE_CONFIG_DIR=\"${JETBRAINS_INSPECTION_IDE_CONFIG_DIR:?Set JETBRAINS_INSPECTION_IDE_CONFIG_DIR}\" python3 ${CODE_EXEC_HARNESS_ROOT}/tools/code-exec-harness/harness.py test-fixtures/exec-harness/jetbrains-inspection-262-worktree-live.json --inherit-auth --skill-root ${JETBRAINS_INSPECTION_SKILL_ROOT:-$HOME/.code/skills} --max-seconds 420"
     },
     "releaseCompatibility": {

--- a/README.md
+++ b/README.md
@@ -614,9 +614,9 @@ target IDE line:
 JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew buildPlugin
 JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew verifyPluginStructure
 JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew verifyPlugin
-./scripts/dogfood-red-lane-smoke.sh --product intellij --ide "IntelliJ IDEA" --ide-app "IntelliJ IDEA"
-./scripts/dogfood-red-lane-smoke.sh --product pycharm --ide "PyCharm" --ide-app "PyCharm"
-./scripts/dogfood-red-lane-smoke.sh --product webstorm --ide "WebStorm" --ide-app "WebStorm 2026.2 EAP"
+./scripts/dogfood-red-lane-smoke.sh --product intellij --ide "IntelliJ IDEA" --ide-app "IntelliJ IDEA" --ide-channel eap --ide-version 2026.2 --timeout-ms 300000 --prepare-timeout-ms 300000
+./scripts/dogfood-red-lane-smoke.sh --product pycharm --ide "PyCharm" --ide-app "PyCharm" --ide-channel eap --ide-version 2026.2 --timeout-ms 300000 --prepare-timeout-ms 300000
+./scripts/dogfood-red-lane-smoke.sh --product webstorm --ide "WebStorm" --ide-app "WebStorm" --ide-channel eap --ide-version 2026.2 --timeout-ms 300000 --prepare-timeout-ms 300000
 ```
 
 For agent-facing worktree proof, run the maintained exec-harness scenario in

--- a/TESTING.md
+++ b/TESTING.md
@@ -210,7 +210,7 @@ evidence for:
 - `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew verifyPluginStructure`
 - `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew verifyPlugin`
 - IntelliJ IDEA, PyCharm, and WebStorm red-lane dogfood smokes with exact
-  `--ide-app` values for the installed apps.
+  2026.2 EAP selectors and `--timeout-ms 300000 --prepare-timeout-ms 300000`.
 - The exec-harness worktree scenario in
   `test-fixtures/exec-harness/jetbrains-inspection-262-worktree-live.json`, with
   `JETBRAINS_INSPECTION_API_REPO` pointing at this checkout,


### PR DESCRIPTION
## Summary

- Record exact 2026.2 EAP red-lane smoke commands in `.github/github.json`.
- Update README/TESTING release-gate guidance to use `--ide-channel eap --ide-version 2026.2` and the 300s wait/prepare ceiling.
- Update the repo-local JetBrains workflow skill so future agents run the proven 2026.2 EAP gate instead of rediscovering the 240s IntelliJ timeout boundary.

Refs #125

## Validation

- `jq empty .github/github.json`
- `git diff --check`
- `uv run /Users/cbusillo/Developer/codex-skills/skill-creator/scripts/quick_validate.py .code/skills/jetbrains-inspection-workflow`
- `./scripts/test-red-lane-smoke-script.sh`
- Commit hook reran plugin/core/MCP/build gates successfully while creating `67d8c313`.

## Release Gate Evidence

Clean `main` build `27e5d17ddf8a-clean` was installed into `IntelliJIdea2026.2`, `PyCharm2026.2`, and `WebStorm2026.2`; all three exact 2026.2 EAP red-lane smokes passed at 300s:

- `.code/262-gate/red-lane-intellij-262-eap-clean-main-300s.json`: `RED`, `total_problems=1`, cleanup `closed`.
- `.code/262-gate/red-lane-pycharm-262-eap-clean-main-300s.json`: `RED`, `total_problems=1`, cleanup `closed`.
- `.code/262-gate/red-lane-webstorm-262-eap-clean-main-300s.json`: `RED`, `total_problems=2`, cleanup `closed`.
