### PR TITLE
Add workflow and shell hygiene checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,15 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      - name: Lint GitHub Actions workflows
+        uses: reviewdog/action-actionlint@v1
+        with:
+          fail_level: error
+          reporter: github-check
+
+      - name: Lint shell scripts
+        run: shellcheck --severity=warning scripts/*.sh
+
       - name: Run commit gate
         run: ./scripts/commit-gate.sh --ci
 

--- a/scripts/generate-release-notes.sh
+++ b/scripts/generate-release-notes.sh
@@ -54,7 +54,7 @@ maintenance="$(mktemp)"
 other_updates="$(mktemp)"
 seen_subjects="$(mktemp)"
 
-git log --pretty=format:'%s' --no-merges $range > "$commit_summary"
+git log --pretty=format:'%s' --no-merges "$range" > "$commit_summary"
 
 while IFS= read -r subject; do
   [[ -n "$subject" ]] || continue


### PR DESCRIPTION
## Summary

- add actionlint to the required CI commit gate
- add shellcheck for repo shell scripts at warning-or-higher severity
- quote the release-notes git log range so shellcheck can pass cleanly

## Notes

GitHub-managed CodeQL is already active for this repo with stable-looking `Analyze (actions)` and `Analyze (python)` contexts. After this PR is green, those contexts should be added to branch protection so CodeQL findings are caught before release train work.

## Validation

- `actionlint .github/workflows/ci.yml .github/workflows/release.yml`
- `shellcheck --severity=warning scripts/*.sh`
- `git diff --check`
- `./scripts/commit-gate.sh --ci`
