### PR TITLE
Add capture snapshot wiring tests

### DIFF
--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -165,6 +165,62 @@ internal data class InspectionModelExtraction(
         }
 }
 
+internal data class InspectionCaptureSnapshotInput(
+    val bestResults: List<Map<String, Any>>,
+    val bestSource: String,
+    val snapshotTimeMs: Long,
+    val projectState: InspectionProjectStateSnapshot,
+    val emptyOutcome: InspectionSnapshotOutcome,
+    val emptyNote: String?,
+    val captureScope: InspectionCaptureScope,
+    val captureDiagnostic: Map<String, Any?>?,
+    val runId: Long,
+    val triggerTimeMs: Long?,
+    val viewReadyOk: Boolean,
+)
+
+internal fun buildInspectionCaptureSnapshot(input: InspectionCaptureSnapshotInput): InspectionResultsSnapshot {
+    val captureIncompleteReason = classifyCaptureIncompleteReason(input.captureDiagnostic)
+    return when {
+        input.bestResults.isNotEmpty() -> InspectionResultsSnapshot(
+            problems = input.bestResults,
+            timestamp = input.snapshotTimeMs,
+            projectState = input.projectState,
+            outcome = InspectionSnapshotOutcome.PROBLEMS_FOUND,
+            source = input.bestSource,
+            captureScope = input.captureScope,
+            runId = input.runId,
+            triggerTimeMs = input.triggerTimeMs,
+        )
+
+        input.emptyOutcome == InspectionSnapshotOutcome.CLEAN_CONFIRMED -> InspectionResultsSnapshot(
+            problems = emptyList(),
+            timestamp = input.snapshotTimeMs,
+            projectState = input.projectState,
+            outcome = InspectionSnapshotOutcome.CLEAN_CONFIRMED,
+            source = "inspection_view",
+            captureScope = input.captureScope,
+            captureDiagnostic = input.captureDiagnostic,
+            runId = input.runId,
+            triggerTimeMs = input.triggerTimeMs,
+        )
+
+        else -> InspectionResultsSnapshot(
+            problems = emptyList(),
+            timestamp = input.snapshotTimeMs,
+            projectState = input.projectState,
+            outcome = InspectionSnapshotOutcome.CAPTURE_INCOMPLETE,
+            source = if (input.viewReadyOk) "inspection_view" else "tool_window",
+            note = input.emptyNote,
+            captureScope = input.captureScope,
+            captureDiagnostic = input.captureDiagnostic,
+            captureIncompleteReason = captureIncompleteReason,
+            runId = input.runId,
+            triggerTimeMs = input.triggerTimeMs,
+        )
+    }
+}
+
 private data class CurrentRunPsiChurnReconciliation(
     val snapshot: InspectionResultsSnapshot?,
     val reconciled: Boolean,
@@ -3649,43 +3705,21 @@ class InspectionHandler : HttpRequestHandler() {
                         } else {
                             null
                         }
-                        val captureIncompleteReason = classifyCaptureIncompleteReason(captureDiagnostic)
-                        val snapshot = when {
-                            bestResults.isNotEmpty() -> InspectionResultsSnapshot(
-                                problems = bestResults,
-                                timestamp = System.currentTimeMillis(),
+                        val snapshot = buildInspectionCaptureSnapshot(
+                            InspectionCaptureSnapshotInput(
+                                bestResults = bestResults,
+                                bestSource = bestSource,
+                                snapshotTimeMs = System.currentTimeMillis(),
                                 projectState = snapshotState,
-                                outcome = InspectionSnapshotOutcome.PROBLEMS_FOUND,
-                                source = bestSource,
-                                captureScope = captureScope,
-                                runId = runId,
-                                triggerTimeMs = inspectionRunStatesByProject[key]?.triggerTimeMs,
-                            )
-                            emptyOutcome == InspectionSnapshotOutcome.CLEAN_CONFIRMED -> InspectionResultsSnapshot(
-                                problems = emptyList(),
-                                timestamp = System.currentTimeMillis(),
-                                projectState = snapshotState,
-                                outcome = InspectionSnapshotOutcome.CLEAN_CONFIRMED,
-                                source = "inspection_view",
+                                emptyOutcome = emptyOutcome,
+                                emptyNote = emptyNote,
                                 captureScope = captureScope,
                                 captureDiagnostic = captureDiagnostic,
                                 runId = runId,
                                 triggerTimeMs = inspectionRunStatesByProject[key]?.triggerTimeMs,
+                                viewReadyOk = viewReadyOk,
                             )
-                            else -> InspectionResultsSnapshot(
-                                problems = emptyList(),
-                                timestamp = System.currentTimeMillis(),
-                                projectState = snapshotState,
-                                outcome = InspectionSnapshotOutcome.CAPTURE_INCOMPLETE,
-                                source = if (viewReadyOk) "inspection_view" else "tool_window",
-                                note = emptyNote,
-                                captureScope = captureScope,
-                                captureDiagnostic = captureDiagnostic,
-                                captureIncompleteReason = captureIncompleteReason,
-                                runId = runId,
-                                triggerTimeMs = inspectionRunStatesByProject[key]?.triggerTimeMs,
-                            )
-                        }
+                        )
                         if (snapshot.outcome == InspectionSnapshotOutcome.CAPTURE_INCOMPLETE && bestResults.isEmpty()) {
                             logger.info(
                                 "Inspection capture incomplete for ${project.name}: " +

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
@@ -124,6 +124,187 @@ class InspectionSnapshotStateTest {
     }
 
     @Test
+    @DisplayName("Capture snapshot builder preserves findings metadata from the production capture path")
+    fun testCaptureSnapshotBuilderPreservesFindingsMetadata() {
+        val captureScope = InspectionCaptureScope(
+            scopeParam = "files",
+            files = listOf("src/App.kt"),
+            maxFiles = 10,
+        )
+        val projectState = InspectionProjectStateSnapshot(psiModificationCount = 7L, unsavedProjectDocuments = 0)
+        val problems = listOf(
+            mapOf(
+                "description" to "warning",
+                "file" to "/tmp/TestProject/src/App.kt",
+                "line" to 4,
+            )
+        )
+
+        val snapshot = buildInspectionCaptureSnapshot(
+            InspectionCaptureSnapshotInput(
+                bestResults = problems,
+                bestSource = "tool_window",
+                snapshotTimeMs = System.currentTimeMillis(),
+                projectState = projectState,
+                emptyOutcome = InspectionSnapshotOutcome.CAPTURE_INCOMPLETE,
+                emptyNote = "ignored when findings exist",
+                captureScope = captureScope,
+                captureDiagnostic = mapOf("exit_reason" to "timeout"),
+                runId = 42L,
+                triggerTimeMs = 1000L,
+                viewReadyOk = true,
+            )
+        )
+
+        assertEquals(InspectionSnapshotOutcome.PROBLEMS_FOUND, snapshot.outcome)
+        assertEquals(problems, snapshot.problems)
+        assertEquals("tool_window", snapshot.source)
+        assertEquals(captureScope, snapshot.captureScope)
+        assertEquals(projectState, snapshot.projectState)
+        assertEquals(42L, snapshot.runId)
+        assertEquals(1000L, snapshot.triggerTimeMs)
+        assertEquals(null, snapshot.captureDiagnostic)
+        assertEquals(null, snapshot.captureIncompleteReason)
+    }
+
+    @Test
+    @DisplayName("Capture snapshot builder keeps clean proof diagnostics from settled empty views")
+    fun testCaptureSnapshotBuilderKeepsCleanProofDiagnostics() {
+        val captureScope = InspectionCaptureScope(scopeParam = "whole_project")
+        val projectState = InspectionProjectStateSnapshot(psiModificationCount = 7L, unsavedProjectDocuments = 0)
+        val diagnostic = mapOf(
+            "exit_reason" to "settled",
+            "view_ready_ok" to true,
+            "observed_inspection_view" to true,
+            "observed_settled_empty_inspection_view" to true,
+            "successful_extraction_count" to 3,
+        )
+        val runState = beginInspectionRun()
+        finishInspectionRun(snapshotKey(), runState.runId)
+
+        val snapshot = buildInspectionCaptureSnapshot(
+            InspectionCaptureSnapshotInput(
+                bestResults = emptyList(),
+                bestSource = "tool_window",
+                snapshotTimeMs = System.currentTimeMillis(),
+                projectState = projectState,
+                emptyOutcome = InspectionSnapshotOutcome.CLEAN_CONFIRMED,
+                emptyNote = null,
+                captureScope = captureScope,
+                captureDiagnostic = diagnostic,
+                runId = runState.runId,
+                triggerTimeMs = runState.triggerTimeMs,
+                viewReadyOk = true,
+            )
+        )
+
+        assertEquals(InspectionSnapshotOutcome.CLEAN_CONFIRMED, snapshot.outcome)
+        assertEquals(emptyList<Map<String, Any>>(), snapshot.problems)
+        assertEquals("inspection_view", snapshot.source)
+        assertEquals(captureScope, snapshot.captureScope)
+        assertEquals(diagnostic, snapshot.captureDiagnostic)
+        assertEquals(null, snapshot.captureIncompleteReason)
+        assertEquals(runState.runId, snapshot.runId)
+
+        InspectionResultsStore.setSnapshot(snapshotKey(), snapshot)
+        val status = buildInspectionStatus()
+
+        assertEquals("GREEN", status["inspection_verdict"])
+        assertEquals("clean_confirmed", status["inspection_verdict_reason"])
+        assertEquals("clean_confirmed", status["snapshot_outcome"])
+        assertEquals(diagnostic, status["capture_diagnostic"])
+        @Suppress("UNCHECKED_CAST")
+        val proof = status["inspection_proof"] as Map<String, Any?>
+        assertEquals("complete", proof["status"])
+        assertEquals(true, proof["capture_complete"])
+    }
+
+    @Test
+    @DisplayName("Capture snapshot builder preserves incomplete reason and diagnostic proof")
+    fun testCaptureSnapshotBuilderPreservesIncompleteReason() {
+        val captureScope = InspectionCaptureScope(scopeParam = "current_file", resolvedCurrentFile = "src/App.kt")
+        val projectState = InspectionProjectStateSnapshot(psiModificationCount = 7L, unsavedProjectDocuments = 0)
+        val diagnostic = mapOf(
+            "exit_reason" to "deadline",
+            "view_ready_ok" to false,
+            "observed_inspection_view" to false,
+            "successful_extraction_count" to 0,
+            "extraction_failure_count" to 2,
+            "last_extraction_cycle_succeeded" to false,
+        )
+        val runState = beginInspectionRun()
+        finishInspectionRun(snapshotKey(), runState.runId)
+
+        val snapshot = buildInspectionCaptureSnapshot(
+            InspectionCaptureSnapshotInput(
+                bestResults = emptyList(),
+                bestSource = "inspection_view",
+                snapshotTimeMs = System.currentTimeMillis(),
+                projectState = projectState,
+                emptyOutcome = InspectionSnapshotOutcome.CAPTURE_INCOMPLETE,
+                emptyNote = "Inspection finished without trustworthy results.",
+                captureScope = captureScope,
+                captureDiagnostic = diagnostic,
+                runId = runState.runId,
+                triggerTimeMs = runState.triggerTimeMs,
+                viewReadyOk = false,
+            )
+        )
+
+        assertEquals(InspectionSnapshotOutcome.CAPTURE_INCOMPLETE, snapshot.outcome)
+        assertEquals("tool_window", snapshot.source)
+        assertEquals("Inspection finished without trustworthy results.", snapshot.note)
+        assertEquals(captureScope, snapshot.captureScope)
+        assertEquals(diagnostic, snapshot.captureDiagnostic)
+        assertEquals(CaptureIncompleteReason.EXTRACTOR_FAILURE, snapshot.captureIncompleteReason)
+        assertEquals(runState.runId, snapshot.runId)
+
+        InspectionResultsStore.setSnapshot(snapshotKey(), snapshot)
+        val status = buildInspectionStatus()
+
+        assertEquals("UNKNOWN", status["inspection_verdict"])
+        assertEquals("extractor_failure", status["inspection_verdict_reason"])
+        assertEquals("capture_incomplete", status["snapshot_outcome"])
+        assertEquals("extractor_failure", status["capture_incomplete_reason"])
+        assertEquals(diagnostic, status["capture_diagnostic"])
+        assertEquals(false, status["clean_inspection"])
+        assertEquals(false, status["has_inspection_results"])
+    }
+
+    @Test
+    @DisplayName("Capture snapshot builder marks incomplete ready views as inspection view source")
+    fun testCaptureSnapshotBuilderKeepsReadyIncompleteSource() {
+        val diagnostic = mapOf(
+            "exit_reason" to "deadline",
+            "view_ready_ok" to true,
+            "observed_inspection_view" to true,
+            "inspection_view_updating" to true,
+            "unreadable_problem_state_observation_count" to 1,
+        )
+
+        val snapshot = buildInspectionCaptureSnapshot(
+            InspectionCaptureSnapshotInput(
+                bestResults = emptyList(),
+                bestSource = "tool_window",
+                snapshotTimeMs = 1234L,
+                projectState = InspectionProjectStateSnapshot(psiModificationCount = 11L, unsavedProjectDocuments = 0),
+                emptyOutcome = InspectionSnapshotOutcome.CAPTURE_INCOMPLETE,
+                emptyNote = "Inspection view was still updating.",
+                captureScope = InspectionCaptureScope(scopeParam = "whole_project"),
+                captureDiagnostic = diagnostic,
+                runId = 45L,
+                triggerTimeMs = 1000L,
+                viewReadyOk = true,
+            )
+        )
+
+        assertEquals(InspectionSnapshotOutcome.CAPTURE_INCOMPLETE, snapshot.outcome)
+        assertEquals("inspection_view", snapshot.source)
+        assertEquals(CaptureIncompleteReason.VIEW_UPDATING_UNREADABLE, snapshot.captureIncompleteReason)
+        assertEquals(diagnostic, snapshot.captureDiagnostic)
+    }
+
+    @Test
     @DisplayName("Confirmed clean snapshot is the only zero-problem state reported as clean")
     fun testCleanSnapshotRequiresConfirmedOutcome() {
         InspectionResultsStore.setSnapshot(


### PR DESCRIPTION
## Summary
- Extract final capture evidence -> `InspectionResultsSnapshot` mapping into a small internal builder.
- Keep the production capture loop on the same fields while making the verdict-driving snapshot construction directly testable.
- Add coverage for findings, clean, incomplete, and ready-but-incomplete capture branches, including downstream status/proof checks for GREEN and UNKNOWN outcomes.

## Validation
- `./gradlew :test --tests com.shiny.inspectionmcp.InspectionSnapshotStateTest`
- `./gradlew :test --tests com.shiny.inspectionmcp.InspectionHandlerTest`
- `./gradlew :test`
- `./gradlew test verifyPlugin`

Fixes #181
