### PR TITLE
Release v1.13.6

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion=1.13.5
+pluginVersion=1.13.6
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
 kotlin.stdlib.default.dependency=false
 # Enable Gradle Configuration Cache -> https://docs.gradle.org/current/userguide/configuration_cache.html

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.shiny.inspection.api</id>
     <name>Inspection API</name>
-    <version>1.13.5</version>
+    <version>1.13.6</version>
     <vendor email="info@shinycomputers.com" url="https://github.com/cbusillo/jetbrains-inspection-api">Shiny Computers (Chris Busillo)</vendor>
     <resource-bundle>messages.InspectionApiBundle</resource-bundle>
     


### PR DESCRIPTION
## Summary
- Bump plugin version metadata to 1.13.6
- Supersedes v1.13.5 with the fallback extraction status fix from #145

## Validation
- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./scripts/test-all.sh
- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew verifyPluginStructure verifyPlugin buildPlugin
- commit hook: plugin tests, core tests, MCP server tests, buildPlugin

## Notes
- Plugin verifier reports compatibility for the configured 251-262 range with the existing known internal API usages.
- No docs or workflow metadata changes needed; this is a patch release for extraction status correctness.