### PR TITLE
Harden dogfood red-green readiness

### DIFF
--- a/.code/skills/jetbrains-inspection-workflow/SKILL.md
+++ b/.code/skills/jetbrains-inspection-workflow/SKILL.md
@@ -46,8 +46,10 @@ Use focused validation first, then broaden based on risk and user-facing impact.
 Keep exact command matrices, environment setup, and troubleshooting in
 `TESTING.md`; keep manual IDE endpoint recipes in `TESTING_INSTRUCTIONS.md`.
 
-1. For narrow docs-only changes, inspect the rendered Markdown or affected
-   examples when useful; do not run the full suite unless behavior changed.
+1. For narrow docs-only changes where no runtime behavior changed, skip
+   inspection and record a one-line not-run reason. Inspect the rendered
+   Markdown or affected examples only when examples describe behavior that is
+   itself under test; do not run the full suite unless behavior changed.
 2. For plugin or inspection-core changes, start with the closest Gradle test
    target, then run broader plugin tests if extraction, filtering, scope, or
    stale-location behavior changed.
@@ -57,8 +59,8 @@ Keep exact command matrices, environment setup, and troubleshooting in
    below and open `TESTING_INSTRUCTIONS.md` for the exact manual sequence.
 5. For lifecycle, capture, routing, or dogfood-exit readiness, run the dogfood
    smoke matrix (`./scripts/dogfood-smoke-matrix.sh`) when local IDEs are
-   available; it exercises preexisting and helper-opened readiness inspection paths and
-   records cleanup evidence.
+   available; it exercises preexisting and helper-opened readiness inspection
+   paths and records cleanup evidence.
 6. For verdict or extraction changes that must prove the red lane, run
    `./scripts/dogfood-red-lane-smoke.sh --product intellij|pycharm|webstorm`
    with the matching local IDE and the current plugin installed; it copies the
@@ -92,13 +94,18 @@ Keep exact command matrices, environment setup, and troubleshooting in
 7. For red-lane smoke tests, prefer `./scripts/dogfood-red-lane-smoke.sh` with
    the relevant `--product` and require current actionable findings in the helper
    response, such as `total_problems > 0`; a paginated current page may have an
-   empty `problems` list even when matching findings exist. `capture_incomplete`, `non_empty_unmapped_tree`, or a
-   non-clean zero-problem response proves only that clean was not confirmed.
+   empty `problems` list even when matching findings exist.
+   `capture_incomplete`, `non_empty_unmapped_tree`, or a non-clean zero-problem
+   response proves only that clean was not confirmed.
 8. Agent-facing inspection reports should use the helper verdict: `GREEN` means
    inspection worked and found no actionable findings for the selected
    scope/filter, `RED` means inspection worked and found actionable current
    problems, and `UNKNOWN` means the IDE/plugin/helper did not prove either
-   state and the next action must be reported.
+   state and the next action must be reported. Prefer the helper's compact
+   `agent_result` envelope: verdict, bucket, scope, one-line finding summary
+   with file/line when available, retry policy, and next action. Raw diagnostic
+   fields such as `capture_diagnostic` belong in helper debugging only. On
+   `UNKNOWN`, retry at most once and only when `retry_policy.retry=true`.
 
 ## IDE Smoke Testing
 
@@ -125,7 +132,9 @@ unit tests.
    `IntelliJ IDEA` should resolve to the latest installed stable/non-EAP app and
    matching config dir. Use exact selectors such as `--ide-channel eap`,
    `--ide-version 2026.2`, or `--ide-app` only when the test intentionally
