### PR TITLE
Harden lifecycle open reliability

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -67,14 +67,14 @@ uv run "$HELPER" inspect-closeout \
   --scope changed_files
 ```
 
-`inspect-closeout` serializes helper-owned IDE opens, requires an exact current-worktree
-route, runs inspection, and calls the plugin lifecycle close endpoint only for
-projects opened by the helper. Projects that were open before the helper started
-are left open. On macOS, lifecycle opens use `open -g` by default so the IDE should
-not take focus while readiness inspection is preparing a worktree. Auto-open requires a
-global trusted-root policy in
-`${CODE_HOME:-${CODEX_HOME:-$HOME/.code}}/jetbrains-inspection.json`; test worktrees should be
-created under those roots, not random temp directories.
+`inspect-closeout` serializes helper-owned IDE opens, requires an exact
+current-worktree route, runs inspection, and calls the plugin lifecycle close
+endpoint only for projects opened by the helper. Projects that were open before
+the helper started are left open. On macOS, lifecycle opens use `open -g` by
+default so the IDE should not take focus while readiness inspection is preparing
+a worktree. Auto-open requires a global trusted-root policy in
+`${CODE_HOME:-${CODEX_HOME:-$HOME/.code}}/jetbrains-inspection.json`; test
+worktrees should be created under those roots, not random temp directories.
 
 Before it starts lifecycle auto-open, the helper adds the matching trusted root
 to the selected JetBrains product's Trusted Locations and sets project opening
@@ -118,6 +118,12 @@ runs the external `jb-inspect.py inspect-closeout`, and requires `VERDICT=RED`,
 `total_problems > 0`, and cleanup `closed`. The helper may exit non-zero because
 `RED` is not readiness-clean; the smoke trusts the structured JSON verdict and
 still fails on invalid JSON or missing cleanup.
+
+The report prints and stores `open_attempt_count`, `open_methods`,
+verdict/error reason, and plugin identity so first-attempt reliability is
+visible. A warm IDE red-lane run should normally be
+`attempts=1 methods=running_ide`; cold IDE runs may include bootstrap attempts,
+but must still end in a trustworthy RED with cleanup `closed`.
 
 ```bash
 ./scripts/dogfood-red-lane-smoke.sh \

