### PR TITLE
Add verdict contract fixtures

### DIFF
--- a/mcp-server-jvm/src/test/kotlin/com/shiny/inspectionmcp/mcpserver/McpServerTest.kt
+++ b/mcp-server-jvm/src/test/kotlin/com/shiny/inspectionmcp/mcpserver/McpServerTest.kt
@@ -1,7 +1,9 @@
 package com.shiny.inspectionmcp.mcpserver
 
 import com.sun.net.httpserver.HttpServer
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
@@ -300,6 +302,41 @@ class McpServerTest {
             assertTrue(text.contains("VERDICT: UNKNOWN"))
             assertTrue(text.contains("reason=stale_results"))
             assertFalse(text.contains("VERDICT: RED"))
+        }
+    }
+
+    @Test
+    fun mcpRenderedVerdictsMatchSharedContractFixtures() {
+        listOf(
+            contractCase("problems-red-findings"),
+            contractCase("problems-unknown-capture-incomplete"),
+            contractCase("problems-unknown-stale-default"),
+            contractCase("status-green-clean"),
+            contractCase("status-unknown-proof-failed"),
+        ).forEach { contract ->
+            val path = "/api/inspection/${contract.endpoint}"
+            MockIdeServer(mapOf(path to MockResponse(contract.payloadText))).use { server ->
+                server.start()
+                val executor = ToolExecutor(server.baseUrl, HttpClient.newHttpClient(), server.port.toString())
+                val tool = when (contract.endpoint) {
+                    "problems" -> "inspection_get_problems"
+                    "status" -> "inspection_get_status"
+                    else -> error("Unsupported contract endpoint: ${contract.endpoint}")
+                }
+
+                val result = executor.handleToolCall(buildToolCall(tool, buildJsonObject { }))
+                val text = result.firstText()
+
+                assertFalse(result.isError(), contract.name)
+                assertTrue(text.contains("VERDICT: ${contract.expected.string("verdict")} reason=${contract.expected.string("reason")}"), contract.name)
+                contract.expected.stringArray("mcp_contains").forEach { expectedText ->
+                    assertTrue(text.contains(expectedText), "${contract.name} missing $expectedText in:\n$text")
+                }
+                contract.expected.stringArray("mcp_not_contains").forEach { forbiddenText ->
+                    assertFalse(text.contains(forbiddenText), "${contract.name} leaked $forbiddenText in:\n$text")
+                }
+                assertFixtureSatisfiesHelperContract(contract)
+            }
         }
     }
 
@@ -1371,6 +1408,104 @@ private fun buildToolCall(name: String, args: JsonObject): JsonObject {
     }
 }
 