-   targets an EAP or exact IDE version.
+   targets an EAP or exact IDE version. Never infer EAP from a discovered EAP
+   install; EAP must be explicitly requested through repo metadata, CLI flags,
+   exact app/version selection, or task text.
 9. If lifecycle auto-open stalls with `ide_selection_required`,
    `ide_config_ambiguous`, or `ide_config_missing`, treat that as repo metadata
    work: add preferred IDE metadata to `.github/github.json` or explicitly pass

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Typical response (truncated):
 Notes:
 - `locationKnown=false` means the IDE did not provide a stable file/line (often stale results). Use `locationNote` and re-run inspection.
 - `status: "no_results"` uses the same pagination, filters, `total_problems`, `problems_shown`, and `problems` fields as result responses, with an empty problems list.
-- `status: "capture_incomplete"` means an inspection finished, but the plugin could not conclusively capture the IDE results. Re-run the inspection or open the Problems/Inspection Results view before treating the project as clean. `capture_incomplete_reason` is a stable machine-readable bucket: `view_not_ready`, `view_updating_unreadable`, `unreadable_tree`, `extractor_failure`, `non_empty_unmapped_tree`, `current_run_psi_churn`, `timeout`, `profile_resolution_error`, `helper_plugin_error`, or `unknown`. Use `capture_diagnostic` for the detailed counters and booleans behind the classification.
+- `status: "capture_incomplete"` means an inspection finished, but the plugin could not conclusively capture the IDE results. Re-run the inspection or open the Problems/Inspection Results view before treating the project as clean. `capture_incomplete_reason` is a stable machine-readable bucket: `view_not_ready`, `view_updating_unreadable`, `unreadable_tree`, `extractor_failure`, `non_empty_unmapped_tree`, `current_run_psi_churn`, `timeout`, `profile_resolution_error`, `helper_plugin_error`, or `unknown`. Use `capture_diagnostic` only when debugging capture or extractor behavior; normal agent workflows should use the external helper's compact `agent_result` envelope.
 - `status: "stale_results"` means project files changed after the last inspection. It is not a clean result. Cached findings are withheld by default; call `/problems?include_stale=true` only when explicitly diagnosing cached data.
 - `snapshot_change_kind` explains freshness classification when present. `snapshot_predates_current_trigger` and `unsaved_documents` are stale; `current_run_psi_churn` is a fresh-run PSI tick that the plugin attempts to reconcile before returning results.
 - `session_drift: true` means the client sent an old `session_id`; the IDE/plugin session restarted or the port was reused.
@@ -500,16 +500,15 @@ Common completion reasons:
 - `no_recent_inspection`: no inspection run is known for the selected project. Trigger one first.
 - `no_project`: no matching project was open during the wait period. This is not reported as `timed_out`; open a project or pass the exact project name.
 
-For agent-facing reports, use `inspection_verdict` and the companion
-`inspection_verdict_reason`, `inspection_verdict_message`, and
+For agent-facing reports from the plugin API, use `inspection_verdict` and the
+companion `inspection_verdict_reason`, `inspection_verdict_message`, and
 `inspection_verdict_next_action` fields. The verdict is `GREEN` when inspection
 worked and found no actionable findings for the selected scope/filter, `RED`
 when inspection worked and returned actionable current findings, and `UNKNOWN`
-when the IDE/plugin/helper did not produce a trustworthy result.
-`UNKNOWN` is not clean and not red; report the included diagnostic reason and
-next action, such as opening the exact worktree in the IDE, waiting for
-indexing, rerunning stale results, or updating the plugin/helper when capture
-evidence points to an extractor or helper bug.
+when the IDE/plugin/helper did not produce a trustworthy result. `UNKNOWN` is
+not clean and not red; report the included reason and next action. The external
+`jb-inspect.py` helper may wrap these fields in its own compact `agent_result`
+envelope for agent workflows.
 
 ### Freshness Notes
 - The plugin saves documents and refreshes external file changes before starting a new inspection run.

--- a/TESTING.md
+++ b/TESTING.md
@@ -91,12 +91,18 @@ session drift, route ambiguity, wrong-worktree routes, and cleanup failures as
 non-clean outcomes. Cached stale findings are returned only when the helper is
 run with `--include-stale` for explicit diagnostics. `capture_incomplete`
 responses expose `capture_incomplete_reason` plus `capture_diagnostic`; use the
