### PR TITLE
Upgrade Kotlin plugins to 2.4.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,15 +13,6 @@ updates:
     patterns:
       - "*"
     multi-ecosystem-group: tooling
-    # Remove after CodeQL 2.26+ Java/Kotlin analysis passes on Kotlin 2.4.x.
-    # Tracking: https://github.com/cbusillo/jetbrains-inspection-api/issues/174
-    ignore:
-      - dependency-name: >-
-          org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin
-        versions: [">= 2.4.0"]
-      - dependency-name: >-
-          org.jetbrains.kotlin.plugin.serialization:org.jetbrains.kotlin.plugin.serialization.gradle.plugin
-        versions: [">= 2.4.0"]
     groups:
       all-security-updates:
         applies-to: security-updates

--- a/TESTING.md
+++ b/TESTING.md
@@ -214,7 +214,9 @@ requests and pushes to `main` via `.github/workflows/ci.yml`:
 The commit gate sync-checks `plugin.xml` against `gradle.properties`, requires
 Java 21, then runs plugin tests, core tests, MCP server tests, and `buildPlugin`.
 Code scanning is tracked through the required `Analyze (actions)` and
-`Analyze (python)` checks alongside `commit-gate`.
+`Analyze (python)` checks alongside `commit-gate`. `Analyze (java-kotlin)` also
+runs as a non-required signal so Kotlin and plugin upgrades can be validated
+before that check is considered stable enough to require.
 
 Version tags (`v*`) run `.github/workflows/release.yml`, which repeats the
 commit gate before publishing to the JetBrains Marketplace and creating the

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,9 +14,9 @@ import java.util.Properties
 
 plugins {
     id("java")
-    id("org.jetbrains.kotlin.jvm") version "2.3.21"
+    id("org.jetbrains.kotlin.jvm") version "2.4.0"
     id("org.jetbrains.intellij.platform") version "2.17.0"
-    kotlin("plugin.serialization") version "2.3.21"
+    kotlin("plugin.serialization") version "2.4.0"
     id("jacoco")
 }
 

--- a/inspection-core/build.gradle.kts
+++ b/inspection-core/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "2.3.21"
+    kotlin("jvm") version "2.4.0"
     id("jacoco")
 }
 

--- a/mcp-server-jvm/build.gradle.kts
+++ b/mcp-server-jvm/build.gradle.kts
@@ -2,8 +2,8 @@ import org.gradle.jvm.tasks.Jar
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "2.3.21"
-    kotlin("plugin.serialization") version "2.3.21"
+    kotlin("jvm") version "2.4.0"
+    kotlin("plugin.serialization") version "2.4.0"
     application
     id("jacoco")
 }

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -1026,8 +1026,8 @@ class InspectionHandlerTest {
         val method = InspectionHandler::class.java.getDeclaredMethod(
             "waitForInspection",
             String::class.java,
-            java.lang.Long::class.java,
-            java.lang.Long::class.java,
+            Long::class.javaObjectType,
+            Long::class.javaObjectType,
         )
         method.isAccessible = true
 


### PR DESCRIPTION
## Summary
- upgrade Kotlin JVM and serialization plugins across all Gradle modules to 2.4.0
- remove the temporary Dependabot ignore for Kotlin 2.4+
- use Kotlin-native boxed Long reflection types in the affected test

Refs #174

## Validation
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew compileKotlin :inspection-core:compileKotlin :mcp-server-jvm:compileKotlin`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./scripts/commit-gate.sh --ci`
- commit hook reran the full commit gate successfully

## Merge condition
Do not merge until GitHub CodeQL `Analyze (java-kotlin)` passes with CodeQL 2.26+.