### PR TITLE
Release v1.13.8

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion=1.13.7
+pluginVersion=1.13.8
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
 kotlin.stdlib.default.dependency=false
 # Enable Gradle Configuration Cache -> https://docs.gradle.org/current/userguide/configuration_cache.html

--- a/src/main/kotlin/com/shiny/inspectionmcp/EnhancedTreeExtractor.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/EnhancedTreeExtractor.kt
@@ -34,8 +34,19 @@ internal data class ProblemExtractionResult(
 class EnhancedTreeExtractor {
 
     private data class InspectionToolWindowSearch(
-        val toolWindows: List<ToolWindow>,
+        val toolWindows: List<InspectionToolWindowCandidate>,
         val succeeded: Boolean,
+    )
+
+    private data class InspectionToolWindowCandidate(
+        val toolWindow: ToolWindow,
+        val acceptEmptyTreeSurface: Boolean,
+    )
+
+    private data class ToolWindowExtractionResult(
+        val succeeded: Boolean,
+        val sawResultsSurface: Boolean,
+        val addedProblems: Boolean,
     )
 
     private enum class InspectionToolWindowState {
@@ -101,25 +112,36 @@ class EnhancedTreeExtractor {
             val inspectionWindows = inspectionSearch.toolWindows
             if (inspectionWindows.isNotEmpty()) {
                 var extractedProblems = false
-                for (tw in inspectionWindows) {
+                var extractedResultsSurface = false
+                for (candidate in inspectionWindows) {
                     val before = problems.size
-                    val windowSucceeded = extractFromToolWindow(tw, problems, project, seen)
-                    extractedProblems = extractedProblems || problems.size > before
-                    succeeded = windowSucceeded && succeeded
+                    val extraction = extractFromToolWindow(
+                        candidate.toolWindow,
+                        problems,
+                        project,
+                        seen,
+                        acceptEmptyTreeSurface = candidate.acceptEmptyTreeSurface,
+                    )
+                    extractedProblems = extractedProblems || extraction.addedProblems || problems.size > before
+                    extractedResultsSurface = extractedResultsSurface || extraction.sawResultsSurface
+                    succeeded = extraction.succeeded && succeeded
                 }
-                if (problems.isNotEmpty()) {
+                if (problems.isNotEmpty() || extractedResultsSurface) {
                     return ProblemExtractionResult(problems, succeeded || extractedProblems)
                 }
             }
 
             // Fallback: when no Inspect Code results exist, scrape the Problems tool window.
-            val fallback = inspectionFallbackToolWindowIds.firstNotNullOfOrNull { name ->
-                toolWindowManager.getToolWindow(name)
+            for (name in inspectionFallbackToolWindowIds) {
+                val fallback = toolWindowManager.getToolWindow(name) ?: continue
+                val beforeFallback = problems.size
+                val extraction = extractFromToolWindow(fallback, problems, project, seen, acceptEmptyTreeSurface = false)
+                if (extraction.addedProblems || problems.size > beforeFallback) {
+                    succeeded = extraction.succeeded
+                    break
+                }
+                succeeded = false
             }
-                ?: return ProblemExtractionResult(problems, succeeded)
-            val beforeFallback = problems.size
-            val fallbackSucceeded = extractFromToolWindow(fallback, problems, project, seen)
-            succeeded = fallbackSucceeded && (succeeded || problems.size > beforeFallback)
             
         } catch (e: Exception) {
             succeeded = false
@@ -137,18 +159,25 @@ class EnhancedTreeExtractor {
             emptyList()
         }
         if (ids.isEmpty()) {
-            val direct = toolWindowManager.getToolWindow(inspectionResultsToolWindowIds.first())
-            if (direct == null) {
+            val directMatches = inspectionResultsToolWindowIds.mapNotNull { id ->
+                val toolWindow = toolWindowManager.getToolWindow(id) ?: return@mapNotNull null
+                val state = inspectToolWindowForResults(toolWindow)
+                if (state.isExtractable) {
+                    InspectionToolWindowCandidate(
+                        toolWindow,
+                        acceptEmptyTreeSurface = id.acceptsCleanEmptyTreeSurface || state == InspectionToolWindowState.HAS_RESULTS_VIEW,
+                    )
+                } else {
+                    null
+                }
+            }
+            if (directMatches.isEmpty()) {
                 return InspectionToolWindowSearch(emptyList(), succeeded = enumeratedIds)
             }
-            val state = inspectToolWindowForResults(direct)
-            return InspectionToolWindowSearch(
-                toolWindows = if (state.isExtractable) listOf(direct) else emptyList(),
-                succeeded = state.isExtractable,
-            )
+            return InspectionToolWindowSearch(directMatches, succeeded = true)
         }
 
-        val matches = mutableListOf<ToolWindow>()
+        val matches = mutableListOf<InspectionToolWindowCandidate>()
         var foundExtractableInspectionWindow = false
         var foundEmptyKnownInspectionWindow = false
         var foundUnreadableKnownInspectionWindow = false
@@ -159,7 +188,12 @@ class EnhancedTreeExtractor {
             if (state == InspectionToolWindowState.HAS_RESULTS_VIEW ||
                 (isKnownInspectionWindow && state == InspectionToolWindowState.HAS_TREE)
             ) {
-                matches.add(toolWindow)
+                matches.add(
+                    InspectionToolWindowCandidate(
+                        toolWindow,
+                        acceptEmptyTreeSurface = id.acceptsCleanEmptyTreeSurface || state == InspectionToolWindowState.HAS_RESULTS_VIEW,
+                    )
+                )
                 if (state.isExtractable) {
                     foundExtractableInspectionWindow = true
                 }
@@ -197,14 +231,21 @@ class EnhancedTreeExtractor {
     private val InspectionToolWindowState.isExtractable: Boolean
         get() = this == InspectionToolWindowState.HAS_RESULTS_VIEW || this == InspectionToolWindowState.HAS_TREE
 
+    private val String.acceptsCleanEmptyTreeSurface: Boolean
+        get() = this == "Inspection Results" || this == "Inspections"
+
     private fun extractFromToolWindow(
         toolWindow: ToolWindow,
         problems: MutableList<Map<String, Any>>,
         project: Project,
         seen: MutableSet<String>,
-    ): Boolean {
-        val contentManager = getContentManager(toolWindow) ?: return false
+        acceptEmptyTreeSurface: Boolean,
+    ): ToolWindowExtractionResult {
+        val contentManager = getContentManager(toolWindow)
+            ?: return ToolWindowExtractionResult(succeeded = false, sawResultsSurface = false, addedProblems = false)
         var succeeded = true
+        var foundResultsSurface = false
+        var addedProblems = false
         return try {
             for (i in 0 until contentManager.contentCount) {
                 val content = contentManager.getContent(i) ?: continue
@@ -213,27 +254,38 @@ class EnhancedTreeExtractor {
                 val before = problems.size
                 val inspectionView = findInspectionResultsView(component)
                 val contentSucceeded = if (inspectionView != null) {
+                    foundResultsSurface = true
                     extractProblemsFromView(inspectionView, problems, project)
                 } else {
                     val tree = findInspectionTree(component)
                     if (tree != null) {
-                        extractProblemsFromTree(tree, problems, project)
+                        val beforeTree = problems.size
+                        val treeSucceeded = extractProblemsFromTree(tree, problems, project)
+                        if (acceptEmptyTreeSurface || problems.size > beforeTree) {
+                            foundResultsSurface = true
+                        }
+                        treeSucceeded
                     } else {
-                        true
+                        false
                     }
                 }
                 succeeded = contentSucceeded && succeeded
 
                 if (problems.size != before) {
+                    addedProblems = true
                     val newSlice = problems.subList(before, problems.size)
                     val deduped = newSlice.filter { p -> seen.add(problemDedupKey(p)) }
                     newSlice.clear()
                     problems.addAll(deduped)
                 }
             }
-            succeeded
+            ToolWindowExtractionResult(
+                succeeded = succeeded && foundResultsSurface,
+                sawResultsSurface = foundResultsSurface,
+                addedProblems = addedProblems,
+            )
         } catch (_: Exception) {
-            false
+            ToolWindowExtractionResult(succeeded = false, sawResultsSurface = foundResultsSurface, addedProblems = addedProblems)
         }
     }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.shiny.inspection.api</id>
     <name>Inspection API</name>
-    <version>1.13.7</version>
+    <version>1.13.8</version>
     <vendor email="info@shinycomputers.com" url="https://github.com/cbusillo/jetbrains-inspection-api">Shiny Computers (Chris Busillo)</vendor>
     <resource-bundle>messages.InspectionApiBundle</resource-bundle>
     

--- a/src/test/kotlin/com/shiny/inspectionmcp/EnhancedTreeExtractorTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/EnhancedTreeExtractorTest.kt
@@ -258,6 +258,9 @@ class EnhancedTreeExtractorTest {
         every { ToolWindowManager.getInstance(project) } returns toolWindowManager
         every { toolWindowManager.toolWindowIds } throws IllegalStateException("tool windows unavailable")
         every { toolWindowManager.getToolWindow("Inspection Results") } returns inspectionWindow
+        every { toolWindowManager.getToolWindow("Problems View") } returns null
+        every { toolWindowManager.getToolWindow("Problems") } returns null
+        every { toolWindowManager.getToolWindow("Inspections") } returns null
 
         every { inspectionWindow.contentManager } returns inspectionContentManager
         every { inspectionContentManager.contentCount } returns 1
@@ -268,6 +271,136 @@ class EnhancedTreeExtractorTest {
         val panel = JPanel()
         panel.add(JTree(root))
         every { inspectionContent.component } returns panel
+
+        val result = extractor.extractAllProblemsWithStatus(project)
+
+        assertTrue(result.succeeded)
+        assertEquals(1, result.problems.size)
+        assertEquals("Fallback warning", result.problems[0]["description"])
+    }
+
+    @Test
+    @DisplayName("Should probe all known inspection windows when ID enumeration fails")
+    fun testExtractionStatusProbesInspectionsDirectFallbackAfterEnumerationFailure() {
+        val app = mockk<Application>()
+        val project = mockk<Project>(relaxed = true)
+        val toolWindowManager = mockk<ToolWindowManager>()
+        val inspectionsWindow = mockk<ToolWindow>()
+        val inspectionsContentManager = mockk<ContentManager>()
+        val inspectionsContent = mockk<Content>()
+        val virtualFile = mockk<VirtualFile>()
+
+        mockkStatic(ApplicationManager::class)
+        every { ApplicationManager.getApplication() } returns app
+        every { app.isDispatchThread } returns true
+
+        mockkStatic(ToolWindowManager::class)
+        every { ToolWindowManager.getInstance(project) } returns toolWindowManager
+        every { toolWindowManager.toolWindowIds } throws IllegalStateException("tool windows unavailable")
+        every { toolWindowManager.getToolWindow("Inspection Results") } returns null
+        every { toolWindowManager.getToolWindow("Problems View") } returns null
+        every { toolWindowManager.getToolWindow("Problems") } returns null
+        every { toolWindowManager.getToolWindow("Inspections") } returns inspectionsWindow
+
+        every { inspectionsWindow.contentManager } returns inspectionsContentManager
+        every { inspectionsContentManager.contentCount } returns 1
+        every { inspectionsContentManager.getContent(0) } returns inspectionsContent
+        every { virtualFile.path } returns "/tmp/project/App.kt"
+        val root = DefaultMutableTreeNode("root")
+        root.add(DefaultMutableTreeNode(FallbackProblem(virtualFile)))
+        val panel = JPanel()
+        panel.add(JTree(root))
+        every { inspectionsContent.component } returns panel
+
+        val result = extractor.extractAllProblemsWithStatus(project)
+
+        assertTrue(result.succeeded)
+        assertEquals(1, result.problems.size)
+        assertEquals("Fallback warning", result.problems[0]["description"])
+    }
+
+    @Test
+    @DisplayName("Should skip blank direct fallback windows when a later inspection window is extractable")
+    fun testExtractionStatusSkipsBlankDirectFallbackAfterEnumerationFailure() {
+        val app = mockk<Application>()
+        val project = mockk<Project>(relaxed = true)
+        val toolWindowManager = mockk<ToolWindowManager>()
+        val blankWindow = mockk<ToolWindow>()
+        val blankContentManager = mockk<ContentManager>()
+        val blankContent = mockk<Content>()
+        val inspectionsWindow = mockk<ToolWindow>()
+        val inspectionsContentManager = mockk<ContentManager>()
+        val inspectionsContent = mockk<Content>()
+        val virtualFile = mockk<VirtualFile>()
+
+        mockkStatic(ApplicationManager::class)
+        every { ApplicationManager.getApplication() } returns app
+        every { app.isDispatchThread } returns true
+
+        mockkStatic(ToolWindowManager::class)
+        every { ToolWindowManager.getInstance(project) } returns toolWindowManager
+        every { toolWindowManager.toolWindowIds } throws IllegalStateException("tool windows unavailable")
+        every { toolWindowManager.getToolWindow("Inspection Results") } returns blankWindow
+        every { toolWindowManager.getToolWindow("Problems View") } returns null
+        every { toolWindowManager.getToolWindow("Problems") } returns null
+        every { toolWindowManager.getToolWindow("Inspections") } returns inspectionsWindow
+
+        every { blankWindow.contentManager } returns blankContentManager
+        every { blankContentManager.contentCount } returns 1
+        every { blankContentManager.getContent(0) } returns blankContent
+        every { blankContent.component } returns JPanel()
+
+        every { inspectionsWindow.contentManager } returns inspectionsContentManager
+        every { inspectionsContentManager.contentCount } returns 1
+        every { inspectionsContentManager.getContent(0) } returns inspectionsContent
+        every { virtualFile.path } returns "/tmp/project/App.kt"
+        val root = DefaultMutableTreeNode("root")
+        root.add(DefaultMutableTreeNode(FallbackProblem(virtualFile)))
+        val panel = JPanel()
+        panel.add(JTree(root))
+        every { inspectionsContent.component } returns panel
+
+        val result = extractor.extractAllProblemsWithStatus(project)
+
+        assertTrue(result.succeeded)
+        assertEquals(1, result.problems.size)
+        assertEquals("Fallback warning", result.problems[0]["description"])
+    }
+
+    @Test
+    @DisplayName("Should skip unreadable direct fallback windows when a later inspection window is extractable")
+    fun testExtractionStatusSkipsUnreadableDirectFallbackAfterEnumerationFailure() {
+        val app = mockk<Application>()
+        val project = mockk<Project>(relaxed = true)
+        val toolWindowManager = mockk<ToolWindowManager>()
+        val unreadableWindow = mockk<ToolWindow>()
+        val inspectionsWindow = mockk<ToolWindow>()
+        val inspectionsContentManager = mockk<ContentManager>()
+        val inspectionsContent = mockk<Content>()
+        val virtualFile = mockk<VirtualFile>()
+
+        mockkStatic(ApplicationManager::class)
+        every { ApplicationManager.getApplication() } returns app
+        every { app.isDispatchThread } returns true
+
+        mockkStatic(ToolWindowManager::class)
+        every { ToolWindowManager.getInstance(project) } returns toolWindowManager
+        every { toolWindowManager.toolWindowIds } throws IllegalStateException("tool windows unavailable")
+        every { toolWindowManager.getToolWindow("Inspection Results") } returns unreadableWindow
+        every { toolWindowManager.getToolWindow("Problems View") } returns null
+        every { toolWindowManager.getToolWindow("Problems") } returns null
+        every { toolWindowManager.getToolWindow("Inspections") } returns inspectionsWindow
+
+        every { unreadableWindow.contentManager } throws IllegalStateException("content manager unavailable")
+        every { inspectionsWindow.contentManager } returns inspectionsContentManager
+        every { inspectionsContentManager.contentCount } returns 1
+        every { inspectionsContentManager.getContent(0) } returns inspectionsContent
+        every { virtualFile.path } returns "/tmp/project/App.kt"
+        val root = DefaultMutableTreeNode("root")
+        root.add(DefaultMutableTreeNode(FallbackProblem(virtualFile)))
+        val panel = JPanel()
+        panel.add(JTree(root))
+        every { inspectionsContent.component } returns panel
 
         val result = extractor.extractAllProblemsWithStatus(project)
 
@@ -329,6 +462,8 @@ class EnhancedTreeExtractorTest {
         every { toolWindowManager.toolWindowIds } throws IllegalStateException("tool windows unavailable")
         every { toolWindowManager.getToolWindow("Inspection Results") } returns null
         every { toolWindowManager.getToolWindow("Problems View") } returns problemsWindow
+        every { toolWindowManager.getToolWindow("Problems") } returns null
+        every { toolWindowManager.getToolWindow("Inspections") } returns null
 
         every { problemsWindow.contentManager } returns problemsContentManager
         every { problemsContentManager.contentCount } returns 1
@@ -372,6 +507,115 @@ class EnhancedTreeExtractorTest {
         every { problemsContentManager.contentCount } returns 1
         every { problemsContentManager.getContent(0) } returns problemsContent
         every { problemsContent.component } returns JPanel()
+
+        val result = extractor.extractAllProblemsWithStatus(project)
+
+        assertFalse(result.succeeded)
+        assertTrue(result.problems.isEmpty())
+    }
+
+    @Test
+    @DisplayName("Should not report successful fallback extraction for blank Problems shell")
+    fun testExtractionStatusFailsWhenFallbackProblemsShellIsBlank() {
+        val app = mockk<Application>()
+        val project = mockk<Project>(relaxed = true)
+        val toolWindowManager = mockk<ToolWindowManager>()
+        val problemsWindow = mockk<ToolWindow>()
+        val problemsContentManager = mockk<ContentManager>()
+        val problemsContent = mockk<Content>()
+
+        mockkStatic(ApplicationManager::class)
+        every { ApplicationManager.getApplication() } returns app
+        every { app.isDispatchThread } returns true
+
+        mockkStatic(ToolWindowManager::class)
+        every { ToolWindowManager.getInstance(project) } returns toolWindowManager
+        every { toolWindowManager.toolWindowIds } returns arrayOf("Problems View")
+        every { toolWindowManager.getToolWindow("Problems View") } returns problemsWindow
+        every { toolWindowManager.getToolWindow("Problems") } returns null
+        every { toolWindowManager.getToolWindow("Inspections") } returns null
+
+        every { problemsWindow.contentManager } returns problemsContentManager
+        every { problemsContentManager.contentCount } returns 1
+        every { problemsContentManager.getContent(0) } returns problemsContent
+        every { problemsContent.component } returns JPanel()
+
+        val result = extractor.extractAllProblemsWithStatus(project)
+
+        assertFalse(result.succeeded)
+        assertTrue(result.problems.isEmpty())
+    }
+
+    @Test
+    @DisplayName("Should keep clean primary inspection result successful when fallback shell is blank")
+    fun testExtractionStatusCleanPrimaryResultIsNotPoisonedByBlankFallback() {
+        val app = mockk<Application>()
+        val project = mockk<Project>(relaxed = true)
+        val toolWindowManager = mockk<ToolWindowManager>()
+        val inspectionWindow = mockk<ToolWindow>()
+        val problemsWindow = mockk<ToolWindow>()
+        val inspectionContentManager = mockk<ContentManager>()
+        val problemsContentManager = mockk<ContentManager>()
+        val inspectionContent = mockk<Content>()
+        val problemsContent = mockk<Content>()
+
+        mockkStatic(ApplicationManager::class)
+        every { ApplicationManager.getApplication() } returns app
+        every { app.isDispatchThread } returns true
+
+        mockkStatic(ToolWindowManager::class)
+        every { ToolWindowManager.getInstance(project) } returns toolWindowManager
+        every { toolWindowManager.toolWindowIds } returns arrayOf("Inspection Results", "Problems View")
+        every { toolWindowManager.getToolWindow("Inspection Results") } returns inspectionWindow
+        every { toolWindowManager.getToolWindow("Problems View") } returns problemsWindow
+
+        every { inspectionWindow.contentManager } returns inspectionContentManager
+        every { inspectionContentManager.contentCount } returns 1
+        every { inspectionContentManager.getContent(0) } returns inspectionContent
+        val cleanRoot = DefaultMutableTreeNode("Inspection Results")
+        cleanRoot.add(DefaultMutableTreeNode("empty"))
+        val cleanPanel = JPanel()
+        cleanPanel.add(JTree(cleanRoot))
+        every { inspectionContent.component } returns cleanPanel
+
+        every { problemsWindow.contentManager } returns problemsContentManager
+        every { problemsContentManager.contentCount } returns 1
+        every { problemsContentManager.getContent(0) } returns problemsContent
+        every { problemsContent.component } returns JPanel()
+
+        val result = extractor.extractAllProblemsWithStatus(project)
+
+        assertTrue(result.succeeded)
+        assertTrue(result.problems.isEmpty())
+    }
+
+    @Test
+    @DisplayName("Should not report successful fallback extraction for empty Problems tree")
+    fun testExtractionStatusFailsWhenFallbackProblemsTreeIsEmpty() {
+        val app = mockk<Application>()
+        val project = mockk<Project>(relaxed = true)
+        val toolWindowManager = mockk<ToolWindowManager>()
+        val problemsWindow = mockk<ToolWindow>()
+        val problemsContentManager = mockk<ContentManager>()
+        val problemsContent = mockk<Content>()
+
+        mockkStatic(ApplicationManager::class)
+        every { ApplicationManager.getApplication() } returns app
+        every { app.isDispatchThread } returns true
+
+        mockkStatic(ToolWindowManager::class)
+        every { ToolWindowManager.getInstance(project) } returns toolWindowManager
+        every { toolWindowManager.toolWindowIds } returns arrayOf("Problems View")
+        every { toolWindowManager.getToolWindow("Problems View") } returns problemsWindow
+        every { toolWindowManager.getToolWindow("Problems") } returns null
+        every { toolWindowManager.getToolWindow("Inspections") } returns null
+
+        every { problemsWindow.contentManager } returns problemsContentManager
+        every { problemsContentManager.contentCount } returns 1
+        every { problemsContentManager.getContent(0) } returns problemsContent
+        val emptyPanel = JPanel()
+        emptyPanel.add(JTree(DefaultMutableTreeNode("root")))
+        every { problemsContent.component } returns emptyPanel
 
         val result = extractor.extractAllProblemsWithStatus(project)
 


### PR DESCRIPTION
## Summary
- Fix inspection extraction status fallback semantics for live tool-window edge cases
- Probe all known inspection result windows when tool-window enumeration is unavailable
- Treat blank/empty Problems fallback shells as unsuccessful while preserving clean primary inspection evidence
- Bump plugin version to 1.13.8

## Validation
- JAVA_HOME=/opt/homebrew/Cellar/openjdk@21/21.0.11/libexec/openjdk.jdk/Contents/Home ./gradlew :test --tests com.shiny.inspectionmcp.EnhancedTreeExtractorTest
- JAVA_HOME=/opt/homebrew/Cellar/openjdk@21/21.0.11/libexec/openjdk.jdk/Contents/Home ./scripts/commit-gate.sh --ci
- Read-only review agents checked the extractor status semantics