### PR TITLE
Keep tree-only inspection windows extractable

### DIFF
--- a/src/main/kotlin/com/shiny/inspectionmcp/EnhancedTreeExtractor.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/EnhancedTreeExtractor.kt
@@ -40,6 +40,7 @@ class EnhancedTreeExtractor {
 
     private enum class InspectionToolWindowState {
         HAS_RESULTS_VIEW,
+        HAS_TREE,
         EMPTY,
         UNREADABLE,
     }
@@ -134,7 +135,7 @@ class EnhancedTreeExtractor {
             }
             val state = inspectToolWindowForResults(direct)
             return InspectionToolWindowSearch(
-                toolWindows = if (state == InspectionToolWindowState.HAS_RESULTS_VIEW) listOf(direct) else emptyList(),
+                toolWindows = if (state.isExtractable) listOf(direct) else emptyList(),
                 succeeded = state != InspectionToolWindowState.UNREADABLE,
             )
         }
@@ -144,17 +145,16 @@ class EnhancedTreeExtractor {
         for (id in ids) {
             val toolWindow = toolWindowManager.getToolWindow(id) ?: continue
             val state = inspectToolWindowForResults(toolWindow)
-            if (state == InspectionToolWindowState.HAS_RESULTS_VIEW) {
+            val isKnownInspectionWindow = id in inspectionResultsToolWindowIds
+            if (state == InspectionToolWindowState.HAS_RESULTS_VIEW ||
+                (isKnownInspectionWindow && (state == InspectionToolWindowState.HAS_TREE || state == InspectionToolWindowState.EMPTY))
+            ) {
                 matches.add(toolWindow)
-            } else if (id in inspectionResultsToolWindowIds && state == InspectionToolWindowState.UNREADABLE) {
+            } else if (isKnownInspectionWindow && state == InspectionToolWindowState.UNREADABLE) {
                 succeeded = false
             }
         }
         return InspectionToolWindowSearch(matches, succeeded)
-    }
-
-    private fun toolWindowHasInspectionResults(toolWindow: ToolWindow): Boolean {
-        return inspectToolWindowForResults(toolWindow) == InspectionToolWindowState.HAS_RESULTS_VIEW
     }
 
     private fun inspectToolWindowForResults(toolWindow: ToolWindow): InspectionToolWindowState {
@@ -166,12 +166,18 @@ class EnhancedTreeExtractor {
                 if (findInspectionResultsView(component) != null) {
                     return InspectionToolWindowState.HAS_RESULTS_VIEW
                 }
+                if (findInspectionTree(component) != null) {
+                    return InspectionToolWindowState.HAS_TREE
+                }
             }
         } catch (_: Exception) {
             return InspectionToolWindowState.UNREADABLE
         }
         return InspectionToolWindowState.EMPTY
     }
+
+    private val InspectionToolWindowState.isExtractable: Boolean
+        get() = this == InspectionToolWindowState.HAS_RESULTS_VIEW || this == InspectionToolWindowState.HAS_TREE
 
     private fun extractFromToolWindow(
         toolWindow: ToolWindow,

--- a/src/test/kotlin/com/shiny/inspectionmcp/EnhancedTreeExtractorTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/EnhancedTreeExtractorTest.kt
@@ -183,6 +183,44 @@ class EnhancedTreeExtractorTest {
     }
 
     @Test
+    @DisplayName("Should keep tree-only inspection result windows in status extraction")
+    fun testExtractionStatusKeepsTreeOnlyInspectionWindow() {
+        val app = mockk<Application>()
+        val project = mockk<Project>(relaxed = true)
+        val toolWindowManager = mockk<ToolWindowManager>()
+        val inspectionWindow = mockk<ToolWindow>()
+        val inspectionContentManager = mockk<ContentManager>()
+        val inspectionContent = mockk<Content>()
+        val virtualFile = mockk<VirtualFile>()
+
+        mockkStatic(ApplicationManager::class)
+        every { ApplicationManager.getApplication() } returns app
+        every { app.isDispatchThread } returns true
+
+        mockkStatic(ToolWindowManager::class)
+        every { ToolWindowManager.getInstance(project) } returns toolWindowManager
+        every { toolWindowManager.toolWindowIds } returns arrayOf("Inspection Results")
+        every { toolWindowManager.getToolWindow("Inspection Results") } returns inspectionWindow
+
+        every { inspectionWindow.contentManager } returns inspectionContentManager
+        every { inspectionContentManager.contentCount } returns 1
+        every { inspectionContentManager.getContent(0) } returns inspectionContent
+        every { virtualFile.path } returns "/tmp/project/App.kt"
+        val root = DefaultMutableTreeNode("root")
+        root.add(DefaultMutableTreeNode(FallbackProblem(virtualFile)))
+        val panel = JPanel()
+        panel.add(JTree(root))
+        every { inspectionContent.component } returns panel
+
+        val result = extractor.extractAllProblemsWithStatus(project)
+
+        assertTrue(result.succeeded)
+        assertEquals(1, result.problems.size)
+        assertEquals("Fallback warning", result.problems[0]["description"])
+        assertEquals("FallbackInspection", result.problems[0]["inspectionType"])
+    }
+
+    @Test
     @DisplayName("Should fall back to Problems view when Inspection Results are empty")
     fun testFallsBackToProblemsViewWhenInspectionResultsAreEmpty() {
         val app = mockk<Application>()


### PR DESCRIPTION
## Summary
- retain tree-only Inspection Results tool windows in extraction matching
- keep unreadable inspection windows marked as failed extraction status
- add regression coverage for tree-only inspection result windows

## Validation
- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test --tests com.shiny.inspectionmcp.EnhancedTreeExtractorTest --tests com.shiny.inspectionmcp.InspectionHandlerTest --tests com.shiny.inspectionmcp.InspectionSnapshotStateTest buildPlugin
- commit hook reran broader Gradle test/core/MCP/build gates successfully
- read-only review agent: P1 fixed; no release blockers