### PR TITLE
Sync IDE Kotlin compiler metadata

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -2,6 +2,6 @@
 <project version="4">
   <component name="KotlinJpsPluginSettings">
     <option name="externalSystemId" value="Gradle" />
-    <option name="version" value="2.3.21" />
+    <option name="version" value="2.4.0" />
   </component>
 </project>


### PR DESCRIPTION
## Summary
- update tracked IntelliJ Kotlin compiler metadata from 2.3.21 to 2.4.0
- keep IDE project configuration aligned with the Gradle plugin upgrade merged in PR #191

Refs #192

## Validation
- `xmllint --noout .idea/kotlinc.xml`
- `git diff --check`
- commit hook: full `./scripts/commit-gate.sh --ci` passed