-reason bucket for triage and the diagnostic payload for counters and state
-evidence. Agent-facing reports should use the helper verdict: `GREEN` means the
-inspection worked and found no actionable findings for the selected
-scope/filter, `RED` means the inspection worked and returned actionable
-findings, and `UNKNOWN` means the tooling did not prove either state and must
-include the helper's next action.
+reason bucket for triage and keep the diagnostic payload for helper debugging.
+Agent-facing reports from plugin endpoint responses should use
+`inspection_verdict`, `inspection_verdict_reason`, `inspection_verdict_message`,
+and `inspection_verdict_next_action`. `GREEN` means the inspection worked and
+found no actionable findings for the selected scope/filter, `RED` means the
+inspection worked and returned actionable findings, and `UNKNOWN` means the
+tooling did not prove either state. The external `jb-inspect.py` helper may wrap
+these fields in its own compact `agent_result` envelope with retry policy for
+agent workflows.
+Use `uv run "$HELPER" summarize-outcomes` to view a helper-side rollup of
+`outcomes.jsonl` by verdict, bucket, retry, IDE channel, and cleanup status
+without running another inspection.
 When this repo changes
 inspection status semantics, route metadata, clean/capture classification,
 lifecycle cleanup contracts, or MCP tool response contracts, update the skill
@@ -106,9 +112,9 @@ workstream.
 ### Red lane dogfood
 
 Use `./scripts/dogfood-red-lane-smoke.sh` when changing verdict semantics,
-capture behavior, extraction, helper readiness inspection, or release readiness. It copies a
-maintained known-bad project fixture to a disposable local project, runs the
-external `jb-inspect.py inspect-closeout`, and requires `VERDICT=RED`,
+capture behavior, extraction, helper readiness inspection, or release readiness.
+It copies a maintained known-bad project fixture to a disposable local project,
+runs the external `jb-inspect.py inspect-closeout`, and requires `VERDICT=RED`,
 `total_problems > 0`, and cleanup `closed`. The helper may exit non-zero because
 `RED` is not readiness-clean; the smoke trusts the structured JSON verdict and
 still fails on invalid JSON or missing cleanup.
@@ -155,9 +161,10 @@ validation.
 
 Use `./scripts/dogfood-smoke-matrix.sh` before release, after lifecycle or
 capture behavior changes, and when closing a dogfood session that should prove
