### PR TITLE
Release v1.13.10

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion=1.13.9
+pluginVersion=1.13.10
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
 kotlin.stdlib.default.dependency=false
 # Enable Gradle Configuration Cache -> https://docs.gradle.org/current/userguide/configuration_cache.html

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.shiny.inspection.api</id>
     <name>Inspection API</name>
-    <version>1.13.9</version>
+    <version>1.13.10</version>
     <vendor email="info@shinycomputers.com" url="https://github.com/cbusillo/jetbrains-inspection-api">Shiny Computers (Chris Busillo)</vendor>
     <resource-bundle>messages.InspectionApiBundle</resource-bundle>
     


### PR DESCRIPTION
## Summary
- Bump pluginVersion to 1.13.10 after readiness hardening merged to main.
- Publish the dogfood/readiness changes that landed after v1.13.9.

## Validation
- ./scripts/release.sh --patch --yes local gates passed before branch-protected main push was rejected.
- Full Gradle test/build gates passed locally during release script.

## Release plan
- Merge via PR because main is protected.
- Push tag v1.13.10 from merged main after CI passes.