+private data class ContractCase(
+    val name: String,
+    val endpoint: String,
+    val payload: JsonObject,
+    val payloadText: String,
+    val expected: JsonObject,
+)
+
+private fun contractCase(name: String): ContractCase {
+    val path = contractFixturePath(name)
+    val root = Json.parseToJsonElement(Files.readString(path)).jsonObject
+    val payload = root["payload"]?.jsonObject ?: error("Missing payload in $name")
+    return ContractCase(
+        name = root.string("name") ?: name,
+        endpoint = root.string("endpoint") ?: error("Missing endpoint in $name"),
+        payload = payload,
+        payloadText = Json.encodeToString(JsonElement.serializer(), payload),
+        expected = root["expected"]?.jsonObject ?: error("Missing expected in $name"),
+    )
+}
+
+private fun contractFixturePath(name: String): Path {
+    val relative = Path.of("test-fixtures/contract-verdicts/$name.json")
+    return generateSequence(Path.of("").toAbsolutePath()) { current -> current.parent }
+        .map { root -> root.resolve(relative) }
+        .firstOrNull { Files.exists(it) }
+        ?: error("Missing contract fixture: $relative")
+}
+
+private fun assertFixtureSatisfiesHelperContract(contract: ContractCase) {
+    val helper = contract.expected["helper_agent_result"]?.jsonObject
+        ?: error("${contract.name} missing helper_agent_result")
+    val retryPolicy = helper["retry_policy"]?.jsonObject
+        ?: error("${contract.name} missing helper retry_policy")
+
+    val helperContract = expectedHelperContract(contract)
+    assertEquals(helperContract.verdict, helper.string("verdict"), "${contract.name} helper verdict")
+    assertEquals(helperContract.bucket, helper.string("bucket"), "${contract.name} helper bucket")
+    assertEquals(helperContract.retry, retryPolicy["retry"]?.jsonPrimitive?.booleanOrNull, "${contract.name} helper retry")
+    assertEquals(helperContract.maxAttempts, retryPolicy["max_attempts"]?.jsonPrimitive?.intOrNull, "${contract.name} helper max_attempts")
+    assertEquals(helperContract.waitMs, retryPolicy["wait_ms"]?.jsonPrimitive?.intOrNull, "${contract.name} helper wait_ms")
+    assertEquals(helperContract.nextAction, helper.string("next_action"), "${contract.name} helper next_action")
+    assertEquals(helperContract.agentReport, helper.string("agent_report"), "${contract.name} helper agent_report")
+    listOf(
+        "inspection_verdict",
+        "inspection_verdict_reason",
+        "inspection_verdict_message",
+        "inspection_verdict_next_action",
+    ).forEach { field ->
+        assertTrue(!contract.payload.string(field).isNullOrBlank(), "${contract.name} missing $field")
+    }
+}
+
+private data class HelperContract(
+    val verdict: String,
+    val bucket: String,
+    val retry: Boolean,
+    val maxAttempts: Int,
+    val waitMs: Int,
+    val nextAction: String,
+    val agentReport: String,
+)
+
+private fun expectedHelperContract(contract: ContractCase): HelperContract {
+    val verdict = contract.expected.string("verdict") ?: "UNKNOWN"
+    val reason = contract.expected.string("reason") ?: "unknown"
+    val bucket = when {
+        verdict == "GREEN" -> "clean"
+        verdict == "RED" -> "actionable_findings"
+        reason == "stale_results" -> "stale_results"
+        reason in setOf("extractor_failure", "inspection_proof_failed") -> "tool_bug"
+        else -> "unknown"
+    }
+    val retry = verdict == "UNKNOWN" && bucket == "stale_results"
+    val nextAction = when {
+        verdict == "GREEN" -> "No inspection action required for this scope/filter."
+        verdict == "RED" -> "Fix the reported findings, then rerun inspection."
+        reason == "extractor_failure" -> "Treat this as a plugin/helper bug: capture the diagnostic payload, update the inspection plugin or helper skill, and rerun."
+        reason == "stale_results" -> "Rerun inspection; stale cached findings must not be treated as current."
+        reason == "inspection_proof_failed" -> "Do not report GREEN or RED. Rerun inspection and include helper diagnostics if it remains UNKNOWN."
+        else -> "Do not report GREEN or RED. Rerun inspection and include helper diagnostics if it remains UNKNOWN."
+    }
+    val agentReport = when (verdict) {
+        "GREEN" -> "JetBrains inspection passed for the selected scope."
+        "RED" -> "JetBrains inspection found ${contract.payload["total_problems"]?.jsonPrimitive?.intOrNull ?: 0} actionable finding(s)."
+        else -> "JetBrains inspection was inconclusive ($bucket: $reason). $nextAction"
+    }
+    return HelperContract(
+        verdict = verdict,
+        bucket = bucket,
+        retry = retry,
+        maxAttempts = if (retry) 1 else 0,
+        waitMs = if (retry) 30000 else 0,
+        nextAction = nextAction,
+        agentReport = agentReport,
+    )
+}
+
 private fun JsonObject.firstText(): String {
     val content = this["content"]?.jsonArray?.firstOrNull()?.jsonObject ?: return ""
     return content["text"]?.jsonPrimitive?.content ?: ""
@@ -1382,4 +1517,8 @@ private fun JsonObject.isError(): Boolean {
 
 private fun JsonObject.string(field: String): String? {
     return this[field]?.jsonPrimitive?.contentOrNull
+}
+
+private fun JsonObject.stringArray(field: String): List<String> {
+    return this[field]?.jsonArray?.mapNotNull { item -> item.jsonPrimitive.contentOrNull } ?: emptyList()
 }

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
@@ -17,6 +17,13 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -24,8 +31,12 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
 
 class InspectionSnapshotStateTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
 
     private lateinit var handler: InspectionHandler
     private lateinit var mockProject: Project
@@ -302,6 +313,27 @@ class InspectionSnapshotStateTest {
         assertEquals("inspection_view", snapshot.source)
         assertEquals(CaptureIncompleteReason.VIEW_UPDATING_UNREADABLE, snapshot.captureIncompleteReason)
         assertEquals(diagnostic, snapshot.captureDiagnostic)
+    }
+
+    @Test
+    @DisplayName("Plugin HTTP verdict payloads match shared contract fixtures")
+    fun testPluginHttpVerdictPayloadsMatchContractFixtures() {
+        val cases = listOf(
+            contractCase("status-green-clean") to pluginStatusGreenClean(),
+            contractCase("problems-red-findings") to pluginProblemsRedFindings(),
+            contractCase("problems-unknown-capture-incomplete") to pluginProblemsUnknownCaptureIncomplete(),
+            contractCase("problems-unknown-stale-default") to pluginProblemsUnknownStaleDefault(),
+            contractCase("status-unknown-proof-failed") to pluginStatusUnknownProofFailed(),
+        )
+
+        cases.forEach { (contract, actual) ->
+            val expectedPayload = contract.payload
+
+            assertJsonContains(expectedPayload, actual, contract.name)
+            assertEquals(expectedPayload.string("inspection_verdict"), actual.string("inspection_verdict"), contract.name)
+            assertEquals(expectedPayload.string("inspection_verdict_reason"), actual.string("inspection_verdict_reason"), contract.name)
+            assertRequiredHelperFields(actual, contract.name)
+        }
     }
 
     @Test
@@ -2911,6 +2943,109 @@ class InspectionSnapshotStateTest {
         return method.invoke(handler, mockProject) as MutableMap<String, Any>
     }
 
+    private fun pluginStatusGreenClean(): JsonObject {
+        InspectionResultsStore.setSnapshot(
+            snapshotKey(),
+            InspectionResultsSnapshot(
+                problems = emptyList(),
+                timestamp = System.currentTimeMillis(),
+                projectState = InspectionProjectStateSnapshot(psiModificationCount = 7L, unsavedProjectDocuments = 0),
+                outcome = InspectionSnapshotOutcome.CLEAN_CONFIRMED,
+                source = "inspection_view",
+            ),
+        )
+        return buildInspectionStatus().toJsonObject()
+    }
+
+    private fun pluginProblemsRedFindings(): JsonObject {
+        val runState = beginInspectionRun()
+        finishInspectionRun(snapshotKey(), runState.runId)
+        InspectionResultsStore.setSnapshot(
+            snapshotKey(),
+            InspectionResultsSnapshot(
+                problems = listOf(
+                    staleProblem(
+                        description = "Unresolved reference: missingSymbol",
+                        file = "/tmp/TestProject/src/App.kt",
+                        line = 4,
+                        column = 9,
+                        severity = "error",
+                        inspectionType = "UnresolvedReference",
+                    ),
+                ),
+                timestamp = System.currentTimeMillis(),
+                projectState = InspectionProjectStateSnapshot(psiModificationCount = 7L, unsavedProjectDocuments = 0),
+                outcome = InspectionSnapshotOutcome.PROBLEMS_FOUND,
+                source = "inspection_view",
+                runId = runState.runId,
+                triggerTimeMs = runState.triggerTimeMs,
+            ),
+        )
+        return json.parseToJsonElement(getInspectionProblems()).jsonObject
+    }
+
+    private fun pluginProblemsUnknownCaptureIncomplete(): JsonObject {
+        val runState = beginInspectionRun()
+        finishInspectionRun(snapshotKey(), runState.runId)
+        InspectionResultsStore.setSnapshot(
+            snapshotKey(),
+            InspectionResultsSnapshot(
+                problems = emptyList(),
+                timestamp = System.currentTimeMillis(),
+                projectState = InspectionProjectStateSnapshot(psiModificationCount = 7L, unsavedProjectDocuments = 0),
+                outcome = InspectionSnapshotOutcome.CAPTURE_INCOMPLETE,
+                source = "tool_window",
+                captureDiagnostic = mapOf(
+                    "exit_reason" to "deadline",
+                    "extraction_failure_count" to 2,
+                    "last_extraction_cycle_succeeded" to false,
+                ),
+                captureIncompleteReason = CaptureIncompleteReason.EXTRACTOR_FAILURE,
+                runId = runState.runId,
+                triggerTimeMs = runState.triggerTimeMs,
+            ),
+        )
+        return json.parseToJsonElement(getInspectionProblems()).jsonObject
+    }
+
+    private fun pluginProblemsUnknownStaleDefault(): JsonObject {
+        val runState = beginInspectionRun()
+        finishInspectionRun(snapshotKey(), runState.runId)
+        InspectionResultsStore.setSnapshot(
+            snapshotKey(),
+            InspectionResultsSnapshot(
+                problems = listOf(staleProblem(description = "Cached warning", file = "/tmp/TestProject/src/App.kt")),
+                timestamp = System.currentTimeMillis() - 16000L,
+                projectState = InspectionProjectStateSnapshot(psiModificationCount = 7L, unsavedProjectDocuments = 0),
+                outcome = InspectionSnapshotOutcome.PROBLEMS_FOUND,
+                source = "inspection_view",
+                runId = runState.runId,
+                triggerTimeMs = runState.triggerTimeMs,
+            ),
+        )
+        every { PsiModificationTracker.getInstance(mockProject).modificationCount } returns 8L
+        return json.parseToJsonElement(getInspectionProblems(includeStale = false)).jsonObject
+    }
+
+    private fun pluginStatusUnknownProofFailed(): JsonObject {
+        every { PsiModificationTracker.getInstance(mockProject).modificationCount } returns 7L
+        InspectionResultsStore.setSnapshot(
+            snapshotKey(),
+            InspectionResultsSnapshot(
+                problems = emptyList(),
+                timestamp = System.currentTimeMillis(),
+                projectState = InspectionProjectStateSnapshot(psiModificationCount = 7L, unsavedProjectDocuments = 0),
+                outcome = InspectionSnapshotOutcome.CLEAN_CONFIRMED,
+                source = "inspection_view",
+                captureDiagnostic = mapOf(
+                    "profile_missing" to true,
+                    "profile_requested" to "Fable Contract Profile",
+                ),
+            ),
+        )
+        return buildInspectionStatus().toJsonObject()
+    }
+
     private fun getInspectionProblems(): String {
         return getInspectionProblems(includeStale = false)
     }
@@ -2939,14 +3074,18 @@ class InspectionSnapshotStateTest {
     private fun staleProblem(
         description: String = "Old warning",
         file: String = "/tmp/TestProject/src/app.js",
+        line: Int = 12,
+        column: Int = 4,
+        severity: String = "weak_warning",
+        inspectionType: String = "JSUnresolvedReference",
     ): Map<String, Any> {
         return mapOf(
             "description" to description,
             "file" to file,
-            "line" to 12,
-            "column" to 4,
-            "severity" to "weak_warning",
-            "inspectionType" to "JSUnresolvedReference",
+            "line" to line,
+            "column" to column,
+            "severity" to severity,
+            "inspectionType" to inspectionType,
         )
     }
 
@@ -2960,6 +3099,60 @@ class InspectionSnapshotStateTest {
         method.isAccessible = true
         return method.invoke(handler, "TestProject", timeoutMs, pollMs) as String
     }
+
+    private fun contractCase(name: String): ContractCase {
+        val path = contractFixturePath(name)
+        val root = json.parseToJsonElement(Files.readString(path)).jsonObject
+        return ContractCase(
+            name = root.string("name") ?: name,
+            payload = root["payload"]?.jsonObject ?: error("Missing payload in $name"),
+            expected = root["expected"]?.jsonObject ?: error("Missing expected in $name"),
+        )
+    }
+
+    private fun contractFixturePath(name: String): Path {
+        val relative = Path.of("test-fixtures/contract-verdicts/$name.json")
+        return generateSequence(Path.of("").toAbsolutePath()) { current -> current.parent }
+            .map { root -> root.resolve(relative) }
+            .firstOrNull { Files.exists(it) }
+            ?: error("Missing contract fixture: $relative")
+    }
+
+    private fun assertRequiredHelperFields(payload: JsonObject, context: String) {
+        listOf(
+            "inspection_verdict",
+            "inspection_verdict_reason",
+            "inspection_verdict_message",
+            "inspection_verdict_next_action",
+        ).forEach { field ->
+            assertTrue(!payload.string(field).isNullOrBlank(), "$context missing $field")
+        }
+    }
+
+    private data class ContractCase(
+        val name: String,
+        val payload: JsonObject,
+        val expected: JsonObject,
+    )
+
+    private fun Map<String, Any>.toJsonObject(): JsonObject {
+        return json.parseToJsonElement(com.shiny.inspectionmcp.core.formatJsonManually(this)).jsonObject
+    }
+
+    private fun assertJsonContains(expected: JsonElement, actual: JsonElement?, context: String) {
+        when (expected) {
+            is JsonObject -> {
+                assertTrue(actual is JsonObject, "$context expected JSON object")
+                expected.forEach { (key, expectedValue) ->
+                    assertJsonContains(expectedValue, (actual as JsonObject)[key], "$context.$key")
+                }
+            }
+            is JsonArray -> assertEquals(expected, actual, context)
+            else -> assertEquals(expected, actual, context)
+        }
+    }
+
+    private fun JsonObject.string(key: String): String? = this[key]?.jsonPrimitive?.contentOrNull
 
     private fun snapshotKey(project: Project = mockProject): String {
         return projectKey(project)

--- a/test-fixtures/contract-verdicts/problems-red-findings.json
+++ b/test-fixtures/contract-verdicts/problems-red-findings.json
@@ -1,0 +1,49 @@
+{
+  "name": "problems-red-findings",
+  "endpoint": "problems",
+  "payload": {
+    "status": "results_available",
+    "inspection_verdict": "RED",
+    "inspection_verdict_reason": "actionable_findings",
+    "inspection_verdict_message": "Inspection worked and returned actionable findings for the selected scope/filter.",
+    "inspection_verdict_next_action": "Fix the reported findings, then rerun inspection.",
+    "total_problems": 1,
+    "problems_shown": 1,
+    "pagination": {
+      "limit": 100,
+      "offset": 0,
+      "has_more": false,
+      "next_offset": null
+    },
+    "problems": [
+      {
+        "description": "Unresolved reference: missingSymbol",
+        "file": "/tmp/TestProject/src/App.kt",
+        "line": 4,
+        "column": 9,
+        "severity": "error",
+        "inspectionType": "UnresolvedReference"
+      }
+    ]
+  },
+  "expected": {
+    "verdict": "RED",
+    "reason": "actionable_findings",
+    "mcp_contains": [
+      "VERDICT: RED reason=actionable_findings",
+      "Unresolved reference: missingSymbol",
+      "\"total_problems\": 1"
+    ],
+    "helper_agent_result": {
+      "verdict": "RED",
+      "bucket": "actionable_findings",
+      "retry_policy": {
+        "retry": false,
+        "max_attempts": 0,
+        "wait_ms": 0
+      },
+      "next_action": "Fix the reported findings, then rerun inspection.",
+      "agent_report": "JetBrains inspection found 1 actionable finding(s)."
+    }
+  }
+}

--- a/test-fixtures/contract-verdicts/problems-unknown-capture-incomplete.json
+++ b/test-fixtures/contract-verdicts/problems-unknown-capture-incomplete.json
@@ -1,0 +1,45 @@
+{
+  "name": "problems-unknown-capture-incomplete",
+  "endpoint": "problems",
+  "payload": {
+    "status": "capture_incomplete",
+    "inspection_verdict": "UNKNOWN",
+    "inspection_verdict_reason": "extractor_failure",
+    "inspection_verdict_message": "Inspection did not produce a trustworthy GREEN or RED result.",
+    "inspection_verdict_next_action": "Treat this as a plugin/helper bug: include capture_diagnostic, update the plugin or helper, and rerun.",
+    "capture_incomplete": true,
+    "capture_incomplete_reason": "extractor_failure",
+    "total_problems": 0,
+    "problems_shown": 0,
+    "problems": [],
+    "capture_diagnostic": {
+      "exit_reason": "deadline",
+      "extraction_failure_count": 2
+    }
+  },
+  "expected": {
+    "verdict": "UNKNOWN",
+    "reason": "extractor_failure",
+    "mcp_contains": [
+      "VERDICT: UNKNOWN reason=extractor_failure",
+      "plugin/helper bug",
+      "capture_incomplete_reason"
+    ],
+    "mcp_not_contains": [
+      "capture_diagnostic",
+      "\"problems\"",
+      "\"total_problems\""
+    ],
+    "helper_agent_result": {
+      "verdict": "UNKNOWN",
+      "bucket": "tool_bug",
+      "retry_policy": {
+        "retry": false,
+        "max_attempts": 0,
+        "wait_ms": 0
+      },
+      "next_action": "Treat this as a plugin/helper bug: capture the diagnostic payload, update the inspection plugin or helper skill, and rerun.",
+      "agent_report": "JetBrains inspection was inconclusive (tool_bug: extractor_failure). Treat this as a plugin/helper bug: capture the diagnostic payload, update the inspection plugin or helper skill, and rerun."
+    }
+  }
+}

--- a/test-fixtures/contract-verdicts/problems-unknown-stale-default.json
+++ b/test-fixtures/contract-verdicts/problems-unknown-stale-default.json
@@ -1,0 +1,43 @@
+{
+  "name": "problems-unknown-stale-default",
+  "endpoint": "problems",
+  "payload": {
+    "status": "stale_results",
+    "inspection_verdict": "UNKNOWN",
+    "inspection_verdict_reason": "stale_results",
+    "inspection_verdict_message": "Inspection did not produce a trustworthy GREEN or RED result.",
+    "inspection_verdict_next_action": "Rerun inspection; stale cached findings must not be treated as current.",
+    "results_may_be_stale": true,
+    "include_stale": false,
+    "snapshot_change_kind": "project_changed_since_inspection",
+    "snapshot_outcome": "problems_found",
+    "stale_reasons": ["project_changed_since_inspection"],
+    "cached_total_problems": 1,
+    "cached_problems_shown": 0
+  },
+  "expected": {
+    "verdict": "UNKNOWN",
+    "reason": "stale_results",
+    "mcp_contains": [
+      "VERDICT: UNKNOWN reason=stale_results",
+      "\"cached_total_problems\": 1",
+      "project_changed_since_inspection"
+    ],
+    "mcp_not_contains": [
+      "Cached warning",
+      "\"total_problems\"",
+      "\"problems\""
+    ],
+    "helper_agent_result": {
+      "verdict": "UNKNOWN",
+      "bucket": "stale_results",
+      "retry_policy": {
+        "retry": true,
+        "max_attempts": 1,
+        "wait_ms": 30000
+      },
+      "next_action": "Rerun inspection; stale cached findings must not be treated as current.",
+      "agent_report": "JetBrains inspection was inconclusive (stale_results: stale_results). Rerun inspection; stale cached findings must not be treated as current."
+    }
+  }
+}

--- a/test-fixtures/contract-verdicts/status-green-clean.json
+++ b/test-fixtures/contract-verdicts/status-green-clean.json
@@ -1,0 +1,42 @@
+{
+  "name": "status-green-clean",
+  "endpoint": "status",
+  "payload": {
+    "inspection_verdict": "GREEN",
+    "inspection_verdict_reason": "clean_confirmed",
+    "inspection_verdict_message": "Inspection worked and found no actionable findings for the selected scope/filter.",
+    "inspection_verdict_next_action": "No inspection action required for this scope/filter.",
+    "clean_inspection": true,
+    "has_inspection_results": true,
+    "capture_incomplete": false,
+    "snapshot_outcome": "clean_confirmed",
+    "inspection_proof": {
+      "status": "complete",
+      "capture_complete": true,
+      "inspection_completed": true,
+      "indexing_complete": true,
+      "session_fresh": true,
+      "results_fresh": true,
+      "snapshot_outcome": "clean_confirmed"
+    }
+  },
+  "expected": {
+    "verdict": "GREEN",
+    "reason": "clean_confirmed",
+    "mcp_contains": [
+      "VERDICT: GREEN reason=clean_confirmed",
+      "Inspection worked and found no actionable findings for the selected scope/filter."
+    ],
+    "helper_agent_result": {
+      "verdict": "GREEN",
+      "bucket": "clean",
+      "retry_policy": {
+        "retry": false,
+        "max_attempts": 0,
+        "wait_ms": 0
+      },
+      "next_action": "No inspection action required for this scope/filter.",
+      "agent_report": "JetBrains inspection passed for the selected scope."
+    }
+  }
+}

--- a/test-fixtures/contract-verdicts/status-unknown-proof-failed.json
+++ b/test-fixtures/contract-verdicts/status-unknown-proof-failed.json
@@ -1,0 +1,49 @@
+{
+  "name": "status-unknown-proof-failed",
+  "endpoint": "status",
+  "payload": {
+    "inspection_verdict": "UNKNOWN",
+    "inspection_verdict_reason": "inspection_proof_failed",
+    "inspection_verdict_message": "Inspection returned contradictory proof and did not establish a trustworthy GREEN or RED result.",
+    "inspection_verdict_next_action": "Resolve the route/profile/scope proof failure, then trigger and wait for a fresh inspection before reporting GREEN or RED.",
+    "capture_incomplete": false,
+    "clean_inspection": true,
+    "has_inspection_results": true,
+    "snapshot_outcome": "clean_confirmed",
+    "proof_failures": ["profile_mismatch"],
+    "inspection_proof": {
+      "status": "complete",
+      "capture_complete": true,
+      "expected_profile": "Fable Contract Profile",
+      "indexing_complete": true,
+      "inspection_completed": true,
+      "results_fresh": true,
+      "session_fresh": true,
+      "snapshot_outcome": "clean_confirmed"
+    }
+  },
+  "expected": {
+    "verdict": "UNKNOWN",
+    "reason": "inspection_proof_failed",
+    "mcp_contains": [
+      "VERDICT: UNKNOWN reason=inspection_proof_failed",
+      "profile_mismatch"
+    ],
+    "mcp_not_contains": [
+      "\"total_problems\"",
+      "\"problems\"",
+      "VERDICT: GREEN"
+    ],
+    "helper_agent_result": {
+      "verdict": "UNKNOWN",
+      "bucket": "tool_bug",
+      "retry_policy": {
+        "retry": false,
+        "max_attempts": 0,
+        "wait_ms": 0
+      },
+      "next_action": "Do not report GREEN or RED. Rerun inspection and include helper diagnostics if it remains UNKNOWN.",
+      "agent_report": "JetBrains inspection was inconclusive (tool_bug: inspection_proof_failed). Do not report GREEN or RED. Rerun inspection and include helper diagnostics if it remains UNKNOWN."
+    }
+  }
+}


### PR DESCRIPTION
## Summary\n\n- Add shared verdict contract fixtures for RED, GREEN, and UNKNOWN inspection outcomes\n- Exercise all fixtures from real plugin HTTP payload producers\n- Exercise the same fixtures through MCP rendering and helper-compatible agent_result contract assertions\n\nCloses #183\n\n## Validation\n\n- `./gradlew :test --tests com.shiny.inspectionmcp.InspectionSnapshotStateTest --tests '*Plugin HTTP verdict payloads*' :mcp-server-jvm:test --tests com.shiny.inspectionmcp.mcpserver.McpServerTest --tests '*mcpRenderedVerdicts*' --rerun-tasks`\n- `./gradlew :test --tests com.shiny.inspectionmcp.InspectionSnapshotStateTest :mcp-server-jvm:test --tests com.shiny.inspectionmcp.mcpserver.McpServerTest`\n- `./gradlew :test :inspection-core:test :mcp-server-jvm:test buildPlugin`\n- `git diff --check`\n- `npx prettier --check test-fixtures/contract-verdicts/*.json`