-agent readiness inspection behavior. The matrix wraps `jb-inspect.py inspect-closeout`, includes
-this repo by default, includes `~/Developer/mediaforce` when present, and runs
-both preexisting-project and helper-opened worktree cases.
+agent readiness inspection behavior. The matrix wraps
+`jb-inspect.py inspect-closeout`, includes this repo by default, includes
+`~/Developer/mediaforce` when present, and runs both preexisting-project and
+helper-opened worktree cases.
 
 ```bash
 ./scripts/dogfood-smoke-matrix.sh \
@@ -169,9 +176,9 @@ project is not already open it is reported as a skipped preexisting row. The
 helper-opened case creates a disposable linked worktree under
 `~/.code/working/jetbrains-inspection-api/dogfood-smoke`, expects
 `opened_by_helper=true`, and expects cleanup `closed`. Each row records the IDE
-identity, plugin version, cleanup status, result bucket, and the issue bucket to
-check for failures such as `capture_incomplete`, opaque helper errors, or
-lifecycle cleanup regressions.
+identity, plugin version, cleanup status, result bucket, helper `agent_result`
+bucket/retry decision, and the issue bucket to check for failures such as
+`capture_incomplete`, opaque helper errors, or lifecycle cleanup regressions.
 
 For a smaller targeted pass, restrict the matrix explicitly:
 

--- a/scripts/dogfood-red-lane-smoke.sh
+++ b/scripts/dogfood-red-lane-smoke.sh
@@ -145,7 +145,7 @@ pycharm | python)
 	FIXTURE="$ROOT/test-fixtures/inspection-red-lane-pycharm"
 	PROJECT_SLUG="inspection-red-lane-pycharm"
 	DEFAULT_IDE="PyCharm"
-	REQUIRED_PROFILE_TOOLS=("PyUnresolvedReferencesInspection")
+	REQUIRED_PROFILE_TOOLS=("PyDictDuplicateKeysInspection")
 	;;
 webstorm | javascript | js)
 	PRODUCT="webstorm"
@@ -220,13 +220,23 @@ fi
 VERDICT=$(jq -r '.verdict // .inspection_verdict // ""' "$PAYLOAD_FILE")
 TOTAL=$(jq -r '.total_problems // 0' "$PAYLOAD_FILE")
 CLEANUP_STATUS=$(jq -r '.cleanup.status // ""' "$PAYLOAD_FILE")
+AGENT_BUCKET=$(jq -r '.agent_result.bucket // .bucket // ""' "$PAYLOAD_FILE")
+AGENT_RETRY=$(jq -r '(.agent_result.retry_policy.retry // .retry_policy.retry // false) | tostring' "$PAYLOAD_FILE")
 
-if [ "$EXIT_CODE" -le 1 ] && [ "$VERDICT" = "RED" ] && [ "$TOTAL" != "0" ] && [ "$TOTAL" != "null" ] && [ "$CLEANUP_STATUS" = "closed" ]; then
+if [ "$EXIT_CODE" -le 1 ] && [ "$VERDICT" = "RED" ] && { [ "$AGENT_BUCKET" = "" ] || [ "$AGENT_BUCKET" = "actionable_findings" ]; } && [ "$TOTAL" != "0" ] && [ "$TOTAL" != "null" ] && [ "$CLEANUP_STATUS" = "closed" ]; then
 	STATUS="ok"
 	BUCKET="red_confirmed"
 else
 	STATUS="failed"
-	BUCKET="red_not_confirmed"
+	if [ -n "$AGENT_BUCKET" ] && [ "$AGENT_BUCKET" != "actionable_findings" ]; then
+		if [ "$AGENT_RETRY" = "true" ]; then
+			BUCKET="red_unknown_retryable:$AGENT_BUCKET"
+		else
+			BUCKET="red_unknown_terminal:$AGENT_BUCKET"
+		fi
+	else
+		BUCKET="red_not_confirmed"
+	fi
 fi
 
 REPORT=$(
@@ -261,6 +271,11 @@ REPORT=$(
         exit_code: $exit_code,
         verdict: (payload.verdict // payload.inspection_verdict // null),
         verdict_reason: (payload.verdict_reason // payload.inspection_verdict_reason // null),
+        agent_result: (payload.agent_result // {
+          bucket: (payload.bucket // null),
+          retry_policy: (payload.retry_policy // null),
+          agent_report: (payload.agent_report // null)
+        }),
         total_problems: (payload.total_problems // null),
         problems_shown: (payload.problems_shown // null),
         cleanup: (payload.cleanup // null),
@@ -271,7 +286,7 @@ REPORT=$(
       }'
 )
 
-printf '%s\n' "$REPORT" | jq -r '"status=\(.status) bucket=\(.bucket) verdict=\(.verdict) total=\(.total_problems // "-") cleanup=\(.cleanup.status // "-")"'
+printf '%s\n' "$REPORT" | jq -r '"status=\(.status) bucket=\(.bucket) verdict=\(.verdict) agent=\(.agent_result.bucket // "-") retry=\(.agent_result.retry_policy.retry // false) total=\(.total_problems // "-") cleanup=\(.cleanup.status // "-")"'
 
 if [ -n "$JSON_OUT" ]; then
 	mkdir -p "$(dirname "$JSON_OUT")"

--- a/scripts/dogfood-smoke-matrix.sh
+++ b/scripts/dogfood-smoke-matrix.sh
@@ -203,8 +203,7 @@ cleanup() {
 trap cleanup EXIT
 
 write_row() {
-	ROW_INDEX=$((ROW_INDEX + 1))
-	cat >"$TMP_DIR/row-$ROW_INDEX.json"
+	cat >"$TMP_DIR/row-$(date +%s)-$RANDOM-$RANDOM.json"
 }
 
 command_json() {
@@ -213,7 +212,7 @@ command_json() {
 
 issue_for_bucket() {
 	case "$1" in
-	opaque_error | helper_error | invalid_helper_json | capture_incomplete* | cleanup_* | lifecycle_* | skipped_preexisting_not_open | dry_run | clean | findings) echo "#68" ;;
+	opaque_error | helper_error | invalid_helper_json | capture_incomplete* | cleanup_* | lifecycle_* | skipped_preexisting_not_open | dry_run | clean | findings | unknown_retryable:* | unknown_terminal:*) echo "#68" ;;
 	*) echo "#65" ;;
 	esac
 }
@@ -234,17 +233,19 @@ classify_payload() {
 		return
 	fi
 
-	local status error_reason capture cleanup_status clean total
+	local status error_reason capture cleanup_status clean total agent_bucket agent_retry
 	status=$(jq -r '.status // ""' "$payload")
 	error_reason=$(jq -r '.error_reason // ""' "$payload")
 	capture=$(jq -r '(.capture_incomplete // false) | tostring' "$payload")
 	cleanup_status=$(jq -r '.cleanup.status // ""' "$payload")
 	clean=$(jq -r '(.clean // false) | tostring' "$payload")
 	total=$(jq -r '(.total_problems // .wait.total_problems // 0) | tostring' "$payload")
+	agent_bucket=$(jq -r '.agent_result.bucket // .bucket // ""' "$payload")
+	agent_retry=$(jq -r '(.agent_result.retry_policy.retry // .retry_policy.retry // false) | tostring' "$payload")
 
 	if [ "$scenario" = "preexisting" ] && [ "$exit_code" -ne 0 ] && [ "$status" = "error" ]; then
 		case "$error_reason" in
-		inspection_api_unavailable | missing_project | project_not_open | route_not_found | no_open_project | invalid_project | ide_open_failed | inspection_helper_error | worktree_route_mismatch)
+		inspection_api_unavailable | missing_project | project_not_open | target_project_not_open | route_not_found | no_open_project | invalid_project | ide_open_failed | inspection_helper_error | worktree_route_mismatch)
 			echo "skipped_preexisting_not_open"
 			return
 			;;
@@ -297,6 +298,14 @@ classify_payload() {
 	fi
 
 	if [ "$exit_code" -ne 0 ]; then
+		if [ -n "$agent_bucket" ]; then
+			if [ "$agent_retry" = "true" ]; then
+				echo "unknown_retryable:$agent_bucket"
+			else
+				echo "unknown_terminal:$agent_bucket"
+			fi
+			return
+		fi
 		echo "helper_error"
 		return
 	fi
@@ -362,6 +371,11 @@ build_row() {
         scenario: $scenario,
         exit_code: $exit_code,
         bucket: $bucket,
+        agent_result: ($payload.agent_result // {
+          bucket: ($payload.bucket // null),
+          retry_policy: ($payload.retry_policy // null),
+          agent_report: ($payload.agent_report // null)
+        }),
         issue: $issue,
         status: ($payload.status // null),
         clean: ($payload.clean // null),
@@ -441,6 +455,7 @@ write_static_row() {
 	: >"$raw_file"
 	: >"$stderr_file"
 	build_row "$label" "$source_repo" "$target_repo" "$ide" "$scenario" 2 "$bucket" "$cmd_file" "$payload_file" true "$raw_file" "$stderr_file" "" | write_row
+	ROW_INDEX=$((ROW_INDEX + 1))
 }
 
 run_case() {
@@ -504,6 +519,7 @@ run_case() {
 	local bucket
 	bucket=$(classify_payload "$scenario" "$exit_code" "$payload_file" "$valid_json")
 	build_row "$label" "$source_repo" "$target_repo" "$ide" "$scenario" "$exit_code" "$bucket" "$cmd_file" "$payload_file" "$valid_json" "$raw_file" "$stderr_file" "$worktree_path" | write_row
+	ROW_INDEX=$((ROW_INDEX + 1))
 }
 
 SCENARIOS=()
@@ -563,6 +579,8 @@ REPORT=$(
       summary: {
         rows: ($rows[0] | length),
         by_bucket: ($rows[0] | group_by(.bucket) | map({key: .[0].bucket, value: length}) | from_entries),
+        by_agent_bucket: ($rows[0] | group_by(.agent_result.bucket // "unknown") | map({key: (.[0].agent_result.bucket // "unknown"), value: length}) | from_entries),
+        by_agent_retry: ($rows[0] | group_by((.agent_result.retry_policy.retry // false) | tostring) | map({key: ((.[0].agent_result.retry_policy.retry // false) | tostring), value: length}) | from_entries),
         by_issue: ($rows[0] | group_by(.issue) | map({key: .[0].issue, value: length}) | from_entries)
       },
       rows: $rows[0]
@@ -571,7 +589,7 @@ REPORT=$(
 
 printf '%s\n' "$REPORT" | jq -r '
   "status=\(.status) rows=\(.summary.rows)",
-  (.rows[] | "[\(.bucket)] \(.scenario) \(.label) on \(.ide) cleanup=\(.cleanup.status // "-") open=\(.prepared.opened_by_helper // "-") plugin=\(.identity.plugin_version // "unknown") issue=\(.issue)")
+  (.rows[] | "[\(.bucket)] \(.scenario) \(.label) on \(.ide) agent=\(.agent_result.bucket // "-") retry=\(.agent_result.retry_policy.retry // false) cleanup=\(.cleanup.status // "-") open=\(.prepared.opened_by_helper // "-") plugin=\(.identity.plugin_version // "unknown") issue=\(.issue)")
 '
 
 if [ -n "$JSON_OUT" ]; then

--- a/scripts/test-red-lane-smoke-script.sh
+++ b/scripts/test-red-lane-smoke-script.sh
@@ -28,9 +28,10 @@ assert_fixture_pycharm() {
 	local fixture_profile="test-fixtures/inspection-red-lane-pycharm/.idea/inspectionProfiles/RedLane.xml"
 
 	grep -q 'INTENTIONAL RED-LANE FIXTURE' "$fixture_source"
-	grep -q 'definitely_missing_symbol()' "$fixture_source"
+	grep -q '"duplicate": "first"' "$fixture_source"
+	grep -q '"duplicate": "second"' "$fixture_source"
 	test -f test-fixtures/inspection-red-lane-pycharm/pyproject.toml
-	grep -q 'PyUnresolvedReferencesInspection' "$fixture_profile"
+	grep -q 'PyDictDuplicateKeysInspection' "$fixture_profile"
 }
 
 assert_fixture_webstorm() {
@@ -55,6 +56,7 @@ HELPER="$TMP_DIR/jb-inspect.py"
 cat >"$HELPER" <<'STUB'
 #!/usr/bin/env python3
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -76,7 +78,7 @@ while args:
 
 fixtures = [
     ("IntelliJ IDEA", "src/main/java/com/example/redlane/DefinitelyRed.java", "redLaneField"),
-    ("PyCharm", "src/definitely_red.py", "definitely_missing_symbol"),
+    ("PyCharm", "src/definitely_red.py", "duplicate"),
     ("WebStorm", "src/definitely-red.json", "duplicate"),
 ]
 
@@ -96,6 +98,23 @@ if ide != expected_ide:
     print(json.dumps({"status": "error", "error_reason": "wrong_ide", "expected_ide": expected_ide, "actual_ide": ide}))
     sys.exit(3)
 
+stub_bucket = os.environ.get("JB_INSPECT_STUB_BUCKET", "")
+if stub_bucket:
+    retry = os.environ.get("JB_INSPECT_STUB_RETRY", "false") == "true"
+    print(json.dumps({
+        "status": "no_results",
+        "verdict": "UNKNOWN",
+        "verdict_reason": "no_results",
+        "total_problems": 0,
+        "cleanup": {"status": "closed"},
+        "agent_result": {
+            "bucket": stub_bucket,
+            "retry_policy": {"retry": retry, "max_attempts": 1 if retry else 0},
+            "agent_report": "Stubbed unknown result",
+        },
+    }))
+    sys.exit(1)
+
 print(json.dumps({
     "status": "findings",
     "verdict": "RED",
@@ -105,6 +124,11 @@ print(json.dumps({
     "problems_shown": 1,
     "clean": False,
     "cleanup": {"status": "closed"},
+    "agent_result": {
+        "bucket": "actionable_findings",
+        "retry_policy": {"retry": False, "max_attempts": 0},
+        "agent_report": "Inspection worked and returned actionable findings.",
+    },
     "ide_selection": {"channel": ide_channel or None, "version": ide_version or None},
     "route": {"base_path": repo, "project_name": Path(repo).name, "ide": {"name": ide}},
     "problems": [{"severity": "error", "file": str(fixture), "line": 1, "description": f"Cannot resolve symbol {marker}"}],
@@ -139,7 +163,40 @@ run_case() {
     .verdict == "RED" and
     .total_problems == 1 and
     .cleanup.status == "closed" and
+    .agent_result.bucket == "actionable_findings" and
+    .payload.agent_result.bucket == "actionable_findings" and
     (.payload.problems[0].description | contains($expected_marker))
+  ' "$json_out" >/dev/null
+}
+
+run_unknown_case() {
+	local product=$1
+	local stub_bucket=$2
+	local stub_retry=$3
+	local expected_bucket=$4
+	local json_out="$TMP_DIR/$product-$stub_bucket-report.json"
+
+	if JB_INSPECT_STUB_BUCKET="$stub_bucket" JB_INSPECT_STUB_RETRY="$stub_retry" \
+		./scripts/dogfood-red-lane-smoke.sh \
+		--product "$product" \
+		--helper "$HELPER" \
+		--work-root "$TMP_DIR/work" \
+		--json-out "$json_out"; then
+		echo "expected unknown red-lane smoke case to fail: $product $stub_bucket" >&2
+		return 1
+	fi
+
+	jq -e \
+		--arg expected_bucket "$expected_bucket" \
+		--arg stub_bucket "$stub_bucket" \
+		--argjson stub_retry "$stub_retry" '
+    .status == "failed" and
+    .bucket == $expected_bucket and
+    .verdict == "UNKNOWN" and
+    .total_problems == 0 and
+    .cleanup.status == "closed" and
+    .agent_result.bucket == $stub_bucket and
+    .agent_result.retry_policy.retry == $stub_retry
   ' "$json_out" >/dev/null
 }
 
@@ -148,7 +205,9 @@ assert_fixture_pycharm
 assert_fixture_webstorm
 
 run_case intellij "IntelliJ IDEA" redLaneField
-run_case pycharm PyCharm definitely_missing_symbol
+run_case pycharm PyCharm duplicate
 run_case webstorm WebStorm duplicate
+run_unknown_case pycharm capture_not_ready true red_unknown_retryable:capture_not_ready
+run_unknown_case pycharm tool_bug false red_unknown_terminal:tool_bug
 
 echo "red-lane smoke script contract passed"

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -4772,7 +4772,7 @@ class InspectionHandler : HttpRequestHandler() {
             ideProductCode.equals("WS", ignoreCase = true) ->
                 linkedSetOf("JSUnresolvedReference", "JsonDuplicatePropertyKeys", "JsonStandardCompliance")
             isPyCharmProductCode(ideProductCode) ->
-                linkedSetOf("PyUnresolvedReferencesInspection")
+                linkedSetOf("PyDictDuplicateKeysInspection")
             else -> emptySet()
         }
     }

--- a/test-fixtures/inspection-red-lane-pycharm/.idea/inspectionProfiles/RedLane.xml
+++ b/test-fixtures/inspection-red-lane-pycharm/.idea/inspectionProfiles/RedLane.xml
@@ -1,6 +1,6 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0" is_locked="false">
     <option name="myName" value="RedLane" />
-    <inspection_tool class="PyUnresolvedReferencesInspection" enabled="true" level="ERROR" enabled_by_default="true" />
+    <inspection_tool class="PyDictDuplicateKeysInspection" enabled="true" level="ERROR" enabled_by_default="true" />
   </profile>
 </component>

--- a/test-fixtures/inspection-red-lane-pycharm/FIXTURE.md
+++ b/test-fixtures/inspection-red-lane-pycharm/FIXTURE.md
@@ -1,6 +1,6 @@
 # PyCharm Red-Lane Fixture
 
-This project is intentionally broken. Do not resolve the missing symbol;
-the fixture must keep producing current PyCharm inspection findings so
+This project is intentionally broken. Do not remove the duplicate literal dict
+key; the fixture must keep producing current PyCharm inspection findings so
 `dogfood-red-lane-smoke.sh --product pycharm` can prove the helper reports
 `RED`.

--- a/test-fixtures/inspection-red-lane-pycharm/src/definitely_red.py
+++ b/test-fixtures/inspection-red-lane-pycharm/src/definitely_red.py
@@ -1,7 +1,5 @@
-def main() -> None:
-    # INTENTIONAL RED-LANE FIXTURE: keep these PyCharm inspection findings.
-    definitely_missing_symbol()
-
-
-if __name__ == "__main__":
-    main()
+# INTENTIONAL RED-LANE FIXTURE: keep these PyCharm inspection findings.
+RED_LANE_VALUE = {
+    "duplicate": "first",
+    "duplicate": "second",
+}


### PR DESCRIPTION
## Summary

- harden the dogfood red/green readiness path and docs around decisive agent verdicts
- switch the PyCharm red-lane fixture to deterministic duplicate-dict-key inspection evidence
- strengthen smoke scripts to classify `agent_result` success, retryable UNKNOWN, and terminal UNKNOWN explicitly
- fix matrix artifact row handling so all rows survive on macOS and command/payload temp files stay unique

Coordinated with the matching `codex-skills` helper PR for retry taxonomy.

## Validation

- `shfmt -d scripts/dogfood-red-lane-smoke.sh scripts/dogfood-smoke-matrix.sh scripts/test-red-lane-smoke-script.sh`
- `shellcheck scripts/dogfood-red-lane-smoke.sh scripts/dogfood-smoke-matrix.sh scripts/test-red-lane-smoke-script.sh`
- `bash scripts/test-red-lane-smoke-script.sh`
- `./scripts/commit-gate.sh --ci`
- `./scripts/test-all.sh`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew verifyPluginStructure verifyPlugin`
- JetBrains changed-files closeout: retryable `UNKNOWN/capture_not_ready` first, then one allowed retry `GREEN/clean`, cleanup `closed`
- Post-install matrix: `tmp/final-post-install-20260705185648/smoke-matrix.json`, `status=ok`, 12 rows, 6 helper-opened `clean` rows on plugin `1.13.9`, 6 expected preexisting `route_not_ready` skips
- Installed `build/distributions/jetbrains-inspection-api-1.13.9.zip` into local IntelliJ/PyCharm/WebStorm 2026.1 and 2026.2 config dirs; verified all installed plugin jars report `1.13.9`

## Notes

The earlier warm soak remains the 85% target evidence: `32/33` decisive eligible outcomes, `96.97%`, target met. Evidence and final caveats are recorded on #151.
