### PR TITLE
Fix 262 close retry followups

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -35,7 +35,7 @@
       "redLaneDogfood": "./scripts/dogfood-red-lane-smoke.sh",
       "redLaneDogfoodIntelliJ": "./scripts/dogfood-red-lane-smoke.sh --product intellij --ide \"IntelliJ IDEA\" --ide-app \"IntelliJ IDEA\" --ide-channel eap --ide-version 2026.2 --timeout-ms 300000 --prepare-timeout-ms 300000",
       "redLaneDogfoodPyCharm": "./scripts/dogfood-red-lane-smoke.sh --product pycharm --ide \"PyCharm\" --ide-app \"PyCharm\" --ide-channel eap --ide-version 2026.2 --timeout-ms 300000 --prepare-timeout-ms 300000",
-      "redLaneDogfoodWebStorm": "./scripts/dogfood-red-lane-smoke.sh --product webstorm --ide \"WebStorm\" --ide-app \"WebStorm\" --ide-channel eap --ide-version 2026.2 --timeout-ms 300000 --prepare-timeout-ms 300000",
+      "redLaneDogfoodWebStorm": "./scripts/dogfood-red-lane-smoke.sh --product webstorm --ide \"WebStorm\" --ide-app \"WebStorm 2026.2 EAP\" --ide-channel eap --ide-version 2026.2 --timeout-ms 300000 --prepare-timeout-ms 300000",
       "execHarness262Worktree": "JETBRAINS_INSPECTION_API_REPO=$PWD JETBRAINS_INSPECTION_TRUSTED_AUTO_OPEN_ROOTS=${CODE_EXEC_HARNESS_ROOT:?Set CODE_EXEC_HARNESS_ROOT}/.tmp/code-exec-harness JETBRAINS_INSPECTION_IDE_CONFIG_DIR=\"${JETBRAINS_INSPECTION_IDE_CONFIG_DIR:?Set JETBRAINS_INSPECTION_IDE_CONFIG_DIR}\" python3 ${CODE_EXEC_HARNESS_ROOT}/tools/code-exec-harness/harness.py test-fixtures/exec-harness/jetbrains-inspection-262-worktree-live.json --inherit-auth --skill-root ${JETBRAINS_INSPECTION_SKILL_ROOT:-$HOME/.code/skills} --max-seconds 420"
     },
     "releaseCompatibility": {

--- a/README.md
+++ b/README.md
@@ -616,7 +616,7 @@ JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew verifyPluginStructure
 JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew verifyPlugin
 ./scripts/dogfood-red-lane-smoke.sh --product intellij --ide "IntelliJ IDEA" --ide-app "IntelliJ IDEA" --ide-channel eap --ide-version 2026.2 --timeout-ms 300000 --prepare-timeout-ms 300000
 ./scripts/dogfood-red-lane-smoke.sh --product pycharm --ide "PyCharm" --ide-app "PyCharm" --ide-channel eap --ide-version 2026.2 --timeout-ms 300000 --prepare-timeout-ms 300000
-./scripts/dogfood-red-lane-smoke.sh --product webstorm --ide "WebStorm" --ide-app "WebStorm" --ide-channel eap --ide-version 2026.2 --timeout-ms 300000 --prepare-timeout-ms 300000
+./scripts/dogfood-red-lane-smoke.sh --product webstorm --ide "WebStorm" --ide-app "WebStorm 2026.2 EAP" --ide-channel eap --ide-version 2026.2 --timeout-ms 300000 --prepare-timeout-ms 300000
 ```
 
 For agent-facing worktree proof, run the maintained exec-harness scenario in

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -1466,10 +1466,10 @@ class InspectionHandler : HttpRequestHandler() {
 
     private fun closeClaimedProject(project: Project, projectInstanceId: String): List<LifecycleCloseAttempt> {
         val attempts = mutableListOf<LifecycleCloseAttempt>()
-        val verificationDeadline = closeVerificationNow() + closeVerificationTimeoutMs
         val saveModes = listOf(true, false, false)
         for ((index, save) in saveModes.withIndex()) {
             val forceCloseReturned = closeProjectOnEdt(project, save)
+            val verificationDeadline = closeVerificationNow() + closeVerificationTimeoutMs
             val closedVerified = waitForProjectClosed(project, projectInstanceId, verificationDeadline)
             attempts.add(
                 LifecycleCloseAttempt(

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -1656,6 +1656,51 @@ class InspectionHandlerTest {
     }
 
     @Test
+    fun `test lifecycle close gives no-save retry a fresh verification window`() {
+        every { mockProject.basePath } returns "/repo/app"
+        every { mockProject.projectFilePath } returns "/repo/app/.idea/misc.xml"
+        val instanceId = projectInstanceId(mockProject)
+        val claim = processGetRequest(
+            "/api/inspection/lifecycle/claim?worktree_path=/repo/app&project_instance_id=$instanceId&lease_id=test-lease"
+        ).content().toString(Charsets.UTF_8)
+        val token = Regex("\"close_token\": \"([^\"]+)\"").find(claim)?.groupValues?.get(1)
+        assertNotNull(token)
+        every { mockApplication.isDispatchThread } returns false
+        every { mockApplication.invokeAndWait(any()) } answers { firstArg<Runnable>().run() }
+        handler.closeVerificationTimeoutMs = 300
+        handler.closeVerificationPollMs = 100
+        var nowMs = 0L
+        var noSaveStartMs: Long? = null
+        handler.closeVerificationNow = { nowMs }
+        handler.closeVerificationSleep = { millis -> nowMs += millis }
+        val saveModes = mutableListOf<Boolean>()
+        handler.forceCloseProject = { _, save ->
+            saveModes.add(save)
+            if (save) {
+                false
+            } else {
+                noSaveStartMs = nowMs
+                true
+            }
+        }
+        every { mockProjectManager.openProjects } answers {
+            val retryStart = noSaveStartMs
+            if (retryStart != null && nowMs - retryStart >= 200) emptyArray() else arrayOf(mockProject)
+        }
+
+        val response = processGetRequest(
+            "/api/inspection/lifecycle/close?worktree_path=/repo/app&project_instance_id=$instanceId&close_token=$token"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertEquals(listOf(true, false), saveModes)
+        assertTrue(body.contains("\"status\": \"closed\""))
+        assertTrue(body.contains("\"attempt\": 2"))
+        assertTrue(body.contains("\"closed_verified\": true"))
+    }
+
+    @Test
     fun `test lifecycle close does not poll for close verification on dispatch thread`() {
         every { mockProject.basePath } returns "/repo/app"
         every { mockProject.projectFilePath } returns "/repo/app/.idea/misc.xml"


### PR DESCRIPTION
## Summary
- give every lifecycle-close retry its own verification deadline
- add a regression test for slow successful no-save retry closure
- preserve the exact WebStorm 2026.2 EAP bundle selector in release-gate smoke commands

## Why
This addresses the current auto-review findings against the 262 follow-up work. The close verification window must reset per retry, and the release red-lane smoke command intentionally targets the exact WebStorm EAP app bundle when validating 2026.2 EAP.

## Paired helper PR
- https://github.com/cbusillo/codex-skills/pull/395 extends the helper lifecycle-close HTTP timeout so it can wait through the plugin's expected close verification path.

## Validation
- ./scripts/test-red-lane-smoke-script.sh && jq empty .github/github.json && git diff --check
- JAVA_HOME=/opt/homebrew/Cellar/openjdk@21/21.0.11/libexec/openjdk.jdk/Contents/Home ./gradlew :test --tests 'com.shiny.inspectionmcp.InspectionHandlerTest.test lifecycle close*'
- commit hook reran the plugin/core/MCP/build gate successfully on commit 8094529a
- read-only review agent found no blocking issues