--- a/scripts/dogfood-red-lane-smoke.sh
+++ b/scripts/dogfood-red-lane-smoke.sh
@@ -257,6 +257,9 @@ REPORT=$(
 		--arg stderr "$(head -c 4000 "$ERR_OUT" 2>/dev/null || true)" '
       def command: $command[0];
       def payload: $payload[0];
+      def route: payload.route // payload.prepared.route // payload.prepared.lease.route // payload.prepared.claim.route // {};
+      def identity: route.ide // {};
+      def open_attempts: payload.open_attempts // payload.prepared.open_attempts // payload.prepared.lease.open_attempts // payload.lease.open_attempts // [];
       {
         status: $status,
         bucket: $bucket,
@@ -271,6 +274,13 @@ REPORT=$(
         exit_code: $exit_code,
         verdict: (payload.verdict // payload.inspection_verdict // null),
         verdict_reason: (payload.verdict_reason // payload.inspection_verdict_reason // null),
+        error_reason: (payload.error_reason // null),
+        blocked_diagnostic: (payload.blocked_diagnostic // null),
+        route_diagnostic: (payload.route_diagnostic // null),
+        open_attempts: open_attempts,
+        open_attempt_count: (open_attempts | length),
+        open_methods: (open_attempts | map(.method) | unique),
+        first_attempt_reliable: ((open_attempts | length) <= 1),
         agent_result: (payload.agent_result // {
           bucket: (payload.bucket // null),
           retry_policy: (payload.retry_policy // null),
@@ -279,14 +289,22 @@ REPORT=$(
         total_problems: (payload.total_problems // null),
         problems_shown: (payload.problems_shown // null),
         cleanup: (payload.cleanup // null),
-        route: (payload.route // null),
+        route: (if route == {} then null else route end),
+        identity: {
+          name: (identity.name // null),
+          product_code: (identity.product_code // null),
+          version: (identity.version // null),
+          plugin_version: (identity.plugin_version // null),
+          plugin_fingerprint: (identity.plugin_fingerprint // null),
+          pid: (identity.pid // null)
+        },
         command: command,
         payload: payload,
         stderr_excerpt: (if $stderr == "" then null else $stderr end)
       }'
 )
 
-printf '%s\n' "$REPORT" | jq -r '"status=\(.status) bucket=\(.bucket) verdict=\(.verdict) agent=\(.agent_result.bucket // "-") retry=\(.agent_result.retry_policy.retry // false) total=\(.total_problems // "-") cleanup=\(.cleanup.status // "-")"'
+printf '%s\n' "$REPORT" | jq -r '"status=\(.status) bucket=\(.bucket) verdict=\(.verdict) reason=\(.verdict_reason // .error_reason // "-") agent=\(.agent_result.bucket // "-") retry=\(.agent_result.retry_policy.retry // false) total=\(.total_problems // "-") cleanup=\(.cleanup.status // "-") attempts=\(.open_attempt_count) methods=\((.open_methods // []) | join(",")) plugin=\(.identity.plugin_version // "unknown")"'
 
 if [ -n "$JSON_OUT" ]; then
 	mkdir -p "$(dirname "$JSON_OUT")"

--- a/scripts/dogfood-smoke-matrix.sh
+++ b/scripts/dogfood-smoke-matrix.sh
@@ -362,6 +362,7 @@ build_row() {
         // $payload.prepared.claim.route
         // {};
       def identity: route.ide // {};
+      def open_attempts: $payload.open_attempts // $payload.prepared.open_attempts // $payload.prepared.lease.open_attempts // $payload.lease.open_attempts // [];
       {
         label: $label,
         source_repo: $source_repo,
@@ -378,6 +379,8 @@ build_row() {
         }),
         issue: $issue,
         status: ($payload.status // null),
+        verdict_reason: ($payload.verdict_reason // $payload.inspection_verdict_reason // null),
+        error_reason: ($payload.error_reason // null),
         clean: ($payload.clean // null),
         total_problems: ($payload.total_problems // $payload.wait.total_problems // null),
         capture_incomplete: ($payload.capture_incomplete // null),
@@ -390,6 +393,10 @@ build_row() {
           // null
         ),
         cleanup: ($payload.cleanup // null),
+        open_attempts: open_attempts,
+        open_attempt_count: (open_attempts | length),
+        open_methods: (open_attempts | map(.method) | unique),
+        first_attempt_reliable: ((open_attempts | length) <= 1),
         prepared: {
           opened_by_helper: ($payload.prepared.lease.opened_by_helper // $payload.prepared.opened_by_helper // null),
           open_method: ($payload.prepared.lease.open_method // $payload.prepared.open_method // null),
@@ -589,7 +596,7 @@ REPORT=$(
 
 printf '%s\n' "$REPORT" | jq -r '
   "status=\(.status) rows=\(.summary.rows)",
-  (.rows[] | "[\(.bucket)] \(.scenario) \(.label) on \(.ide) agent=\(.agent_result.bucket // "-") retry=\(.agent_result.retry_policy.retry // false) cleanup=\(.cleanup.status // "-") open=\(.prepared.opened_by_helper // "-") plugin=\(.identity.plugin_version // "unknown") issue=\(.issue)")
+  (.rows[] | "[\(.bucket)] \(.scenario) \(.label) on \(.ide) agent=\(.agent_result.bucket // "-") reason=\(.verdict_reason // .error_reason // "-") attempts=\(.open_attempt_count) retry=\(.agent_result.retry_policy.retry // false) cleanup=\(.cleanup.status // "-") open=\(.prepared.opened_by_helper // "-") plugin=\(.identity.plugin_version // "unknown") issue=\(.issue)")
 '
 
 if [ -n "$JSON_OUT" ]; then

--- a/scripts/test-red-lane-smoke-script.sh
+++ b/scripts/test-red-lane-smoke-script.sh
@@ -112,6 +112,9 @@ if stub_bucket:
             "retry_policy": {"retry": retry, "max_attempts": 1 if retry else 0},
             "agent_report": "Stubbed unknown result",
         },
+        "open_attempts": [{"method": "running_ide", "accepted": False, "reason": "project_open_blocked"}],
+        "route_diagnostic": {"reason": "target_ide_running_without_target_project"},
+        "blocked_diagnostic": {"reason": "jetbrains_project_open_blocked"},
     }))
     sys.exit(1)
 
@@ -129,8 +132,9 @@ print(json.dumps({
         "retry_policy": {"retry": False, "max_attempts": 0},
         "agent_report": "Inspection worked and returned actionable findings.",
     },
+    "open_attempts": [{"method": "running_ide", "accepted": True, "endpoint_status": "opening"}],
     "ide_selection": {"channel": ide_channel or None, "version": ide_version or None},
-    "route": {"base_path": repo, "project_name": Path(repo).name, "ide": {"name": ide}},
+    "route": {"base_path": repo, "project_name": Path(repo).name, "ide": {"name": ide, "plugin_version": "test-1.0.0", "plugin_fingerprint": "test-clean"}},
     "problems": [{"severity": "error", "file": str(fixture), "line": 1, "description": f"Cannot resolve symbol {marker}"}],
 }))
 STUB
@@ -165,6 +169,10 @@ run_case() {
     .cleanup.status == "closed" and
     .agent_result.bucket == "actionable_findings" and
     .payload.agent_result.bucket == "actionable_findings" and
+    .open_attempt_count == 1 and
+    .first_attempt_reliable == true and
+    .open_methods == ["running_ide"] and
+    .identity.plugin_version == "test-1.0.0" and
     (.payload.problems[0].description | contains($expected_marker))
   ' "$json_out" >/dev/null
 }
@@ -196,7 +204,11 @@ run_unknown_case() {
     .total_problems == 0 and
     .cleanup.status == "closed" and
     .agent_result.bucket == $stub_bucket and
-    .agent_result.retry_policy.retry == $stub_retry
+    .agent_result.retry_policy.retry == $stub_retry and
+    .open_attempt_count == 1 and
+    .open_methods == ["running_ide"] and
+    .route_diagnostic.reason == "target_ide_running_without_target_project" and
+    .blocked_diagnostic.reason == "jetbrains_project_open_blocked"
   ' "$json_out" >/dev/null
 }
 

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -759,14 +759,15 @@ class InspectionHandler : HttpRequestHandler() {
     internal var closeVerificationSleep: (Long) -> Unit = { millis -> Thread.sleep(millis) }
     internal var inspectionRunExpirationMs: Long = 300000L
     internal var trustProjectPath: (Path) -> Unit = { path ->
-        TrustedProjects.setProjectTrusted(path, true)
+        TrustedProjects.setProjectTrusted(canonicalTrustPath(path), true)
     }
     internal var openProjectPath: (Path) -> Project? = { path ->
+        val openPath = canonicalTrustPath(path)
         ProjectManagerEx.getInstanceEx().openProject(
-            path,
+            openPath,
             OpenProjectTask.build()
                 .withForceOpenInNewFrame(true)
-                .withProjectName(path.fileName?.toString() ?: path.toString()),
+                .withProjectName(openPath.fileName?.toString() ?: openPath.toString()),
         )
     }
 
@@ -1387,11 +1388,19 @@ class InspectionHandler : HttpRequestHandler() {
 
         val scheduled = runCatching {
             ApplicationManager.getApplication().invokeLater {
+                var opened: Project? = null
+                var keepOpeningGuard = false
                 try {
                     trustProjectPath(target.openPath)
-                    openProjectPath(target.openPath)
+                    opened = openProjectPath(target.openPath)
+                    if (opened != null) {
+                        keepOpeningGuard = true
+                        releaseLifecycleOpenGuardWhenUsable(target.key, opened)
+                    }
                 } finally {
-                    openingProjectPaths.remove(target.key)
+                    if (!keepOpeningGuard) {
+                        openingProjectPaths.remove(target.key)
+                    }
                 }
             }
         }.isSuccess
@@ -1414,6 +1423,25 @@ class InspectionHandler : HttpRequestHandler() {
             "worktree_path" to target.path.toString(),
             "session_id" to InspectionIdeSession.sessionId,
         ) to HttpResponseStatus.OK
+    }
+
+    private fun releaseLifecycleOpenGuardWhenUsable(key: String, project: Project) {
+        ApplicationManager.getApplication().executeOnPooledThread {
+            val deadline = System.currentTimeMillis() + 30_000L
+            try {
+                while (System.currentTimeMillis() <= deadline) {
+                    val usable = runCatching {
+                        ApplicationManager.getApplication().runReadAction<Boolean, Exception> {
+                            isUsableProject(project)
+                        }
+                    }.getOrDefault(false)
+                    if (usable) return@executeOnPooledThread
+                    Thread.sleep(200L)
+                }
+            } finally {
+                openingProjectPaths.remove(key)
+            }
+        }
     }
 
     private fun lifecycleOpenAlreadyOpen(project: Project): Pair<Map<String, Any?>, HttpResponseStatus> {
@@ -1451,6 +1479,11 @@ class InspectionHandler : HttpRequestHandler() {
     private fun canonicalLifecycleOpenKey(path: Path): String {
         return runCatching { path.toRealPath().toString() }
             .getOrElse { path.normalize().toAbsolutePath().toString() }
+    }
+
+    private fun canonicalTrustPath(path: Path): Path {
+        return runCatching { path.toRealPath() }
+            .getOrElse { path.normalize().toAbsolutePath() }
     }
 
     private fun findOpenProjectForLifecycleOpen(path: String): Project? {
@@ -1611,12 +1644,14 @@ class InspectionHandler : HttpRequestHandler() {
 
     private fun findOpenProjectByPath(path: String): Project? {
         val normalized = normalizeFileSystemPath(path) ?: return null
+        val canonical = runCatching { canonicalLifecycleOpenKey(Paths.get(normalized)) }.getOrNull()
         return ApplicationManager.getApplication().runReadAction<Project?, Exception> {
             ProjectManager.getInstance().openProjects.firstOrNull { project ->
                 isUsableProject(project) &&
                     (normalizeFileSystemPath(project.basePath) == normalized ||
                         projectRootFromProjectFilePath(project.projectFilePath) == normalized ||
                         normalizeFileSystemPath(project.projectFilePath) == normalized ||
+                        canonical?.let { lifecycleOpenKeys(project).contains(it) } == true ||
                         projectKey(project) == "path:$normalized" ||
                         projectKey(project) == "file:$normalized")
             }

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -1580,7 +1580,7 @@ class InspectionHandlerTest {
         every { mockApplication.invokeLater(any()) } answers {
             scheduled += firstArg<Runnable>()
         }
-        handler.openProjectPath = { mockProject }
+        handler.openProjectPath = { null }
 
         val first = processGetRequest(lifecycleOpenUri(tempDir))
         val second = processGetRequest(lifecycleOpenUri(tempDir))
@@ -1595,6 +1595,35 @@ class InspectionHandlerTest {
         val third = processGetRequest(lifecycleOpenUri(tempDir))
         assertEquals(2, scheduled.size)
         assertEquals(HttpResponseStatus.OK, third.status())
+    }
+
+    @Test
+    fun `test lifecycle open keeps opening guard until returned project is initialized`() {
+        val tempDir = Files.createTempDirectory("inspection-open-initializing")
+        every { mockProjectManager.openProjects } returns emptyArray()
+        val initializingProject = mockk<Project>()
+        every { initializingProject.isDefault } returns false
+        every { initializingProject.isDisposed } returns false
+        every { initializingProject.isInitialized } returns false
+        every { initializingProject.name } returns "inspection-open-initializing"
+        every { initializingProject.basePath } returns tempDir.toString()
+        every { initializingProject.projectFilePath } returns tempDir.resolve(".idea/misc.xml").toString()
+        val scheduled = mutableListOf<Runnable>()
+        every { mockApplication.invokeLater(any()) } answers {
+            scheduled += firstArg<Runnable>()
+        }
+        handler.openProjectPath = { initializingProject }
+
+        val first = processGetRequest(lifecycleOpenUri(tempDir))
+        scheduled.single().run()
+        val second = processGetRequest(lifecycleOpenUri(tempDir))
+        val secondBody = second.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, first.status())
+        assertEquals(HttpResponseStatus.OK, second.status())
+        assertEquals(1, scheduled.size)
+        assertTrue(secondBody.contains("\"reason\": \"already_opening\""))
+        assertTrue(secondBody.contains("\"opening_scheduled\": false"))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- keep lifecycle/open coalescing active until returned projects are usable, avoiding duplicate opens during IDE initialization
- canonicalize trust/open/project matching paths to avoid symlink path mismatches
- surface open attempt counts, methods, verdict reasons, route diagnostics, and plugin identity in red-lane smoke reports and matrix rows
- document first-attempt red-lane evidence expectations

## Validation
- ./scripts/test-red-lane-smoke-script.sh
- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test --tests com.shiny.inspectionmcp.InspectionHandlerTest buildPlugin
- pre-commit hook during commit ran ./gradlew :test, :inspection-core:test, :mcp-server-jvm:test, and buildPlugin successfully
- live dogfood red-lane smokes after local plugin install:
  - IntelliJ IDEA: RED, total=1, cleanup=closed, attempts=1, methods=running_ide, plugin=1.13.10
  - PyCharm warm: RED, total=2, cleanup=closed, attempts=1, methods=running_ide, plugin=1.13.10
  - WebStorm cold: RED, total=2, cleanup=closed, attempts=3, methods=bootstrap_ide/bootstrapped_ide/running_ide, plugin=1.13.10
  - WebStorm warm: RED, total=2, cleanup=closed, attempts=1, methods=running_ide, plugin=1.13.10

Paired helper skill PR: cbusillo/codex-skills branch fix/jb-inspect-app-open-fallback