### PR TITLE
Release v1.13.5

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion=1.13.4
+pluginVersion=1.13.5
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
 kotlin.stdlib.default.dependency=false
 # Enable Gradle Configuration Cache -> https://docs.gradle.org/current/userguide/configuration_cache.html

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.shiny.inspection.api</id>
     <name>Inspection API</name>
-    <version>1.13.4</version>
+    <version>1.13.5</version>
     <vendor email="info@shinycomputers.com" url="https://github.com/cbusillo/jetbrains-inspection-api">Shiny Computers (Chris Busillo)</vendor>
     <resource-bundle>messages.InspectionApiBundle</resource-bundle>
     


### PR DESCRIPTION
## Summary
- Bump plugin version to 1.13.5 for release.
- Includes the merged inspection status/capture fixes from PR #142 and PR #143.

## Validation
- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./scripts/test-all.sh
- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew verifyPluginStructure verifyPlugin buildPlugin
- Commit hook reran plugin/core/MCP/build gates successfully during version bump commit.
- Final pre-release dogfood on main before bump: installed patched plugin into IntelliJ IDEA 2026.1 and got GREEN/clean/fresh snapshot for jetbrains-inspection-api changed_files.
- codex-lab real-agent exec harness false-green proof passed: agent rejected contradictory GREEN/0 as UNKNOWN/not ready.