### PR TITLE
Avoid false extractor failures for stale inspection windows

### DIFF
--- a/src/main/kotlin/com/shiny/inspectionmcp/EnhancedTreeExtractor.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/EnhancedTreeExtractor.kt
@@ -138,12 +138,13 @@ class EnhancedTreeExtractor {
             val state = inspectToolWindowForResults(direct)
             return InspectionToolWindowSearch(
                 toolWindows = if (state.isExtractable) listOf(direct) else emptyList(),
-                succeeded = enumeratedIds && state != InspectionToolWindowState.UNREADABLE,
+                succeeded = state != InspectionToolWindowState.UNREADABLE && (enumeratedIds || state.isExtractable),
             )
         }
 
         val matches = mutableListOf<ToolWindow>()
-        var succeeded = true
+        var foundExtractableInspectionWindow = false
+        var foundUnreadableKnownInspectionWindow = false
         for (id in ids) {
             val toolWindow = toolWindowManager.getToolWindow(id) ?: continue
             val state = inspectToolWindowForResults(toolWindow)
@@ -152,11 +153,17 @@ class EnhancedTreeExtractor {
                 (isKnownInspectionWindow && (state == InspectionToolWindowState.HAS_TREE || state == InspectionToolWindowState.EMPTY))
             ) {
                 matches.add(toolWindow)
+                if (state.isExtractable) {
+                    foundExtractableInspectionWindow = true
+                }
             } else if (isKnownInspectionWindow && state == InspectionToolWindowState.UNREADABLE) {
-                succeeded = false
+                foundUnreadableKnownInspectionWindow = true
             }
         }
