### PR TITLE
Preserve successful fallback extraction status

### DIFF
--- a/src/main/kotlin/com/shiny/inspectionmcp/EnhancedTreeExtractor.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/EnhancedTreeExtractor.kt
@@ -113,7 +113,9 @@ class EnhancedTreeExtractor {
                 toolWindowManager.getToolWindow(name)
             }
                 ?: return ProblemExtractionResult(problems, succeeded)
-            succeeded = extractFromToolWindow(fallback, problems, project, seen) && succeeded
+            val beforeFallback = problems.size
+            val fallbackSucceeded = extractFromToolWindow(fallback, problems, project, seen)
+            succeeded = fallbackSucceeded && (succeeded || problems.size > beforeFallback)
             
         } catch (e: Exception) {
             succeeded = false

--- a/src/test/kotlin/com/shiny/inspectionmcp/EnhancedTreeExtractorTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/EnhancedTreeExtractorTest.kt
@@ -278,6 +278,76 @@ class EnhancedTreeExtractorTest {
     }
 
     @Test
+    @DisplayName("Should preserve successful status when Problems fallback extracts findings after ID enumeration fails")
+    fun testExtractionStatusPreservesSuccessWhenProblemsFallbackWorksAfterEnumerationFailure() {
+        val app = mockk<Application>()
+        val project = mockk<Project>(relaxed = true)
+        val toolWindowManager = mockk<ToolWindowManager>()
+        val problemsWindow = mockk<ToolWindow>()
+        val problemsContentManager = mockk<ContentManager>()
+        val problemsContent = mockk<Content>()
+        val virtualFile = mockk<VirtualFile>()
+
+        mockkStatic(ApplicationManager::class)
+        every { ApplicationManager.getApplication() } returns app
+        every { app.isDispatchThread } returns true
+
+        mockkStatic(ToolWindowManager::class)
+        every { ToolWindowManager.getInstance(project) } returns toolWindowManager
+        every { toolWindowManager.toolWindowIds } throws IllegalStateException("tool windows unavailable")
+        every { toolWindowManager.getToolWindow("Inspection Results") } returns null
+        every { toolWindowManager.getToolWindow("Problems View") } returns problemsWindow
+
+        every { problemsWindow.contentManager } returns problemsContentManager
+        every { problemsContentManager.contentCount } returns 1
+        every { problemsContentManager.getContent(0) } returns problemsContent
+        every { virtualFile.path } returns "/tmp/project/App.kt"
+        val root = DefaultMutableTreeNode("root")
+        root.add(DefaultMutableTreeNode(FallbackProblem(virtualFile)))
+        val panel = JPanel()
+        panel.add(JTree(root))
+        every { problemsContent.component } returns panel
+
+        val result = extractor.extractAllProblemsWithStatus(project)
+
+        assertTrue(result.succeeded)
+        assertEquals(1, result.problems.size)
+        assertEquals("Fallback warning", result.problems[0]["description"])
+        assertEquals("problems_view", result.problems[0]["source"])
+    }
+
+    @Test
+    @DisplayName("Should keep failed status when Problems fallback is empty after ID enumeration fails")
+    fun testExtractionStatusKeepsFailureWhenProblemsFallbackAfterEnumerationFailureIsEmpty() {
+        val app = mockk<Application>()
+        val project = mockk<Project>(relaxed = true)
+        val toolWindowManager = mockk<ToolWindowManager>()
+        val problemsWindow = mockk<ToolWindow>()
+        val problemsContentManager = mockk<ContentManager>()
+        val problemsContent = mockk<Content>()
+
+        mockkStatic(ApplicationManager::class)
+        every { ApplicationManager.getApplication() } returns app
+        every { app.isDispatchThread } returns true
+
+        mockkStatic(ToolWindowManager::class)
+        every { ToolWindowManager.getInstance(project) } returns toolWindowManager
+        every { toolWindowManager.toolWindowIds } throws IllegalStateException("tool windows unavailable")
+        every { toolWindowManager.getToolWindow("Inspection Results") } returns null
+        every { toolWindowManager.getToolWindow("Problems View") } returns problemsWindow
+
+        every { problemsWindow.contentManager } returns problemsContentManager
+        every { problemsContentManager.contentCount } returns 1
+        every { problemsContentManager.getContent(0) } returns problemsContent
+        every { problemsContent.component } returns JPanel()
+
+        val result = extractor.extractAllProblemsWithStatus(project)
+
+        assertFalse(result.succeeded)
+        assertTrue(result.problems.isEmpty())
+    }
+
+    @Test
     @DisplayName("Should not fail status when another inspection window extracts valid results")
     fun testExtractionStatusIgnoresUnreadableStaleWindowWhenReadableInspectionWindowHasResults() {
         val app = mockk<Application>()


### PR DESCRIPTION
## Summary
- Preserve a successful extraction status when Problems fallback recovers findings after tool window discovery fails
- Keep extraction failure status when the fallback is empty after discovery failure
- Add regression coverage for both status paths

## Validation
- git diff --check
- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test --tests 'com.shiny.inspectionmcp.EnhancedTreeExtractorTest'
- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test buildPlugin
- commit hook: ./scripts/commit-gate.sh equivalent tasks (:test, :inspection-core:test, :mcp-server-jvm:test, buildPlugin)