### PR TITLE
Fix inspection search failure status

### DIFF
--- a/src/main/kotlin/com/shiny/inspectionmcp/EnhancedTreeExtractor.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/EnhancedTreeExtractor.kt
@@ -123,20 +123,22 @@ class EnhancedTreeExtractor {
     }
 
     private fun findToolWindowsContainingInspectionResults(toolWindowManager: ToolWindowManager): InspectionToolWindowSearch {
+        var enumeratedIds = true
         val ids = try {
             toolWindowManager.toolWindowIds.toList()
         } catch (_: Exception) {
+            enumeratedIds = false
             emptyList()
         }
         if (ids.isEmpty()) {
             val direct = toolWindowManager.getToolWindow(inspectionResultsToolWindowIds.first())
             if (direct == null) {
-                return InspectionToolWindowSearch(emptyList(), succeeded = true)
+                return InspectionToolWindowSearch(emptyList(), succeeded = enumeratedIds)
             }
             val state = inspectToolWindowForResults(direct)
             return InspectionToolWindowSearch(
                 toolWindows = if (state.isExtractable) listOf(direct) else emptyList(),
-                succeeded = state != InspectionToolWindowState.UNREADABLE,
+                succeeded = enumeratedIds && state != InspectionToolWindowState.UNREADABLE,
             )
         }
 

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionToolWindows.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionToolWindows.kt
@@ -4,6 +4,7 @@ internal val inspectionResultsToolWindowIds = listOf(
     "Inspection Results",
     "Problems View",
     "Problems",
+    "Inspections",
 )
 
 internal val inspectionFallbackToolWindowIds = listOf(

--- a/src/test/kotlin/com/shiny/inspectionmcp/EnhancedTreeExtractorTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/EnhancedTreeExtractorTest.kt
@@ -183,6 +183,31 @@ class EnhancedTreeExtractorTest {
     }
 
     @Test
+    @DisplayName("Should report unsuccessful status when tool window IDs cannot be enumerated")
+    fun testExtractionStatusReportsToolWindowEnumerationFailure() {
+        val app = mockk<Application>()
+        val project = mockk<Project>(relaxed = true)
+        val toolWindowManager = mockk<ToolWindowManager>()
+
+        mockkStatic(ApplicationManager::class)
+        every { ApplicationManager.getApplication() } returns app
+        every { app.isDispatchThread } returns false
+
+        mockkStatic(ToolWindowManager::class)
+        every { ToolWindowManager.getInstance(project) } returns toolWindowManager
+        every { toolWindowManager.toolWindowIds } throws IllegalStateException("tool windows unavailable")
+        every { toolWindowManager.getToolWindow("Inspection Results") } returns null
+        every { toolWindowManager.getToolWindow("Problems View") } returns null
+        every { toolWindowManager.getToolWindow("Problems") } returns null
+        every { toolWindowManager.getToolWindow("Inspections") } returns null
+
+        val result = extractor.extractAllProblemsWithStatus(project)
+
+        assertFalse(result.succeeded)
+        assertTrue(result.problems.isEmpty())
+    }
+
+    @Test
     @DisplayName("Should keep tree-only inspection result windows in status extraction")
     fun testExtractionStatusKeepsTreeOnlyInspectionWindow() {
         val app = mockk<Application>()
@@ -211,6 +236,44 @@ class EnhancedTreeExtractorTest {
         val panel = JPanel()
         panel.add(JTree(root))
         every { inspectionContent.component } returns panel
+
+        val result = extractor.extractAllProblemsWithStatus(project)
+
+        assertTrue(result.succeeded)
+        assertEquals(1, result.problems.size)
+        assertEquals("Fallback warning", result.problems[0]["description"])
+        assertEquals("FallbackInspection", result.problems[0]["inspectionType"])
+    }
+
+    @Test
+    @DisplayName("Should keep tree-only Inspections tool windows in status extraction")
+    fun testExtractionStatusKeepsTreeOnlyInspectionsWindow() {
+        val app = mockk<Application>()
+        val project = mockk<Project>(relaxed = true)
+        val toolWindowManager = mockk<ToolWindowManager>()
+        val inspectionsWindow = mockk<ToolWindow>()
+        val inspectionsContentManager = mockk<ContentManager>()
+        val inspectionsContent = mockk<Content>()
+        val virtualFile = mockk<VirtualFile>()
+
+        mockkStatic(ApplicationManager::class)
+        every { ApplicationManager.getApplication() } returns app
+        every { app.isDispatchThread } returns true
+
+        mockkStatic(ToolWindowManager::class)
+        every { ToolWindowManager.getInstance(project) } returns toolWindowManager
+        every { toolWindowManager.toolWindowIds } returns arrayOf("Inspections")
+        every { toolWindowManager.getToolWindow("Inspections") } returns inspectionsWindow
+
+        every { inspectionsWindow.contentManager } returns inspectionsContentManager
+        every { inspectionsContentManager.contentCount } returns 1
+        every { inspectionsContentManager.getContent(0) } returns inspectionsContent
+        every { virtualFile.path } returns "/tmp/project/App.kt"
+        val root = DefaultMutableTreeNode("root")
+        root.add(DefaultMutableTreeNode(FallbackProblem(virtualFile)))
+        val panel = JPanel()
+        panel.add(JTree(root))
+        every { inspectionsContent.component } returns panel
 
         val result = extractor.extractAllProblemsWithStatus(project)
 

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -2270,6 +2270,7 @@ class InspectionHandlerTest {
         every { toolWindowManager.getToolWindow("Inspection Results") } returns toolWindow
         every { toolWindowManager.getToolWindow("Problems View") } returns null
         every { toolWindowManager.getToolWindow("Problems") } returns null
+        every { toolWindowManager.getToolWindow("Inspections") } returns null
         every { toolWindow.contentManager } returns contentManager
         every { contentManager.contentCount } returns 3
         every { contentManager.getContent(2) } returns otherContent


### PR DESCRIPTION
## Summary
- mark inspection extraction unsuccessful when toolWindowIds enumeration fails
- include the Inspections tool window in tree-only inspection result detection
- add regressions for enumeration failure and tree-only Inspections windows

## Validation
- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test --tests com.shiny.inspectionmcp.EnhancedTreeExtractorTest
- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test --tests com.shiny.inspectionmcp.EnhancedTreeExtractorTest --tests com.shiny.inspectionmcp.InspectionHandlerTest --tests com.shiny.inspectionmcp.InspectionSnapshotStateTest buildPlugin
- commit hook reran broader plugin/core/MCP/build gates successfully