### PR TITLE
Release v1.13.9

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion=1.13.8
+pluginVersion=1.13.9
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
 kotlin.stdlib.default.dependency=false
 # Enable Gradle Configuration Cache -> https://docs.gradle.org/current/userguide/configuration_cache.html

--- a/src/main/kotlin/com/shiny/inspectionmcp/EnhancedTreeExtractor.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/EnhancedTreeExtractor.kt
@@ -110,6 +110,7 @@ class EnhancedTreeExtractor {
             val inspectionSearch = findToolWindowsContainingInspectionResults(toolWindowManager)
             succeeded = inspectionSearch.succeeded && succeeded
             val inspectionWindows = inspectionSearch.toolWindows
+            var primaryEmptySurfaceSucceeded: Boolean? = null
             if (inspectionWindows.isNotEmpty()) {
                 var extractedProblems = false
                 var extractedResultsSurface = false
@@ -126,21 +127,33 @@ class EnhancedTreeExtractor {
                     extractedResultsSurface = extractedResultsSurface || extraction.sawResultsSurface
                     succeeded = extraction.succeeded && succeeded
                 }
-                if (problems.isNotEmpty() || extractedResultsSurface) {
+                if (problems.isNotEmpty()) {
                     return ProblemExtractionResult(problems, succeeded || extractedProblems)
+                }
+                if (extractedResultsSurface) {
+                    primaryEmptySurfaceSucceeded = succeeded || extractedProblems
                 }
             }
 
             // Fallback: when no Inspect Code results exist, scrape the Problems tool window.
             for (name in inspectionFallbackToolWindowIds) {
-                val fallback = toolWindowManager.getToolWindow(name) ?: continue
+                val fallback = try {
+                    toolWindowManager.getToolWindow(name)
+                } catch (_: Exception) {
+                    null
+                } ?: continue
                 val beforeFallback = problems.size
                 val extraction = extractFromToolWindow(fallback, problems, project, seen, acceptEmptyTreeSurface = false)
                 if (extraction.addedProblems || problems.size > beforeFallback) {
                     succeeded = extraction.succeeded
                     break
                 }
-                succeeded = false
+                if (primaryEmptySurfaceSucceeded == null && !extraction.sawResultsSurface) {
+                    succeeded = false
+                }
+            }
+            if (problems.isEmpty() && primaryEmptySurfaceSucceeded != null) {
+                succeeded = primaryEmptySurfaceSucceeded
             }
             
         } catch (e: Exception) {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.shiny.inspection.api</id>
     <name>Inspection API</name>
-    <version>1.13.8</version>
+    <version>1.13.9</version>
     <vendor email="info@shinycomputers.com" url="https://github.com/cbusillo/jetbrains-inspection-api">Shiny Computers (Chris Busillo)</vendor>
     <resource-bundle>messages.InspectionApiBundle</resource-bundle>
     

--- a/src/test/kotlin/com/shiny/inspectionmcp/EnhancedTreeExtractorTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/EnhancedTreeExtractorTest.kt
@@ -565,9 +565,11 @@ class EnhancedTreeExtractorTest {
 
         mockkStatic(ToolWindowManager::class)
         every { ToolWindowManager.getInstance(project) } returns toolWindowManager
-        every { toolWindowManager.toolWindowIds } returns arrayOf("Inspection Results", "Problems View")
+        every { toolWindowManager.toolWindowIds } returns arrayOf("Inspection Results")
         every { toolWindowManager.getToolWindow("Inspection Results") } returns inspectionWindow
         every { toolWindowManager.getToolWindow("Problems View") } returns problemsWindow
+        every { toolWindowManager.getToolWindow("Problems") } returns null
+        every { toolWindowManager.getToolWindow("Inspections") } returns null
 
         every { inspectionWindow.contentManager } returns inspectionContentManager
         every { inspectionContentManager.contentCount } returns 1
@@ -587,6 +589,59 @@ class EnhancedTreeExtractorTest {
 
         assertTrue(result.succeeded)
         assertTrue(result.problems.isEmpty())
+    }
+
+    @Test
+    @DisplayName("Should keep probing Problems fallback when primary inspection result is empty")
+    fun testExtractionStatusChecksProblemsFallbackAfterEmptyPrimaryInspectionResult() {
+        val app = mockk<Application>()
+        val project = mockk<Project>(relaxed = true)
+        val toolWindowManager = mockk<ToolWindowManager>()
+        val inspectionWindow = mockk<ToolWindow>()
+        val problemsWindow = mockk<ToolWindow>()
+        val inspectionContentManager = mockk<ContentManager>()
+        val problemsContentManager = mockk<ContentManager>()
+        val inspectionContent = mockk<Content>()
+        val problemsContent = mockk<Content>()
+        val virtualFile = mockk<VirtualFile>()
+
+        mockkStatic(ApplicationManager::class)
+        every { ApplicationManager.getApplication() } returns app
+        every { app.isDispatchThread } returns true
+
+        mockkStatic(ToolWindowManager::class)
+        every { ToolWindowManager.getInstance(project) } returns toolWindowManager
+        every { toolWindowManager.toolWindowIds } returns arrayOf("Inspection Results")
+        every { toolWindowManager.getToolWindow("Inspection Results") } returns inspectionWindow
+        every { toolWindowManager.getToolWindow("Problems View") } returns problemsWindow
+        every { toolWindowManager.getToolWindow("Problems") } returns null
+        every { toolWindowManager.getToolWindow("Inspections") } returns null
+
+        every { inspectionWindow.contentManager } returns inspectionContentManager
+        every { inspectionContentManager.contentCount } returns 1
+        every { inspectionContentManager.getContent(0) } returns inspectionContent
+        val cleanRoot = DefaultMutableTreeNode("Inspection Results")
+        cleanRoot.add(DefaultMutableTreeNode("empty"))
+        val cleanPanel = JPanel()
+        cleanPanel.add(JTree(cleanRoot))
+        every { inspectionContent.component } returns cleanPanel
+
+        every { problemsWindow.contentManager } returns problemsContentManager
+        every { problemsContentManager.contentCount } returns 1
+        every { problemsContentManager.getContent(0) } returns problemsContent
+        every { virtualFile.path } returns "/tmp/project/App.kt"
+        val root = DefaultMutableTreeNode("root")
+        root.add(DefaultMutableTreeNode(FallbackProblem(virtualFile)))
+        val panel = JPanel()
+        panel.add(JTree(root))
+        every { problemsContent.component } returns panel
+
+        val result = extractor.extractAllProblemsWithStatus(project)
+
+        assertTrue(result.succeeded)
+        assertEquals(1, result.problems.size)
+        assertEquals("Fallback warning", result.problems[0]["description"])
+        assertEquals("problems_view", result.problems[0]["source"])
     }
 
     @Test


### PR DESCRIPTION
## Summary
- keep probing Problems fallback after empty primary inspection results
- preserve clean primary extraction status when fallback shells are blank
- bump plugin version to 1.13.9

## Validation
- JAVA_HOME=/opt/homebrew/Cellar/openjdk@21/21.0.11/libexec/openjdk.jdk/Contents/Home ./gradlew :test --tests com.shiny.inspectionmcp.EnhancedTreeExtractorTest
- JAVA_HOME=/opt/homebrew/Cellar/openjdk@21/21.0.11/libexec/openjdk.jdk/Contents/Home ./scripts/commit-gate.sh --ci
- fresh read-only review agents: 2 no production issues; 1 test-shape concern addressed before commit