### PR TITLE
Fix reviewdog permissions and lifecycle timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ name: CI
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   commit-gate:

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -1373,6 +1373,12 @@ class InspectionHandler : HttpRequestHandler() {
                 return lifecycleOpenAlreadyOpen(project)
             }
         }
+        unresolvedLifecycleOpenProjects[target.key]?.let { project ->
+            if (isUnresolvedLifecycleOpenActive(project)) {
+                return lifecycleOpenStateUnknown(target)
+            }
+            unresolvedLifecycleOpenProjects.remove(target.key, project)
+        }
         findOpenProjectForLifecycleOpenKey(target.key)?.let { project ->
             unresolvedLifecycleOpenProjects.remove(target.key)
             return if (isUsableProject(project)) {
@@ -1380,12 +1386,6 @@ class InspectionHandler : HttpRequestHandler() {
             } else {
                 lifecycleOpenAlreadyOpening(target)
             }
-        }
-        unresolvedLifecycleOpenProjects[target.key]?.let { project ->
-            if (isUnresolvedLifecycleOpenActive(project)) {
-                return lifecycleOpenStateUnknown(target)
-            }
-            unresolvedLifecycleOpenProjects.remove(target.key, project)
         }
         firstParameter(parameters, "session_id") ?: return mapOf(
             "status" to "failed",
@@ -1472,7 +1472,7 @@ class InspectionHandler : HttpRequestHandler() {
                                 val isIdentifiableProject = isOpenProject && lifecycleOpenKeys(project).contains(key)
                                 val isUsableLifecycleProject = isIdentifiableProject && isUsableProject(project)
                                 observedOpenProject = observedOpenProject || isOpenProject
-                                unresolvedOpenState = !isIdentifiableProject && nowMs >= deadlineMs
+                                unresolvedOpenState = !isUsableLifecycleProject && nowMs >= deadlineMs
                                 project.isDisposed ||
                                     isUsableLifecycleProject ||
                                     (observedOpenProject && !isOpenProject) ||

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -1836,7 +1836,7 @@ class InspectionHandlerTest {
     }
 
     @Test
-    fun `test lifecycle open avoids duplicate scheduling at hard timeout after project is observed`() {
+    fun `test lifecycle open reports unknown state at hard timeout when observed project stays unusable`() {
         val tempDir = Files.createTempDirectory("inspection-open-observed-timeout")
         val openProjects = arrayOfNulls<Project>(1)
         every { mockProjectManager.openProjects } answers { openProjects.filterNotNull().toTypedArray() }
@@ -1853,6 +1853,10 @@ class InspectionHandlerTest {
         every { mockApplication.invokeLater(any()) } answers {
             scheduled += firstArg<Runnable>()
         }
+        every { mockApplication.executeOnPooledThread(any<Runnable>()) } answers {
+            firstArg<Runnable>().run()
+            mockk(relaxed = true)
+        }
         handler.lifecycleOpenGuardTimeoutMs = 400
         handler.lifecycleOpenGuardNow = { nowMs }
         handler.lifecycleOpenGuardSleep = { millis -> nowMs += millis }
@@ -1867,11 +1871,11 @@ class InspectionHandlerTest {
         val secondBody = second.content().toString(Charsets.UTF_8)
 
         assertEquals(HttpResponseStatus.OK, first.status())
-        assertEquals(HttpResponseStatus.OK, second.status())
+        assertEquals(HttpResponseStatus.CONFLICT, second.status())
         assertEquals(1, scheduled.size)
         assertFalse(initialized)
-        assertTrue(secondBody.contains("\"status\": \"opening\""))
-        assertTrue(secondBody.contains("\"reason\": \"already_opening\""))
+        assertTrue(secondBody.contains("\"status\": \"failed\""))
+        assertTrue(secondBody.contains("\"reason\": \"open_state_unknown\""))
         assertTrue(secondBody.contains("\"opening_scheduled\": false"))
     }
 


### PR DESCRIPTION
## Summary
- restore pull-requests write permission for reviewdog actionlint PR reviews
- time out lifecycle opens when an observed project never becomes usable
- add/update lifecycle regression coverage for the stalled project state

## Validation
- actionlint .github/workflows/ci.yml .github/workflows/release.yml
- shellcheck --severity=warning scripts/*.sh
- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test --tests 'com.shiny.inspectionmcp.InspectionHandlerTest.test lifecycle open reports unknown state at hard timeout when observed project stays unusable' --no-daemon --no-configuration-cache --no-build-cache --rerun-tasks --max-workers=1 --stacktrace
- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test --tests 'com.shiny.inspectionmcp.InspectionHandlerTest' --no-daemon --no-configuration-cache --no-build-cache --rerun-tasks --max-workers=1 --stacktrace
- JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test :inspection-core:test :mcp-server-jvm:test buildPlugin --no-daemon --no-configuration-cache --no-build-cache --rerun-tasks --max-workers=1 --stacktrace
- uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py inspect-closeout --repo "$PWD" --scope changed_files