-        return InspectionToolWindowSearch(matches, succeeded)
+        return InspectionToolWindowSearch(
+            matches,
+            succeeded = foundExtractableInspectionWindow || !foundUnreadableKnownInspectionWindow,
+        )
     }
 
     private fun inspectToolWindowForResults(toolWindow: ToolWindow): InspectionToolWindowState {

--- a/src/test/kotlin/com/shiny/inspectionmcp/EnhancedTreeExtractorTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/EnhancedTreeExtractorTest.kt
@@ -208,6 +208,151 @@ class EnhancedTreeExtractorTest {
     }
 
     @Test
+    @DisplayName("Should preserve successful status when direct inspection fallback works after ID enumeration fails")
+    fun testExtractionStatusPreservesSuccessWhenDirectFallbackWorksAfterEnumerationFailure() {
+        val app = mockk<Application>()
+        val project = mockk<Project>(relaxed = true)
+        val toolWindowManager = mockk<ToolWindowManager>()
+        val inspectionWindow = mockk<ToolWindow>()
+        val inspectionContentManager = mockk<ContentManager>()
+        val inspectionContent = mockk<Content>()
+        val virtualFile = mockk<VirtualFile>()
+
+        mockkStatic(ApplicationManager::class)
+        every { ApplicationManager.getApplication() } returns app
+        every { app.isDispatchThread } returns true
+
+        mockkStatic(ToolWindowManager::class)
+        every { ToolWindowManager.getInstance(project) } returns toolWindowManager
+        every { toolWindowManager.toolWindowIds } throws IllegalStateException("tool windows unavailable")
+        every { toolWindowManager.getToolWindow("Inspection Results") } returns inspectionWindow
+
+        every { inspectionWindow.contentManager } returns inspectionContentManager
+        every { inspectionContentManager.contentCount } returns 1
+        every { inspectionContentManager.getContent(0) } returns inspectionContent
+        every { virtualFile.path } returns "/tmp/project/App.kt"
+        val root = DefaultMutableTreeNode("root")
+        root.add(DefaultMutableTreeNode(FallbackProblem(virtualFile)))
+        val panel = JPanel()
+        panel.add(JTree(root))
+        every { inspectionContent.component } returns panel
+
+        val result = extractor.extractAllProblemsWithStatus(project)
+
+        assertTrue(result.succeeded)
+        assertEquals(1, result.problems.size)
+        assertEquals("Fallback warning", result.problems[0]["description"])
+    }
+
+    @Test
+    @DisplayName("Should fail status when ID enumeration fails and direct inspection window is empty")
+    fun testExtractionStatusFailsWhenDirectFallbackAfterEnumerationFailureIsEmpty() {
+        val app = mockk<Application>()
+        val project = mockk<Project>(relaxed = true)
+        val toolWindowManager = mockk<ToolWindowManager>()
+        val inspectionWindow = mockk<ToolWindow>()
+        val inspectionContentManager = mockk<ContentManager>()
+        val inspectionContent = mockk<Content>()
+
+        mockkStatic(ApplicationManager::class)
+        every { ApplicationManager.getApplication() } returns app
+        every { app.isDispatchThread } returns true
+
+        mockkStatic(ToolWindowManager::class)
+        every { ToolWindowManager.getInstance(project) } returns toolWindowManager
+        every { toolWindowManager.toolWindowIds } throws IllegalStateException("tool windows unavailable")
+        every { toolWindowManager.getToolWindow("Inspection Results") } returns inspectionWindow
+
+        every { inspectionWindow.contentManager } returns inspectionContentManager
+        every { inspectionContentManager.contentCount } returns 1
+        every { inspectionContentManager.getContent(0) } returns inspectionContent
+        every { inspectionContent.component } returns JPanel()
+        every { toolWindowManager.getToolWindow("Problems View") } returns null
+        every { toolWindowManager.getToolWindow("Problems") } returns null
+        every { toolWindowManager.getToolWindow("Inspections") } returns null
+
+        val result = extractor.extractAllProblemsWithStatus(project)
+
+        assertFalse(result.succeeded)
+        assertTrue(result.problems.isEmpty())
+    }
+
+    @Test
+    @DisplayName("Should not fail status when another inspection window extracts valid results")
+    fun testExtractionStatusIgnoresUnreadableStaleWindowWhenReadableInspectionWindowHasResults() {
+        val app = mockk<Application>()
+        val project = mockk<Project>(relaxed = true)
+        val toolWindowManager = mockk<ToolWindowManager>()
+        val unreadableWindow = mockk<ToolWindow>()
+        val readableWindow = mockk<ToolWindow>()
+        val readableContentManager = mockk<ContentManager>()
+        val readableContent = mockk<Content>()
+        val virtualFile = mockk<VirtualFile>()
+
+        mockkStatic(ApplicationManager::class)
+        every { ApplicationManager.getApplication() } returns app
+        every { app.isDispatchThread } returns true
+
+        mockkStatic(ToolWindowManager::class)
+        every { ToolWindowManager.getInstance(project) } returns toolWindowManager
+        every { toolWindowManager.toolWindowIds } returns arrayOf("Inspection Results", "Inspections")
+        every { toolWindowManager.getToolWindow("Inspection Results") } returns unreadableWindow
+        every { toolWindowManager.getToolWindow("Inspections") } returns readableWindow
+
+        every { unreadableWindow.contentManager } throws IllegalStateException("stale content manager")
+        every { readableWindow.contentManager } returns readableContentManager
+        every { readableContentManager.contentCount } returns 1
+        every { readableContentManager.getContent(0) } returns readableContent
+        every { virtualFile.path } returns "/tmp/project/App.kt"
+        val root = DefaultMutableTreeNode("root")
+        root.add(DefaultMutableTreeNode(FallbackProblem(virtualFile)))
+        val panel = JPanel()
+        panel.add(JTree(root))
+        every { readableContent.component } returns panel
+
+        val result = extractor.extractAllProblemsWithStatus(project)
+
+        assertTrue(result.succeeded)
+        assertEquals(1, result.problems.size)
+        assertEquals("Fallback warning", result.problems[0]["description"])
+    }
+
+    @Test
+    @DisplayName("Should fail status when unreadable inspection window only has an empty candidate beside it")
+    fun testExtractionStatusFailsWhenUnreadableWindowOnlyHasEmptyCandidate() {
+        val app = mockk<Application>()
+        val project = mockk<Project>(relaxed = true)
+        val toolWindowManager = mockk<ToolWindowManager>()
+        val unreadableWindow = mockk<ToolWindow>()
+        val emptyWindow = mockk<ToolWindow>()
+        val emptyContentManager = mockk<ContentManager>()
+        val emptyContent = mockk<Content>()
+
+        mockkStatic(ApplicationManager::class)
+        every { ApplicationManager.getApplication() } returns app
+        every { app.isDispatchThread } returns true
+
+        mockkStatic(ToolWindowManager::class)
+        every { ToolWindowManager.getInstance(project) } returns toolWindowManager
+        every { toolWindowManager.toolWindowIds } returns arrayOf("Inspection Results", "Inspections")
+        every { toolWindowManager.getToolWindow("Inspection Results") } returns unreadableWindow
+        every { toolWindowManager.getToolWindow("Inspections") } returns emptyWindow
+        every { toolWindowManager.getToolWindow("Problems View") } returns null
+        every { toolWindowManager.getToolWindow("Problems") } returns null
+
+        every { unreadableWindow.contentManager } throws IllegalStateException("stale content manager")
+        every { emptyWindow.contentManager } returns emptyContentManager
+        every { emptyContentManager.contentCount } returns 1
+        every { emptyContentManager.getContent(0) } returns emptyContent
+        every { emptyContent.component } returns JPanel()
+
+        val result = extractor.extractAllProblemsWithStatus(project)
+
+        assertFalse(result.succeeded)
+        assertTrue(result.problems.isEmpty())
+    }
+
+    @Test
     @DisplayName("Should keep tree-only inspection result windows in status extraction")
     fun testExtractionStatusKeepsTreeOnlyInspectionWindow() {
         val app = mockk<Application>()


### PR DESCRIPTION
## Summary
- Preserve successful extraction when a direct Inspection Results fallback works after tool-window ID enumeration fails.
- Avoid letting one stale/unreadable inspection candidate fail extraction when another inspection window has extractable results.
- Keep unreadable-only and unreadable-plus-empty cases as failed extraction so empty output cannot become false clean proof.

## Validation
- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test --tests 'com.shiny.inspectionmcp.EnhancedTreeExtractorTest'
- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test
- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew buildPlugin
- Installed built plugin into stable IntelliJ IDEA 2026.1 config and ran: python3 ~/.code/skills/jetbrains-inspection/scripts/jb-inspect.py inspect-closeout --repo /Users/cbusillo/Developer/jetbrains-inspection-api --scope changed_files --ide "IntelliJ IDEA" => VERDICT GREEN, STATUS clean, fresh snapshot