### PR TITLE
Fix dogfood inspection lifecycle reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Typical response (truncated):
     "ide": {
       "name": "IntelliJ IDEA Ultimate",
       "product_code": "IU",
-      "plugin_version": "1.13.16",
+      "plugin_version": "1.13.17",
       "plugin_build_fingerprint": "abc123def456-clean"
     }
   },
@@ -258,7 +258,7 @@ routing state.
       "name": "IntelliJ IDEA Ultimate",
       "version": "2025.1.1",
       "product_code": "IU",
-      "plugin_version": "1.13.16",
+      "plugin_version": "1.13.17",
       "plugin_build_fingerprint": "abc123def456-clean"
     }
   },
@@ -330,7 +330,15 @@ clients should keep using `/route`, `/trigger`, `/wait`, `/status`, and
   original `lease_id` for an additional binding check. It closes the project
   only when all supplied values still match the lease-bound plugin claim.
   Token or supplied lease mismatch, session drift, or route ambiguity returns a
-  skipped/error response and leaves the project open.
+  skipped/error response and leaves the project open. Close work runs off the
+  built-in HTTP server event loop so a slow IDE close cannot block identity,
+  route, or status requests from other agents.
+- `GET /api/inspection/cancel`: accepts the normal route selectors plus the
+  required `inspection_run_id` and requests cancellation only when that exact
+  run is still active for the project. It returns `cancel_requested`,
+  `not_running`, `run_changed`, or `cancellation_unavailable`; callers should
+  poll `/status` until `inspection_in_progress` is false before closing a
+  helper-owned project.
 
 The plugin checks again on the IDE event thread immediately before opening and
 binds ownership only when that request's `beforeInit` project is the same object
@@ -339,6 +347,10 @@ being claimed or closed during the asynchronous scheduling window. The
 contract lets script helpers preserve projects that were already open before
 automation started while cleaning up helper-opened worktrees after readiness
 inspection.
+
+Agent-triggered inspections use a non-modal progress indicator. Long-running
+inspection work therefore remains cancellable without blocking lifecycle opens,
+closes, or the IDE built-in HTTP server event loop.
 
 ### Problems Endpoint
 **URL**: `GET /api/inspection/problems`
@@ -549,6 +561,11 @@ Common completion reasons:
 - `stale_results`: cached results exist, but project files changed after the last inspection. Trigger again before trusting findings. Wait responses expose cached counts as `cached_total_problems`, not `total_problems`.
 - `no_recent_inspection`: no inspection run is known for the selected project. Trigger one first.
 - `no_project`: no matching project was open during the wait period. This is not reported as `timed_out`; open a project or pass the exact project name.
+
+When a bounded wait times out while `inspection_in_progress` is true, automation
+may call `/api/inspection/cancel` and wait briefly for cancellation to settle.
+This keeps a stalled inspection from holding the project and HTTP lifecycle
+queue indefinitely.
 
 For agent-facing reports from the plugin API, use `inspection_verdict` and the
 companion `inspection_verdict_reason`, `inspection_verdict_message`, and

--- a/TESTING.md
+++ b/TESTING.md
@@ -263,7 +263,12 @@ evidence for:
 
 The `/api/inspection/wait` endpoint caps a single wait request at 300 seconds;
 large-project release smokes should prefer helper closeout JSON and rerun with a
-fresh route rather than treating one long wait timeout as a clean result.
+fresh route rather than treating one long wait timeout as a clean result. When
+the timed-out response still reports `inspection_in_progress`, exercise
+`/api/inspection/cancel` with that response's `inspection_run_id`, verify
+`/status` reaches an idle state, and confirm a concurrent `/identity` request
+remains responsive while lifecycle close runs. A `run_changed` response must
+leave the newer run untouched and defer helper-owned project cleanup.
 
 For normal dogfood against the latest installed stable IDE, use
 `qualityGate.manualSmoke.execHarnessInstalledWorktree` from `.github/github.json`

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion=1.13.16
+pluginVersion=1.13.17
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
 kotlin.stdlib.default.dependency=false
 # Enable Gradle Configuration Cache -> https://docs.gradle.org/current/userguide/configuration_cache.html

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -3278,6 +3278,9 @@ class InspectionHandler : HttpRequestHandler() {
             if (expectedRunId != null && inspectionRunId(status) != expectedRunId) {
                 return formatWaitRunChanged(status, start, timeoutMs, pollMs, expectedRunId)
             }
+            if (expectedRunId != null && waitSnapshotRunChanged(status, expectedRunId)) {
+                return formatWaitRunChanged(status, start, timeoutMs, pollMs, expectedRunId)
+            }
             val hasResults = status["has_inspection_results"] as? Boolean ?: false
             val inspectionTriggered = status["inspection_triggered"] as? Boolean ?: false
             val cleanInspection = status["clean_inspection"] as? Boolean ?: false
@@ -3402,6 +3405,23 @@ class InspectionHandler : HttpRequestHandler() {
 
     private fun inspectionRunId(status: Map<String, Any>): Long? {
         return (status["inspection_run_id"] as? Number)?.toLong()
+    }
+
+    private fun waitSnapshotRunChanged(status: Map<String, Any>, expectedRunId: Long): Boolean {
+        if (status["inspection_in_progress"] == true) {
+            return false
+        }
+        val snapshotBacked = status.containsKey("snapshot_run_id") ||
+            status["has_inspection_results"] == true ||
+            status["clean_inspection"] == true ||
+            status["capture_incomplete"] == true ||
+            status["results_may_be_stale"] == true ||
+            status["inspection_triggered"] == true
+        if (!snapshotBacked) {
+            return false
+        }
+        val snapshotRunId = (status["snapshot_run_id"] as? Number)?.toLong()
+        return snapshotRunId != expectedRunId
     }
 
     private fun formatWaitRunChanged(

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -1353,6 +1353,7 @@ class InspectionHandler : HttpRequestHandler() {
                     val includeUnversioned = parseBooleanParameter(parameters, "include_unversioned", defaultValue = true)
                     val changedFilesMode = parseChangedFilesMode(parameters)
                     val maxFiles = parseOptionalIntParameter(parameters, "max_files", min = 1)
+                    val expectedRunId = parseOptionalPositiveLongParameter(parameters, "inspection_run_id")
                     val projectName = extractProjectSelector(urlDecoder, request)
                     ApplicationManager.getApplication().executeOnPooledThread {
                         try {
@@ -1383,6 +1384,7 @@ class InspectionHandler : HttpRequestHandler() {
                                         changedFilesMode,
                                         maxFiles,
                                         validatedRequestScope,
+                                        expectedRunId,
                                     )
                                 }
                                 sendJsonResponse(context, result)
@@ -1472,13 +1474,7 @@ class InspectionHandler : HttpRequestHandler() {
                     val projectName = extractProjectSelector(urlDecoder, request)
                     val timeoutMs = parameters["timeout_ms"]?.firstOrNull()?.toLongOrNull()
                     val pollMs = parameters["poll_ms"]?.firstOrNull()?.toLongOrNull()
-                    val expectedRunId = firstParameter(parameters, "inspection_run_id")?.let { rawRunId ->
-                        rawRunId.toLongOrNull()?.takeIf { it > 0 }
-                            ?: throw BadRequestException(
-                                "inspection_run_id",
-                                "Parameter 'inspection_run_id' must be a positive integer.",
-                            )
-                    }
+                    val expectedRunId = parseOptionalPositiveLongParameter(parameters, "inspection_run_id")
                     ApplicationManager.getApplication().executeOnPooledThread {
                         try {
                             val result = waitForInspection(projectName, timeoutMs, pollMs, expectedRunId)
@@ -1532,10 +1528,15 @@ class InspectionHandler : HttpRequestHandler() {
             )
             val key = projectKey(project)
             val runState = beginInspectionRun(project, captureScope)
-            val runControl = InspectionRunControl(
-                runId = runState.runId,
-                indicator = inspectionIndicatorFactory(project),
-            )
+            val runControl = try {
+                InspectionRunControl(
+                    runId = runState.runId,
+                    indicator = inspectionIndicatorFactory(project),
+                )
+            } catch (error: Throwable) {
+                finishInspectionRun(key, runState.runId)
+                throw error
+            }
             inspectionRunControlsByProject[key] = runControl
             try {
                 ApplicationManager.getApplication().executeOnPooledThread {
@@ -1547,7 +1548,8 @@ class InspectionHandler : HttpRequestHandler() {
                         control = runControl,
                     )
                 }
-            } catch (error: Exception) {
+            } catch (error: Throwable) {
+                runCatching { runControl.indicator.cancel() }
                 inspectionRunControlsByProject.remove(key, runControl)
                 finishInspectionRun(key, runState.runId)
                 throw error
@@ -1616,6 +1618,15 @@ class InspectionHandler : HttpRequestHandler() {
             throw BadRequestException(name, "Parameter '$name' must be at most $max.")
         }
         return value
+    }
+
+    private fun parseOptionalPositiveLongParameter(
+        parameters: Map<String, List<String>>,
+        name: String,
+    ): Long? {
+        val raw = parameters[name]?.firstOrNull()?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+        return raw.toLongOrNull()?.takeIf { it > 0 }
+            ?: throw BadRequestException(name, "Parameter '$name' must be a positive integer.")
     }
 
     private fun parseBooleanParameter(
@@ -2122,28 +2133,16 @@ class InspectionHandler : HttpRequestHandler() {
         val resolved = resolveInspectionRoute(parameters)
             ?: return formatJsonManually(buildMissingProjectResponse(routeProjectSelector(parameters)))
         val key = projectKey(resolved.project)
-        val runState = inspectionRunStatesByProject[key]
         val rawExpectedRunId = firstParameter(parameters, "inspection_run_id")
             ?: throw BadRequestException("inspection_run_id", "Parameter 'inspection_run_id' is required.")
         val expectedRunId = rawExpectedRunId.toLongOrNull()?.takeIf { it > 0 }
             ?: throw BadRequestException("inspection_run_id", "Parameter 'inspection_run_id' must be a positive integer.")
-        if (runState?.inProgress != true) {
-            return formatJsonManually(
-                mapOf(
-                    "status" to "not_running",
-                    "inspection_in_progress" to false,
-                    "inspection_cancellation_requested" to false,
-                    "project_key" to key,
-                    "session_id" to InspectionIdeSession.sessionId,
-                    "route" to routeMetadata(resolved),
-                )
-            )
-        }
-        if (expectedRunId != runState.runId) {
+        val runState = inspectionRunStatesByProject[key]
+        if (runState != null && expectedRunId != runState.runId) {
             return formatJsonManually(
                 mapOf(
                     "status" to "run_changed",
-                    "inspection_in_progress" to true,
+                    "inspection_in_progress" to runState.inProgress,
                     "inspection_cancellation_requested" to false,
                     "expected_inspection_run_id" to expectedRunId,
                     "inspection_run_id" to runState.runId,
@@ -2151,6 +2150,19 @@ class InspectionHandler : HttpRequestHandler() {
                     "session_id" to InspectionIdeSession.sessionId,
                     "route" to routeMetadata(resolved),
                 )
+            )
+        }
+        if (runState?.inProgress != true) {
+            return formatJsonManually(
+                mapOf(
+                    "status" to "not_running",
+                    "inspection_in_progress" to false,
+                    "inspection_cancellation_requested" to false,
+                    "inspection_run_id" to runState?.runId,
+                    "project_key" to key,
+                    "session_id" to InspectionIdeSession.sessionId,
+                    "route" to routeMetadata(resolved),
+                ).filterValues { it != null }
             )
         }
 
@@ -2201,69 +2213,80 @@ class InspectionHandler : HttpRequestHandler() {
         if (!leasesByProjectInstance.remove(expectedProjectInstanceId, lease)) {
             return lifecycleCloseSkipped("not_claimed", "No helper lifecycle claim exists for this project instance.")
         }
-        if (lease.sessionId != InspectionIdeSession.sessionId) {
-            return lifecycleCloseSkipped("session_drift", "IDE session changed before cleanup; leaving the project open.", HttpResponseStatus.CONFLICT)
-        }
-        val expectedSessionId = firstParameter(parameters, "session_id")
-        if (expectedSessionId != null && expectedSessionId != InspectionIdeSession.sessionId) {
-            return lifecycleCloseSkipped("session_drift", "IDE session changed before cleanup; leaving the project open.", HttpResponseStatus.CONFLICT)
-        }
-
-        val project = findOpenProjectByInstanceId(expectedProjectInstanceId)
-            ?: run {
-                lifecycleOpenOwnershipByProjectInstance.remove(expectedProjectInstanceId)
-                return lifecycleCloseSkipped("route_missing", "Claimed project is no longer open; cleanup is already complete.")
+        try {
+            if (lease.sessionId != InspectionIdeSession.sessionId) {
+                return lifecycleCloseSkipped("session_drift", "IDE session changed before cleanup; leaving the project open.", HttpResponseStatus.CONFLICT)
             }
-        if (project !== lease.project) {
-            lifecycleOpenOwnershipByProjectInstance.remove(expectedProjectInstanceId)
-            return lifecycleCloseSkipped(
-                "project_instance_reused",
-                "Claimed project instance no longer refers to the exact project that was opened by this lease.",
-                HttpResponseStatus.CONFLICT,
-            )
-        }
-        if (projectKey(project) != lease.projectKey) {
-            return lifecycleCloseSkipped("project_mismatch", "Claimed project key no longer matches the lifecycle claim.", HttpResponseStatus.CONFLICT)
-        }
-        if (isInspectionInProgress(project)) {
-            leasesByProjectInstance.putIfAbsent(expectedProjectInstanceId, lease)
-            val runState = inspectionRunStatesByProject[projectKey(project)]
-            return lifecycleCloseSkipped(
-                "inspection_in_progress",
-                "An inspection is still running for the claimed project; leaving it open for a later cleanup retry.",
-                HttpResponseStatus.CONFLICT,
-                details = mapOf(
-                    "project_instance_id" to expectedProjectInstanceId,
-                    "project_key" to lease.projectKey,
-                    "lease_id" to lease.leaseId,
-                    "inspection_run_id" to runState?.runId,
-                    "inspection_in_progress" to true,
-                ),
-            )
-        }
+            val expectedSessionId = firstParameter(parameters, "session_id")
+            if (expectedSessionId != null && expectedSessionId != InspectionIdeSession.sessionId) {
+                return lifecycleCloseSkipped("session_drift", "IDE session changed before cleanup; leaving the project open.", HttpResponseStatus.CONFLICT)
+            }
 
-        val closeAttempts = closeClaimedProject(project, expectedProjectInstanceId)
-        val closed = closeAttempts.any { attempt -> attempt.closedVerified }
+            val project = findOpenProjectByInstanceId(expectedProjectInstanceId)
+                ?: run {
+                    removeLifecycleOpenOwnership(expectedProjectInstanceId, lease.project)
+                    return lifecycleCloseSkipped("route_missing", "Claimed project is no longer open; cleanup is already complete.")
+                }
+            if (project !== lease.project) {
+                removeLifecycleOpenOwnership(expectedProjectInstanceId, lease.project)
+                return lifecycleCloseSkipped(
+                    "project_instance_reused",
+                    "Claimed project instance no longer refers to the exact project that was opened by this lease.",
+                    HttpResponseStatus.CONFLICT,
+                )
+            }
+            if (projectKey(project) != lease.projectKey) {
+                return lifecycleCloseSkipped("project_mismatch", "Claimed project key no longer matches the lifecycle claim.", HttpResponseStatus.CONFLICT)
+            }
+            if (isInspectionInProgress(project)) {
+                leasesByProjectInstance.putIfAbsent(expectedProjectInstanceId, lease)
+                val runState = inspectionRunStatesByProject[projectKey(project)]
+                return lifecycleCloseSkipped(
+                    "inspection_in_progress",
+                    "An inspection is still running for the claimed project; leaving it open for a later cleanup retry.",
+                    HttpResponseStatus.CONFLICT,
+                    details = mapOf(
+                        "project_instance_id" to expectedProjectInstanceId,
+                        "project_key" to lease.projectKey,
+                        "lease_id" to lease.leaseId,
+                        "inspection_run_id" to runState?.runId,
+                        "inspection_in_progress" to true,
+                    ),
+                )
+            }
 
-        if (!closed) {
+            val closeAttempts = closeClaimedProject(project, expectedProjectInstanceId)
+            val closed = closeAttempts.any { attempt -> attempt.closedVerified }
+
+            if (!closed) {
+                leasesByProjectInstance.putIfAbsent(expectedProjectInstanceId, lease)
+                return lifecycleCloseSkipped(
+                    "close_failed",
+                    "JetBrains IDE declined or failed to close the claimed project.",
+                    HttpResponseStatus.CONFLICT,
+                    closeAttempts,
+                )
+            }
+            removeLifecycleOpenOwnership(expectedProjectInstanceId, lease.project)
+            return mapOf(
+                "status" to "closed",
+                "project_instance_id" to expectedProjectInstanceId,
+                "project_key" to lease.projectKey,
+                "lease_id" to lease.leaseId,
+                "session_id" to InspectionIdeSession.sessionId,
+                "closed_at_ms" to System.currentTimeMillis(),
+                "close_attempts" to closeAttemptPayload(closeAttempts),
+            ) to HttpResponseStatus.OK
+        } catch (error: Throwable) {
             leasesByProjectInstance.putIfAbsent(expectedProjectInstanceId, lease)
-            return lifecycleCloseSkipped(
-                "close_failed",
-                "JetBrains IDE declined or failed to close the claimed project.",
-                HttpResponseStatus.CONFLICT,
-                closeAttempts,
-            )
+            throw error
         }
-        lifecycleOpenOwnershipByProjectInstance.remove(expectedProjectInstanceId)
-        return mapOf(
-            "status" to "closed",
-            "project_instance_id" to expectedProjectInstanceId,
-            "project_key" to lease.projectKey,
-            "lease_id" to lease.leaseId,
-            "session_id" to InspectionIdeSession.sessionId,
-            "closed_at_ms" to System.currentTimeMillis(),
-            "close_attempts" to closeAttemptPayload(closeAttempts),
-        ) to HttpResponseStatus.OK
+    }
+
+    private fun removeLifecycleOpenOwnership(projectInstanceId: String, project: Project) {
+        lifecycleOpenOwnershipByProjectInstance[projectInstanceId]
+            ?.takeIf { ownership -> ownership.project === project }
+            ?.let { ownership -> lifecycleOpenOwnershipByProjectInstance.remove(projectInstanceId, ownership) }
     }
 
     private fun closeClaimedProject(project: Project, projectInstanceId: String): List<LifecycleCloseAttempt> {
@@ -2559,6 +2582,7 @@ class InspectionHandler : HttpRequestHandler() {
         changedFilesMode: String? = null,
         maxFiles: Int? = null,
         validatedRequestScope: InspectionCaptureScope? = null,
+        expectedInspectionRunId: Long? = null,
     ): String {
         return run {
             val requestedScope = scope.trim().takeIf { it.isNotEmpty() } ?: "whole_project"
@@ -2580,6 +2604,16 @@ class InspectionHandler : HttpRequestHandler() {
             var snapshot = resultsStore.getSnapshot(key)
             val hasSnapshot = snapshot != null
             val runState = inspectionRunStatesByProject[key]
+            if (expectedInspectionRunId != null && runState?.runId != expectedInspectionRunId) {
+                return@run formatInspectionRunChangedResponse(project, expectedInspectionRunId, runState, snapshot)
+            }
+            if (
+                expectedInspectionRunId != null &&
+                snapshot?.runId != null &&
+                snapshot.runId != expectedInspectionRunId
+            ) {
+                return@run formatInspectionRunChangedResponse(project, expectedInspectionRunId, runState, snapshot)
+            }
             var staleness = resolveSnapshotStaleness(project, snapshot)
             if (staleness.changeKind == "current_run_psi_churn") {
                 val reconciliation = reconcileCurrentRunPsiChurn(project, snapshot)
@@ -2836,6 +2870,27 @@ class InspectionHandler : HttpRequestHandler() {
                 formatJsonManually(response)
             }
         }
+    }
+
+    private fun formatInspectionRunChangedResponse(
+        project: Project,
+        expectedRunId: Long,
+        runState: InspectionRunState?,
+        snapshot: InspectionResultsSnapshot?,
+    ): String {
+        val response = mutableMapOf<String, Any>(
+            "status" to "run_changed",
+            "inspection_in_progress" to (runState?.inProgress == true),
+            "expected_inspection_run_id" to expectedRunId,
+            "project_key" to projectKey(project),
+            "session_id" to InspectionIdeSession.sessionId,
+            "route" to routeMetadata(project),
+            "message" to "A different inspection run or snapshot replaced the run accepted by this request.",
+        )
+        runState?.runId?.let { response["inspection_run_id"] = it }
+        snapshot?.runId?.let { response["snapshot_run_id"] = it }
+        addStatusInspectionVerdict(response)
+        return formatJsonManually(response)
     }
 
     private fun getInspectionProblems(
@@ -3590,13 +3645,21 @@ class InspectionHandler : HttpRequestHandler() {
             inspectionRunControlsByProject.remove(key, control)
             return
         }
+        val taskStarted = AtomicBoolean(false)
         try {
             inspectionProcessRunner(
                 Runnable {
+                    taskStarted.set(true)
                     runInspectionUnderProgress(project, runId, captureScope, profileName)
                 },
                 control.indicator,
             )
+        } catch (error: Throwable) {
+            if (!taskStarted.get()) {
+                runCatching { control.indicator.cancel() }
+                finishInspectionRun(key, runId)
+            }
+            throw error
         } finally {
             if (inspectionRunStatesByProject[key]?.inProgress != true) {
                 inspectionRunControlsByProject.remove(key, control)
@@ -4494,7 +4557,8 @@ class InspectionHandler : HttpRequestHandler() {
     }
 
     private fun isCurrentInspectionRun(key: String, runId: Long): Boolean {
-        return inspectionRunStatesByProject[key]?.runId == runId
+        val state = inspectionRunStatesByProject[key]
+        return state?.runId == runId && state.inProgress
     }
 
     private fun checkInspectionRunCancellation(key: String, runId: Long) {

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -15,7 +15,7 @@ import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.module.ModuleUtilCore
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
-import com.intellij.openapi.progress.util.ProgressIndicatorBase
+import com.intellij.openapi.progress.util.ProgressWindow
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.project.Project
@@ -990,6 +990,11 @@ class InspectionHandler : HttpRequestHandler() {
     internal var inspectionProcessRunner: (Runnable, ProgressIndicator) -> Unit = { task, indicator ->
         ProgressManager.getInstance().runProcess(task, indicator)
     }
+    internal var inspectionIndicatorFactory: (Project) -> ProgressIndicator = { project ->
+        ProgressWindow(false, true, project).apply {
+            setDelayInMillis(Int.MAX_VALUE)
+        }
+    }
     internal var lifecycleCloseExecutor: (Runnable) -> Unit = { task ->
         ApplicationManager.getApplication().executeOnPooledThread(task)
     }
@@ -1519,7 +1524,7 @@ class InspectionHandler : HttpRequestHandler() {
             val runState = beginInspectionRun(project, captureScope)
             val runControl = InspectionRunControl(
                 runId = runState.runId,
-                indicator = ProgressIndicatorBase(),
+                indicator = inspectionIndicatorFactory(project),
             )
             inspectionRunControlsByProject[key] = runControl
             try {
@@ -4310,7 +4315,8 @@ class InspectionHandler : HttpRequestHandler() {
                             }
                         } catch (e: com.intellij.openapi.progress.ProcessCanceledException) {
                             throw e
-                        } catch (_: Exception) {
+                        } catch (error: Exception) {
+                            logger.warn("Inspection result capture failed for ${project.name}", error)
                             if (isCurrentInspectionRun(key, runId)) {
                                 resultsStore.setSnapshot(
                                     key,
@@ -4322,7 +4328,7 @@ class InspectionHandler : HttpRequestHandler() {
                                         source = "inspection_view",
                                         note = "Inspection failed before results could be captured.",
                                         captureScope = effectiveCaptureScope,
-                                        captureDiagnostic = mapOf("exit_reason" to "helper_plugin_error"),
+                                        captureDiagnostic = captureFailureDiagnostic(error),
                                         captureIncompleteReason = CaptureIncompleteReason.HELPER_PLUGIN_ERROR,
                                         runId = runId,
                                         triggerTimeMs = inspectionRunStatesByProject[key]?.triggerTimeMs,
@@ -4336,13 +4342,15 @@ class InspectionHandler : HttpRequestHandler() {
                 captureScheduled = true
             } catch (e: com.intellij.openapi.progress.ProcessCanceledException) {
                 throw e
-            } catch (_: Exception) {
-                publishCaptureFailureIfCurrent(key, runId, project, captureScope)
+            } catch (error: Exception) {
+                logger.warn("Inspection setup or capture scheduling failed for ${project.name}", error)
+                publishCaptureFailureIfCurrent(key, runId, project, captureScope, error)
             }
         } catch (e: com.intellij.openapi.progress.ProcessCanceledException) {
             throw e
-        } catch (_: Exception) {
-            publishCaptureFailureIfCurrent(key, runId, project, captureScope)
+        } catch (error: Exception) {
+            logger.warn("Inspection execution failed for ${project.name}", error)
+            publishCaptureFailureIfCurrent(key, runId, project, captureScope, error)
         } finally {
             if (!captureScheduled) {
                 finishInspectionRun(key, runId)
@@ -4422,6 +4430,7 @@ class InspectionHandler : HttpRequestHandler() {
         runId: Long,
         project: Project,
         captureScope: InspectionCaptureScope,
+        error: Exception? = null,
     ) {
         if (!isCurrentInspectionRun(key, runId)) {
             return
@@ -4436,12 +4445,23 @@ class InspectionHandler : HttpRequestHandler() {
                 source = "inspection_view",
                 note = "Inspection failed before results could be captured.",
                 captureScope = captureScope,
-                captureDiagnostic = mapOf("exit_reason" to "helper_plugin_error"),
+                captureDiagnostic = captureFailureDiagnostic(error),
                 captureIncompleteReason = CaptureIncompleteReason.HELPER_PLUGIN_ERROR,
                 runId = runId,
                 triggerTimeMs = inspectionRunStatesByProject[key]?.triggerTimeMs,
             )
         )
+    }
+
+    private fun captureFailureDiagnostic(error: Exception?): Map<String, Any> {
+        val diagnostic = mutableMapOf<String, Any>("exit_reason" to "helper_plugin_error")
+        if (error != null) {
+            diagnostic["exception_type"] = error.javaClass.name
+            error.message?.takeIf { it.isNotBlank() }?.let { message ->
+                diagnostic["exception_message"] = message.take(1000)
+            }
+        }
+        return diagnostic
     }
 
     private fun syncProjectState(project: Project) {

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -24,7 +24,6 @@ import com.intellij.openapi.project.ex.ProjectManagerEx
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.openapi.wm.IdeFocusManager
 import com.intellij.openapi.wm.WindowManager
 import com.intellij.psi.PsiDocumentManager
@@ -1004,6 +1003,11 @@ class InspectionHandler : HttpRequestHandler() {
     internal var trustProjectPath: (Path) -> Unit = { path ->
         TrustedProjects.setProjectTrusted(canonicalTrustPath(path), true)
     }
+    internal var refreshProjectRoot: (String) -> Unit = { path ->
+        LocalFileSystem.getInstance()
+            .refreshAndFindFileByPath(path)
+            ?.refresh(false, true)
+    }
     internal var openProjectPath: (Path, (Project) -> Unit) -> Project? = { path, beforeInit ->
         val openPath = canonicalTrustPath(path)
         ProjectManagerEx.getInstanceEx().openProject(
@@ -1865,14 +1869,9 @@ class InspectionHandler : HttpRequestHandler() {
                     val initializedProject = AtomicReference<Project?>()
                     trustProjectPath(target.openPath)
                     opened = openProjectPath(target.openPath) { project ->
-                        initializedProject.compareAndSet(null, project)
-                    }
-                    if (
-                        requestedLeaseId != null &&
-                        opened != null &&
-                        initializedProject.get() === opened
-                    ) {
-                        registerLifecycleOpenOwnership(opened, requestedLeaseId, target.key)
+                        if (initializedProject.compareAndSet(null, project) && requestedLeaseId != null) {
+                            registerLifecycleOpenOwnership(project, requestedLeaseId, target.key)
+                        }
                     }
                     if (opened != null) {
                         keepOpeningGuard = true
@@ -4646,7 +4645,9 @@ class InspectionHandler : HttpRequestHandler() {
         val refreshTask = Runnable {
             FileDocumentManager.getInstance().saveAllDocuments()
             PsiDocumentManager.getInstance(project).commitAllDocuments()
-            VirtualFileManager.getInstance().syncRefresh()
+            val projectRootPath = project.basePath
+                ?: project.projectFilePath?.let(::projectRootFromProjectFilePath)
+            projectRootPath?.let(refreshProjectRoot)
             PsiDocumentManager.getInstance(project).commitAllDocuments()
         }
         if (application.isDispatchThread) {

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -3410,16 +3410,7 @@ class InspectionHandler : HttpRequestHandler() {
         if (status["inspection_in_progress"] == true) {
             return false
         }
-        val snapshotBacked = status.containsKey("snapshot_run_id") ||
-            status["has_inspection_results"] == true ||
-            status["clean_inspection"] == true ||
-            status["capture_incomplete"] == true ||
-            status["results_may_be_stale"] == true ||
-            status["inspection_triggered"] == true
-        if (!snapshotBacked) {
-            return false
-        }
-        val snapshotRunId = (status["snapshot_run_id"] as? Number)?.toLong()
+        val snapshotRunId = (status["snapshot_run_id"] as? Number)?.toLong() ?: return false
         return snapshotRunId != expectedRunId
     }
 

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -4385,7 +4385,7 @@ class InspectionHandler : HttpRequestHandler() {
                             val fallbackScopeFiles = scopedPsiFilesForInspectionEngine(
                                 project,
                                 effectiveCaptureScope.scopeParam,
-                                effectiveCaptureScope.directoryParam,
+                                effectiveCaptureScope.resolvedDirectory ?: effectiveCaptureScope.directoryParam,
                                 effectiveCaptureScope.files,
                                 effectiveCaptureScope.resolvedCurrentFile,
                                 resolvedChangedFiles = changedFilesScopeFiles,
@@ -5467,7 +5467,7 @@ class InspectionHandler : HttpRequestHandler() {
             }
             val resolved = resolveRequestedFilesStrict(project, files).toSet()
             if (resolved.size == 1) {
-                psiFileForScope(project, resolved.first())?.let { return AnalysisScope(it) }
+                analysisScopeForFile(project, resolved.first())?.let { return it }
             }
             return AnalysisScope(project, resolved)
         }
@@ -5483,7 +5483,7 @@ class InspectionHandler : HttpRequestHandler() {
                 throw BadRequestException("scope", "scope=changed_files resolved to no files.")
             }
             if (limited.size == 1) {
-                psiFileForScope(project, limited.first())?.let { return AnalysisScope(it) }
+                analysisScopeForFile(project, limited.first())?.let { return it }
             }
             return AnalysisScope(project, limited.toSet())
         }
@@ -5494,19 +5494,13 @@ class InspectionHandler : HttpRequestHandler() {
                     "scope",
                     "scope=current_file requires a valid selected project file in the active editor.",
                 )
-            val psiFile = PsiManager.getInstance(project).findFile(vf)
-            if (psiFile != null) {
-                return AnalysisScope(psiFile)
-            }
+            analysisScopeForFile(project, vf)?.let { return it }
             return AnalysisScope(project, setOf(vf))
         }
 
         if (scopeLower == "directory") {
             val vfs = resolveRequestedDirectoryStrict(project, directoryParam)
-            val psiDir = PsiManager.getInstance(project).findDirectory(vfs)
-            if (psiDir != null) {
-                return AnalysisScope(psiDir)
-            }
+            analysisScopeForDirectory(project, vfs)?.let { return it }
             return AnalysisScope(project, setOf(vfs))
         }
 
@@ -5516,11 +5510,22 @@ class InspectionHandler : HttpRequestHandler() {
         return AnalysisScope(project)
     }
 
-    private fun psiFileForScope(project: Project, file: VirtualFile): com.intellij.psi.PsiFile? {
+    private fun analysisScopeForFile(project: Project, file: VirtualFile): AnalysisScope? {
         val app = ApplicationManager.getApplication()
         return try {
-            app.runReadAction<com.intellij.psi.PsiFile?, Exception> {
-                PsiManager.getInstance(project).findFile(file)
+            app.runReadAction<AnalysisScope?, Exception> {
+                PsiManager.getInstance(project).findFile(file)?.let(::AnalysisScope)
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun analysisScopeForDirectory(project: Project, directory: VirtualFile): AnalysisScope? {
+        val app = ApplicationManager.getApplication()
+        return try {
+            app.runReadAction<AnalysisScope?, Exception> {
+                PsiManager.getInstance(project).findDirectory(directory)?.let(::AnalysisScope)
             }
         } catch (_: Exception) {
             null
@@ -5982,11 +5987,17 @@ class InspectionHandler : HttpRequestHandler() {
     }
 
     private fun resolveActiveEditorFile(project: Project): VirtualFile? {
-        val fileEditorManager = FileEditorManager.getInstance(project)
-        val candidates = fileEditorManager.selectedFiles.asList()
-        val projectFileIndex = ProjectFileIndex.getInstance(project)
-        return candidates.firstOrNull { file ->
-            file.isValid && file.isInLocalFileSystem && projectFileIndex.isInContent(file)
+        val app = ApplicationManager.getApplication()
+        return try {
+            app.runReadAction<VirtualFile?, Exception> {
+                val fileEditorManager = FileEditorManager.getInstance(project)
+                val projectFileIndex = ProjectFileIndex.getInstance(project)
+                fileEditorManager.selectedFiles.firstOrNull { file ->
+                    file.isValid && file.isInLocalFileSystem && projectFileIndex.isInContent(file)
+                }
+            }
+        } catch (_: Exception) {
+            null
         }
     }
     
@@ -6597,7 +6608,7 @@ class InspectionHandler : HttpRequestHandler() {
             }
         }
 
-        if (scopeLower != null && scopeLower !in setOf("whole_project", "all")) {
+        if (scopeLower != null && scopeLower !in setOf("whole_project", "all", "directory")) {
             return emptyList()
         }
         val files = mutableListOf<com.intellij.psi.PsiFile>()
@@ -6613,6 +6624,9 @@ class InspectionHandler : HttpRequestHandler() {
                 }
                 LocalFileSystem.getInstance().findFileByPath(absolute)
             }
+        if (scopeLower == "directory" && sourceRoot == null) {
+            return emptyList()
+        }
         ApplicationManager.getApplication().runReadAction<Unit, Exception> {
             val index = ProjectFileIndex.getInstance(project)
             val psiManager = PsiManager.getInstance(project)

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -2,7 +2,9 @@ package com.shiny.inspectionmcp
 
 import com.intellij.analysis.AnalysisScope
 import com.intellij.codeInspection.InspectionEngine
+import com.intellij.codeInspection.InspectionProfile
 import com.intellij.codeInspection.InspectionManager
+import com.intellij.codeInspection.ex.InspectionProfileImpl
 import com.intellij.codeInspection.ui.InspectionResultsView
 import com.intellij.ide.DataManager
 import com.intellij.ide.RecentProjectsManagerBase
@@ -12,24 +14,38 @@ import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.module.ModuleUtilCore
+import com.intellij.openapi.roots.CompilerModuleExtension
+import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.util.ProgressWindow
 import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.util.JDOMUtil
 import com.intellij.openapi.roots.ProjectFileIndex
+import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.project.ex.ProjectManagerEx
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.openapi.vfs.newvfs.BulkFileListener
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileMoveEvent
+import com.intellij.openapi.vfs.newvfs.events.VFilePropertyChangeEvent
 import com.intellij.openapi.wm.IdeFocusManager
 import com.intellij.openapi.wm.WindowManager
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiManager
+import com.intellij.psi.search.scope.packageSet.NamedScopeManager
+import com.intellij.psi.search.scope.packageSet.NamedScopesHolder
 import com.intellij.psi.util.PsiModificationTracker
+import com.intellij.packageDependencies.DependencyValidationManager
+import com.intellij.profile.ProfileChangeAdapter
 import com.shiny.inspectionmcp.core.filterProblems
 import com.shiny.inspectionmcp.core.formatJsonManually
 import com.shiny.inspectionmcp.core.InspectionRouteIdentity
@@ -47,6 +63,7 @@ import io.netty.buffer.Unpooled
 import io.netty.channel.ChannelHandlerContext
 import io.netty.handler.codec.http.*
 import com.intellij.openapi.diagnostic.Logger
+import org.jdom.Element
 import org.jetbrains.ide.HttpRequestHandler
 import java.awt.Component
 import java.awt.Container
@@ -54,6 +71,7 @@ import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.security.MessageDigest
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
@@ -113,9 +131,24 @@ internal data class InspectionProjectStateSnapshot(
     val unsavedProjectDocuments: Int,
 )
 
-internal data class InspectionProjectContentEpoch(
-    val vfsModificationCount: Long,
+internal data class InspectionProjectInputsFingerprint(
+    val rootPaths: List<String>,
+    val excludedRootPaths: List<String>,
+    val projectSdkName: String?,
+    val projectSdkTypeName: String?,
+    val projectSdkVersion: String?,
+    val projectSdkHomePath: String?,
+    val requestedProfileName: String?,
+    val resolvedProfileName: String?,
+    val profileToolStates: List<String>,
+    val namedScopeDefinitions: List<String>,
+    val profileConfigurationHash: String,
 )
+
+internal interface InspectionProjectContentTracker : AutoCloseable {
+    fun hasChanges(): Boolean
+    fun runIfUnchanged(action: () -> Unit): Boolean
+}
 
 internal data class InspectionCaptureScope(
     val scopeParam: String? = null,
@@ -255,6 +288,175 @@ private data class InspectionProblemIdentity(
     val column: Long?,
     val description: String?,
 )
+
+internal fun isTrackedInspectionInputPath(
+    projectBasePath: String?,
+    rootPaths: List<String>,
+    eventPath: String,
+    excludedRootPaths: List<String> = emptyList(),
+): Boolean {
+    val normalizedEventPath = normalizeFileSystemPath(eventPath)?.let(Paths::get) ?: return false
+    val normalizedRoots = rootPaths.mapNotNull { rootPath ->
+        normalizeFileSystemPath(rootPath)?.let(Paths::get)
+    }
+    val normalizedExcludedRoots = excludedRootPaths.mapNotNull { rootPath ->
+        normalizeFileSystemPath(rootPath)?.let(Paths::get)
+    }
+    val normalizedProjectBasePath = normalizeFileSystemPath(projectBasePath)?.let(Paths::get)
+    return isTrackedInspectionInputPath(
+        normalizedProjectBasePath,
+        normalizedRoots,
+        normalizedExcludedRoots,
+        normalizedEventPath,
+    )
+}
+
+internal fun localInspectionRootPath(file: VirtualFile): String? {
+    val path = file.path
+    return when {
+        "!/" in path -> path.substringBefore("!/")
+        file.isInLocalFileSystem -> path
+        else -> null
+    }
+}
+
+internal fun inspectionEventPaths(event: VFileEvent): List<String> {
+    return when (event) {
+        is VFileMoveEvent -> listOf(event.oldPath, event.newPath)
+        is VFilePropertyChangeEvent -> if (event.isRename) {
+            listOf(event.oldPath, event.newPath)
+        } else {
+            listOf(event.path)
+        }
+        else -> listOf(event.path)
+    }.distinct()
+}
+
+private fun isTrackedInspectionInputPath(
+    projectBasePath: Path?,
+    rootPaths: List<Path>,
+    excludedRootPaths: List<Path>,
+    eventPath: Path,
+): Boolean {
+    if (rootPaths.none { rootPath -> eventPath == rootPath || eventPath.startsWith(rootPath) }) {
+        return false
+    }
+    if (excludedRootPaths.any { rootPath -> eventPath == rootPath || eventPath.startsWith(rootPath) }) {
+        return false
+    }
+    if (eventPath.any { pathSegment -> pathSegment.toString() == ".git" }) {
+        return false
+    }
+    if (projectBasePath == null || (eventPath != projectBasePath && !eventPath.startsWith(projectBasePath))) {
+        return true
+    }
+
+    val relativePath = projectBasePath.relativize(eventPath)
+    if (relativePath.nameCount == 0) {
+        return true
+    }
+    val relativePathText = relativePath.joinToString("/")
+    return relativePathText != ".idea" && !relativePathText.startsWith(".idea/workspace.xml")
+}
+
+private class MessageBusInspectionProjectContentTracker(
+    project: Project,
+    projectBasePath: String?,
+    rootPaths: List<String>,
+    excludedRootPaths: List<String>,
+) : InspectionProjectContentTracker {
+    private val changed = AtomicBoolean(false)
+    private val closed = AtomicBoolean(false)
+    private val changeLock = Any()
+    private val disposable = Disposable { closed.set(true) }
+    private val normalizedProjectBasePath = normalizeFileSystemPath(projectBasePath)?.let(Paths::get)
+    private val normalizedRootPaths = rootPaths.mapNotNull { rootPath ->
+        normalizeFileSystemPath(rootPath)?.let(Paths::get)
+    }
+    private val normalizedExcludedRootPaths = excludedRootPaths.mapNotNull { rootPath ->
+        normalizeFileSystemPath(rootPath)?.let(Paths::get)
+    }
+
+    init {
+        Disposer.register(project, disposable)
+        ApplicationManager.getApplication().messageBus.connect(disposable).subscribe(
+            VirtualFileManager.VFS_CHANGES,
+            object : BulkFileListener {
+                override fun before(events: List<VFileEvent>) {
+                    recordChanges(events)
+                }
+
+                override fun after(events: List<VFileEvent>) {
+                    recordChanges(events)
+                }
+            },
+        )
+        project.messageBus.connect(disposable).subscribe(
+            ProfileChangeAdapter.TOPIC,
+            object : ProfileChangeAdapter {
+                override fun profileChanged(profile: InspectionProfile) {
+                    markChanged()
+                }
+
+                override fun profileActivated(oldProfile: InspectionProfile?, profile: InspectionProfile?) {
+                    markChanged()
+                }
+
+                override fun profilesInitialized() {
+                    markChanged()
+                }
+            },
+        )
+        val scopeListener = NamedScopesHolder.ScopeListener(::markChanged)
+        DependencyValidationManager.getInstance(project).addScopeListener(scopeListener, disposable)
+        NamedScopeManager.getInstance(project).addScopeListener(scopeListener, disposable)
+    }
+
+    override fun hasChanges(): Boolean = changed.get()
+
+    override fun runIfUnchanged(action: () -> Unit): Boolean {
+        synchronized(changeLock) {
+            if (changed.get()) {
+                return false
+            }
+            action()
+            return true
+        }
+    }
+
+    override fun close() {
+        if (closed.compareAndSet(false, true)) {
+            Disposer.dispose(disposable)
+        }
+    }
+
+    private fun recordChanges(events: List<VFileEvent>) {
+        if (changed.get()) {
+            return
+        }
+        if (events.any { event ->
+                inspectionEventPaths(event).any { eventPath ->
+                    val normalizedEventPath = normalizeFileSystemPath(eventPath)?.let(Paths::get)
+                    normalizedEventPath != null &&
+                        isTrackedInspectionInputPath(
+                            normalizedProjectBasePath,
+                            normalizedRootPaths,
+                            normalizedExcludedRootPaths,
+                            normalizedEventPath,
+                        )
+                }
+            }
+        ) {
+            markChanged()
+        }
+    }
+
+    private fun markChanged() {
+        synchronized(changeLock) {
+            changed.set(true)
+        }
+    }
+}
 
 private data class InspectionVerdict(
     val verdict: String,
@@ -1011,9 +1213,14 @@ class InspectionHandler : HttpRequestHandler() {
             setDelayInMillis(Int.MAX_VALUE)
         }
     }
-    internal var projectContentEpochProvider: () -> InspectionProjectContentEpoch = {
-        captureProjectContentEpoch()
-    }
+    internal var projectInputsFingerprintProvider:
+        (Project, String?) -> InspectionProjectInputsFingerprint? = { project, profileName ->
+            captureInspectionProjectInputs(project, profileName)
+        }
+    internal var projectContentTrackerFactory:
+        (Project, InspectionProjectInputsFingerprint) -> InspectionProjectContentTracker? = { project, fingerprint ->
+            createProjectContentTracker(project, fingerprint)
+        }
     internal var lifecycleCloseExecutor: (Runnable) -> Unit = { task ->
         ApplicationManager.getApplication().executeOnPooledThread(task)
     }
@@ -3216,10 +3423,21 @@ class InspectionHandler : HttpRequestHandler() {
             return CurrentRunPsiChurnReconciliation(null, false)
         }
 
-        val liveExtraction = try {
-            ApplicationManager.getApplication().runReadAction<ProblemExtractionResult, Exception> {
-                enhancedTreeExtractorFactory().extractAllProblemsWithStatus(project)
+        return try {
+            ApplicationManager.getApplication().runReadAction<CurrentRunPsiChurnReconciliation, Exception> {
+                reconcileCurrentRunPsiChurnUnderReadAction(project, snapshot)
             }
+        } catch (_: Exception) {
+            CurrentRunPsiChurnReconciliation(snapshot, false)
+        }
+    }
+
+    private fun reconcileCurrentRunPsiChurnUnderReadAction(
+        project: Project,
+        snapshot: InspectionResultsSnapshot,
+    ): CurrentRunPsiChurnReconciliation {
+        val liveExtraction = try {
+            enhancedTreeExtractorFactory().extractAllProblemsWithStatus(project)
         } catch (_: Exception) {
             return CurrentRunPsiChurnReconciliation(snapshot, false)
         }
@@ -3257,37 +3475,145 @@ class InspectionHandler : HttpRequestHandler() {
         snapshot: InspectionResultsSnapshot,
         captureEndState: InspectionProjectStateSnapshot,
         projectStateChangedDuringCapture: Boolean,
-        inspectionInputContentEpoch: InspectionProjectContentEpoch?,
+        inspectionInputFingerprint: InspectionProjectInputsFingerprint?,
+        projectContentTracker: InspectionProjectContentTracker?,
     ) {
         val key = projectKey(project)
         if (!isCurrentInspectionRun(key, runId)) {
             return
         }
 
-        val snapshotToPublish = if (
-            projectStateChangedDuringCapture &&
-            isWholeProjectCaptureScope(snapshot.captureScope) &&
+        val wholeProjectCapture = isWholeProjectCaptureScope(snapshot.captureScope)
+        val hasInputValidation = inspectionInputFingerprint != null && projectContentTracker != null
+        val canAttemptReconciliation = projectStateChangedDuringCapture &&
+            wholeProjectCapture &&
             captureEndState.unsavedProjectDocuments == 0 &&
-            inspectionInputContentEpoch != null &&
-            captureProjectState(project) == captureEndState
-        ) {
-            val reconciliation = reconcileCurrentRunPsiChurn(project, snapshot)
-            if (
-                reconciliation.reconciled &&
-                projectContentEpochProvider() == inspectionInputContentEpoch &&
-                captureProjectState(project) == captureEndState
-            ) {
-                snapshot.copy(projectState = captureEndState)
-            } else {
-                snapshot
+            hasInputValidation
+        val requiresStableInputValidation = wholeProjectCapture && !projectStateChangedDuringCapture
+        if (!canAttemptReconciliation && !requiresStableInputValidation) {
+            if (!project.isDisposed && isCurrentInspectionRun(key, runId)) {
+                resultsStore.setSnapshot(key, snapshot)
             }
-        } else {
-            snapshot
+            return
+        }
+        if (!hasInputValidation) {
+            if (!project.isDisposed && isCurrentInspectionRun(key, runId)) {
+                resultsStore.setSnapshot(
+                    key,
+                    inspectionInputValidationFailureSnapshot(snapshot, "validation_unavailable"),
+                )
+            }
+            return
         }
 
-        if (isCurrentInspectionRun(key, runId)) {
-            resultsStore.setSnapshot(key, snapshotToPublish)
+        val inputFingerprint = requireNotNull(inspectionInputFingerprint)
+        val contentTracker = requireNotNull(projectContentTracker)
+
+        try {
+            ApplicationManager.getApplication().runReadAction<Unit, Exception> {
+                val contentChangedBeforeVerification = contentTracker.hasChanges()
+                val stateStableBeforeVerification = captureProjectState(project) == captureEndState
+                val reconciliation = if (
+                    canAttemptReconciliation &&
+                    !project.isDisposed &&
+                    !contentChangedBeforeVerification &&
+                    stateStableBeforeVerification &&
+                    isCurrentInspectionRun(key, runId)
+                ) {
+                    reconcileCurrentRunPsiChurnUnderReadAction(project, snapshot)
+                } else {
+                    CurrentRunPsiChurnReconciliation(snapshot, false)
+                }
+                val currentFingerprint = if (
+                    !project.isDisposed &&
+                    !contentChangedBeforeVerification &&
+                    stateStableBeforeVerification &&
+                    isCurrentInspectionRun(key, runId) &&
+                    (!projectStateChangedDuringCapture || reconciliation.reconciled)
+                ) {
+                    projectInputsFingerprintProvider(project, inputFingerprint.requestedProfileName)
+                } else {
+                    null
+                }
+                val contentChangedAfterVerification = contentTracker.hasChanges()
+                val stateStableAfterVerification = captureProjectState(project) == captureEndState
+                val inputsMatched = currentFingerprint == inputFingerprint
+                val finalValidationPassed =
+                    !contentChangedAfterVerification &&
+                    stateStableAfterVerification &&
+                    inputsMatched &&
+                    !project.isDisposed &&
+                    isCurrentInspectionRun(key, runId)
+                val shouldReconcile = reconciliation.reconciled && finalValidationPassed
+                val shouldPublishUnchangedSnapshot =
+                    !projectStateChangedDuringCapture && finalValidationPassed
+                logger.info(
+                    "Inspection snapshot validation for ${project.name}: " +
+                        "liveFindingsMatched=${reconciliation.reconciled}, " +
+                        "contentChangedBefore=$contentChangedBeforeVerification, " +
+                        "contentChangedAfter=$contentChangedAfterVerification, " +
+                        "stateStableBefore=$stateStableBeforeVerification, " +
+                        "stateStableAfter=$stateStableAfterVerification, " +
+                        "inputsMatched=$inputsMatched, " +
+                        "unchangedPublished=$shouldPublishUnchangedSnapshot, " +
+                        "promoted=$shouldReconcile"
+                )
+                val snapshotToPublish = if (shouldReconcile) {
+                    snapshot.copy(projectState = captureEndState)
+                } else if (shouldPublishUnchangedSnapshot || projectStateChangedDuringCapture) {
+                    snapshot
+                } else {
+                    inspectionInputValidationFailureSnapshot(snapshot, "inputs_changed")
+                }
+                if (!project.isDisposed && isCurrentInspectionRun(key, runId)) {
+                    val publicationRequiresStableTracker = shouldReconcile || shouldPublishUnchangedSnapshot
+                    val publishedWithStableTracker = if (publicationRequiresStableTracker) {
+                        contentTracker.runIfUnchanged {
+                            if (!project.isDisposed && isCurrentInspectionRun(key, runId)) {
+                                resultsStore.setSnapshot(key, snapshotToPublish)
+                            }
+                        }
+                    } else {
+                        resultsStore.setSnapshot(key, snapshotToPublish)
+                        true
+                    }
+                    if (!publishedWithStableTracker && !project.isDisposed && isCurrentInspectionRun(key, runId)) {
+                        val fallbackSnapshot = if (projectStateChangedDuringCapture) {
+                            snapshot
+                        } else {
+                            inspectionInputValidationFailureSnapshot(snapshot, "inputs_changed")
+                        }
+                        resultsStore.setSnapshot(key, fallbackSnapshot)
+                    }
+                }
+            }
+        } catch (error: Exception) {
+            logger.warn("Inspection snapshot validation failed for ${project.name}", error)
+            if (!project.isDisposed && isCurrentInspectionRun(key, runId)) {
+                val snapshotToPublish = if (projectStateChangedDuringCapture) {
+                    snapshot
+                } else {
+                    inspectionInputValidationFailureSnapshot(snapshot, "validation_failed")
+                }
+                resultsStore.setSnapshot(key, snapshotToPublish)
+            }
         }
+    }
+
+    private fun inspectionInputValidationFailureSnapshot(
+        snapshot: InspectionResultsSnapshot,
+        failure: String,
+    ): InspectionResultsSnapshot {
+        return snapshot.copy(
+            problems = emptyList(),
+            outcome = InspectionSnapshotOutcome.CAPTURE_INCOMPLETE,
+            source = "inspection_input_validation",
+            note = "Project files or inspection inputs changed while results were being finalized.",
+            captureDiagnostic = snapshot.captureDiagnostic.orEmpty() + mapOf(
+                "final_input_validation" to failure,
+            ),
+            captureIncompleteReason = CaptureIncompleteReason.UNKNOWN,
+        )
     }
 
     private fun isWholeProjectCaptureScope(captureScope: InspectionCaptureScope?): Boolean {
@@ -3792,6 +4118,8 @@ class InspectionHandler : HttpRequestHandler() {
     ) {
         val key = projectKey(project)
         var captureScheduled = false
+        var projectContentTracker: InspectionProjectContentTracker? = null
+        var inspectionInputFingerprint: InspectionProjectInputsFingerprint? = null
         try {
             if (!isCurrentInspectionRun(key, runId)) {
                 return
@@ -3805,30 +4133,26 @@ class InspectionHandler : HttpRequestHandler() {
             waitForSmartMode(project)
             checkInspectionRunCancellation(key, runId)
             val inspectionInputState = captureStableProjectState(project)
-            val inspectionInputContentEpoch = if (isWholeProjectCaptureScope(captureScope)) {
-                projectContentEpochProvider()
-            } else {
-                null
-            }
             val dumbAfterSync = DumbService.getInstance(project).isDumb
 
             val profileManager = com.intellij.profile.codeInspection.InspectionProjectProfileManager.getInstance(project)
             val requestedProfileName = profileName?.trim()?.takeIf { it.isNotEmpty() }
+            val preflightProfile = resolveInspectionProfile(profileManager, requestedProfileName)
             val profileNames = try {
-                profileManager.profiles.map { it.name }.sorted()
+                (profileManager.profiles.map { it.name } + listOfNotNull(preflightProfile?.name))
+                    .distinct()
+                    .sorted()
             } catch (_: Exception) {
                 null
             }
-            val requestedProfileMissing = requestedProfileName != null &&
-                profileNames != null &&
-                requestedProfileName !in profileNames
-            val requestedProfileUnverified = requestedProfileName != null && profileNames == null
+            val requestedProfileMissing = requestedProfileName != null && preflightProfile == null
+            val requestedProfileUnverified = requestedProfileName == null && preflightProfile == null
             if (requestedProfileMissing || requestedProfileUnverified) {
-                val exitReason = if (requestedProfileMissing) "profile_missing" else "profile_list_unreadable"
+                val exitReason = if (requestedProfileMissing) "profile_missing" else "current_profile_unavailable"
                 val note = if (requestedProfileMissing) {
                     "Requested inspection profile '$requestedProfileName' was not found."
                 } else {
-                    "Requested inspection profile '$requestedProfileName' could not be verified."
+                    "The current inspection profile could not be resolved."
                 }
                 resultsStore.setSnapshot(
                     key,
@@ -3926,10 +4250,90 @@ class InspectionHandler : HttpRequestHandler() {
                 resolvedScope = effectiveCaptureScope,
             )
             
-            val profile = if (requestedProfileName != null) {
-                profileManager.getProfile(requestedProfileName)
-            } else {
-                profileManager.currentProfile
+            var profile = resolveInspectionProfile(profileManager, requestedProfileName)
+            if (profile == null) {
+                resultsStore.setSnapshot(
+                    key,
+                    InspectionResultsSnapshot(
+                        problems = emptyList(),
+                        timestamp = System.currentTimeMillis(),
+                        projectState = inspectionInputState,
+                        outcome = InspectionSnapshotOutcome.CAPTURE_INCOMPLETE,
+                        source = "profile_resolution",
+                        note = if (requestedProfileName != null) {
+                            "Requested inspection profile '$requestedProfileName' was no longer available."
+                        } else {
+                            "The current inspection profile was unavailable."
+                        },
+                        captureScope = effectiveCaptureScope,
+                        captureDiagnostic = mapOf(
+                            "profile_requested" to requestedProfileName,
+                            "profile_missing" to true,
+                            "exit_reason" to "profile_disappeared",
+                        ),
+                        captureIncompleteReason = CaptureIncompleteReason.PROFILE_RESOLUTION_ERROR,
+                        runId = runId,
+                        triggerTimeMs = inspectionRunStatesByProject[key]?.triggerTimeMs,
+                    ),
+                )
+                return
+            }
+            if (isWholeProjectCaptureScope(effectiveCaptureScope)) {
+                val initialFingerprint = captureInspectionProjectInputs(
+                    project = project,
+                    selectedProfile = profile,
+                    profileName = requestedProfileName,
+                )
+                val tracker = initialFingerprint?.let { fingerprint ->
+                    projectContentTrackerFactory(project, fingerprint)
+                }
+                val confirmedProfile = if (tracker != null) {
+                    resolveInspectionProfile(profileManager, requestedProfileName)
+                } else {
+                    null
+                }
+                val confirmedFingerprint = confirmedProfile?.let { resolvedProfile ->
+                    captureInspectionProjectInputs(
+                        project = project,
+                        selectedProfile = resolvedProfile,
+                        profileName = requestedProfileName,
+                    )
+                }
+                val trackerChangedDuringPreflight = tracker?.hasChanges() ?: true
+                if (
+                    tracker != null &&
+                    !trackerChangedDuringPreflight &&
+                    initialFingerprint == confirmedFingerprint
+                ) {
+                    projectContentTracker = tracker
+                    inspectionInputFingerprint = confirmedFingerprint
+                    profile = requireNotNull(confirmedProfile)
+                } else {
+                    tracker?.close()
+                    resultsStore.setSnapshot(
+                        key,
+                        InspectionResultsSnapshot(
+                            problems = emptyList(),
+                            timestamp = System.currentTimeMillis(),
+                            projectState = inspectionInputState,
+                            outcome = InspectionSnapshotOutcome.CAPTURE_INCOMPLETE,
+                            source = "inspection_input_validation",
+                            note = "Project inspection inputs could not be captured consistently before inspection.",
+                            captureScope = effectiveCaptureScope,
+                            captureDiagnostic = mapOf(
+                                "initial_fingerprint_available" to (initialFingerprint != null),
+                                "tracker_available" to (tracker != null),
+                                "tracker_changed" to trackerChangedDuringPreflight,
+                                "confirmed_profile_available" to (confirmedProfile != null),
+                                "fingerprints_matched" to (initialFingerprint == confirmedFingerprint),
+                            ),
+                            captureIncompleteReason = CaptureIncompleteReason.UNKNOWN,
+                            runId = runId,
+                            triggerTimeMs = inspectionRunStatesByProject[key]?.triggerTimeMs,
+                        ),
+                    )
+                    return
+                }
             }
             val resolvedProfileName = try {
                 profile.name
@@ -4594,7 +4998,8 @@ class InspectionHandler : HttpRequestHandler() {
                             snapshot = snapshot,
                             captureEndState = captureEndState,
                             projectStateChangedDuringCapture = projectStateChangedDuringCapture,
-                            inspectionInputContentEpoch = inspectionInputContentEpoch,
+                            inspectionInputFingerprint = inspectionInputFingerprint,
+                            projectContentTracker = projectContentTracker,
                         )
                         } catch (e: com.intellij.openapi.progress.ProcessCanceledException) {
                             throw e
@@ -4635,6 +5040,7 @@ class InspectionHandler : HttpRequestHandler() {
             logger.warn("Inspection execution failed for ${project.name}", error)
             publishCaptureFailureIfCurrent(key, runId, project, captureScope, error)
         } finally {
+            projectContentTracker?.close()
             if (!captureScheduled) {
                 finishInspectionRun(key, runId)
             }
@@ -4827,10 +5233,157 @@ class InspectionHandler : HttpRequestHandler() {
         )
     }
 
-    private fun captureProjectContentEpoch(): InspectionProjectContentEpoch {
-        return InspectionProjectContentEpoch(
-            vfsModificationCount = VirtualFileManager.getInstance().modificationCount,
-        )
+    private fun captureInspectionProjectInputs(
+        project: Project,
+        profileName: String?,
+    ): InspectionProjectInputsFingerprint? {
+        val profileManager =
+            com.intellij.profile.codeInspection.InspectionProjectProfileManager.getInstance(project)
+        val selectedProfile = resolveInspectionProfile(profileManager, profileName) ?: return null
+        return captureInspectionProjectInputs(project, selectedProfile, profileName)
+    }
+
+    private fun resolveInspectionProfile(
+        profileManager: com.intellij.profile.codeInspection.InspectionProjectProfileManager,
+        profileName: String?,
+    ): InspectionProfileImpl? {
+        return try {
+            if (profileName != null) {
+                profileManager.getProfile(profileName, false)
+            } else {
+                profileManager.currentProfile
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun captureInspectionProjectInputs(
+        project: Project,
+        selectedProfile: InspectionProfileImpl,
+        profileName: String?,
+    ): InspectionProjectInputsFingerprint? {
+        if (project.isDisposed) {
+            return null
+        }
+        return try {
+            ApplicationManager.getApplication().runReadAction<InspectionProjectInputsFingerprint?, Exception> {
+                if (project.isDisposed) {
+                    return@runReadAction null
+                }
+                val rootManager = ProjectRootManager.getInstance(project)
+                val orderEntries = rootManager.orderEntries().recursively()
+                val rootPaths = buildList {
+                    project.basePath?.let(::add)
+                    addAll(rootManager.contentRoots.mapNotNull(::localInspectionRootPath))
+                    addAll(rootManager.contentSourceRoots.mapNotNull(::localInspectionRootPath))
+                    addAll(orderEntries.classes().roots.mapNotNull(::localInspectionRootPath))
+                    addAll(orderEntries.sources().roots.mapNotNull(::localInspectionRootPath))
+                }.mapNotNull(::normalizeFileSystemPath).distinct().sorted()
+                val excludedRootPaths = ModuleManager.getInstance(project).modules
+                    .flatMap { module ->
+                        val moduleRootManager = ModuleRootManager.getInstance(module)
+                        buildList {
+                            addAll(moduleRootManager.excludeRoots.mapNotNull(::localInspectionRootPath))
+                            val compilerModuleExtension = CompilerModuleExtension.getInstance(module)
+                            compilerModuleExtension?.compilerOutputPath
+                                ?.let(::localInspectionRootPath)
+                                ?.let(::add)
+                            compilerModuleExtension?.compilerOutputPathForTests
+                                ?.let(::localInspectionRootPath)
+                                ?.let(::add)
+                        }
+                    }
+                    .mapNotNull(::normalizeFileSystemPath)
+                    .distinct()
+                    .sorted()
+                val sdk = rootManager.projectSdk
+                selectedProfile.initInspectionTools(project)
+                val resolvedProfileName = runCatching { selectedProfile.name }.getOrNull()
+                val toolStates = runCatching { selectedProfile.allTools }
+                    .getOrElse { return@runReadAction null }
+                val profileToolStates = toolStates.map { state ->
+                        listOf(
+                            state.tool.shortName,
+                            state.scopeName,
+                            state.isEnabled,
+                            state.level.name,
+                            state.editorAttributesExternalName,
+                            inspectionToolConfigurationHash(state),
+                        ).joinToString("|")
+                    }
+                    .sorted()
+                val namedScopeDefinitions = toolStates
+                    .mapNotNull { state -> state.scopeName }
+                    .distinct()
+                    .sorted()
+                    .map { scopeName ->
+                        val scope = NamedScopesHolder.getScope(project, scopeName)
+                        listOf(
+                            scopeName,
+                            scope?.scopeId ?: "<missing>",
+                            scope?.value?.text ?: "<missing>",
+                        ).joinToString("\u0000")
+                    }
+                val profileConfigurationHash = runCatching {
+                    inspectionProfileConfigurationHash(selectedProfile)
+                }.getOrElse { return@runReadAction null }
+                InspectionProjectInputsFingerprint(
+                    rootPaths = rootPaths,
+                    excludedRootPaths = excludedRootPaths,
+                    projectSdkName = runCatching { sdk?.name }.getOrNull(),
+                    projectSdkTypeName = runCatching { sdk?.sdkType?.name }.getOrNull(),
+                    projectSdkVersion = runCatching { sdk?.versionString }.getOrNull(),
+                    projectSdkHomePath = runCatching { sdk?.homePath }.getOrNull()?.let(::normalizeFileSystemPath),
+                    requestedProfileName = profileName,
+                    resolvedProfileName = resolvedProfileName,
+                    profileToolStates = profileToolStates,
+                    namedScopeDefinitions = namedScopeDefinitions,
+                    profileConfigurationHash = profileConfigurationHash,
+                )
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun inspectionProfileConfigurationHash(profile: InspectionProfileImpl): String {
+        val profileElement = Element("profile")
+        profile.writeExternal(profileElement)
+        return sha256(JDOMUtil.writeElement(profileElement))
+    }
+
+    private fun inspectionToolConfigurationHash(
+        state: com.intellij.codeInspection.ex.ScopeToolState,
+    ): String {
+        val toolElement = Element("tool")
+        com.intellij.codeInspection.ex.ScopeToolState.tryWriteSettings(state.tool.tool, toolElement)
+        return sha256(JDOMUtil.writeElement(toolElement))
+    }
+
+    private fun sha256(value: String): String {
+        return MessageDigest.getInstance("SHA-256")
+            .digest(value.toByteArray(Charsets.UTF_8))
+            .joinToString("") { byte -> "%02x".format(byte.toInt() and 0xff) }
+    }
+
+    private fun createProjectContentTracker(
+        project: Project,
+        fingerprint: InspectionProjectInputsFingerprint,
+    ): InspectionProjectContentTracker? {
+        if (project.isDisposed || fingerprint.rootPaths.isEmpty()) {
+            return null
+        }
+        return try {
+            MessageBusInspectionProjectContentTracker(
+                project = project,
+                projectBasePath = project.basePath,
+                rootPaths = fingerprint.rootPaths,
+                excludedRootPaths = fingerprint.excludedRootPaths,
+            )
+        } catch (_: Exception) {
+            null
+        }
     }
 
     private fun captureStableProjectState(project: Project): InspectionProjectStateSnapshot {

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -13,6 +13,9 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.module.ModuleUtilCore
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.progress.util.ProgressIndicatorBase
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.project.Project
@@ -52,6 +55,7 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.UUID
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 import javax.swing.JTree
@@ -271,6 +275,12 @@ internal data class InspectionRunState(
         captureScope = null,
     )
 }
+
+internal data class InspectionRunControl(
+    val runId: Long,
+    val indicator: ProgressIndicator,
+    val cancellationRequested: AtomicBoolean = AtomicBoolean(false),
+)
 
 private data class InspectionProof(
     val summary: Map<String, Any?>,
@@ -960,6 +970,7 @@ class InspectionHandler : HttpRequestHandler() {
     
     private val runIdSequence = AtomicLong()
     private val inspectionRunStatesByProject = java.util.concurrent.ConcurrentHashMap<String, InspectionRunState>()
+    private val inspectionRunControlsByProject = java.util.concurrent.ConcurrentHashMap<String, InspectionRunControl>()
     private val leasesByProjectInstance = java.util.concurrent.ConcurrentHashMap<String, InspectionProjectLease>()
     private val openingProjectRequests = java.util.concurrent.ConcurrentHashMap<String, LifecycleOpenRequest>()
     private val lifecycleOpenOwnershipByProjectInstance = java.util.concurrent.ConcurrentHashMap<String, LifecycleOpenOwnership>()
@@ -976,6 +987,12 @@ class InspectionHandler : HttpRequestHandler() {
     internal var lifecycleOpenGuardNow: () -> Long = { System.currentTimeMillis() }
     internal var lifecycleOpenGuardSleep: (Long) -> Unit = { millis -> Thread.sleep(millis) }
     internal var inspectionRunExpirationMs: Long = 300000L
+    internal var inspectionProcessRunner: (Runnable, ProgressIndicator) -> Unit = { task, indicator ->
+        ProgressManager.getInstance().runProcess(task, indicator)
+    }
+    internal var lifecycleCloseExecutor: (Runnable) -> Unit = { task ->
+        ApplicationManager.getApplication().executeOnPooledThread(task)
+    }
     internal var trustProjectPath: (Path) -> Unit = { path ->
         TrustedProjects.setProjectTrusted(canonicalTrustPath(path), true)
     }
@@ -1283,8 +1300,28 @@ class InspectionHandler : HttpRequestHandler() {
                     sendJsonResponse(context, formatJsonManually(result.first), result.second)
                 }
                 "/api/inspection/lifecycle/close" -> {
-                    val result = closeLifecycleProject(parameters)
-                    sendJsonResponse(context, formatJsonManually(result.first), result.second)
+                    val scheduled = runCatching {
+                        lifecycleCloseExecutor(Runnable {
+                            processLifecycleCloseRequest(parameters, context)
+                        })
+                    }.isSuccess
+                    if (!scheduled) {
+                        sendJsonResponse(
+                            context,
+                            """{"error": "Internal server error"}""",
+                            HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                        )
+                    }
+                }
+                "/api/inspection/cancel" -> {
+                    responseHasSessionDrift(parameters)?.let {
+                        sendJsonResponse(context, it, HttpResponseStatus.CONFLICT)
+                        return true
+                    }
+                    val result = ApplicationManager.getApplication().runReadAction<String, Exception> {
+                        buildInspectionCancellationResponse(parameters)
+                    }
+                    sendJsonResponse(context, result)
                 }
                 "/api/inspection/problems" -> {
                     responseHasSessionDrift(parameters)?.let {
@@ -1478,7 +1515,13 @@ class InspectionHandler : HttpRequestHandler() {
                 maxFiles = maxFiles,
                 allowLegacyProblemsScope = false,
             )
+            val key = projectKey(project)
             val runState = beginInspectionRun(project, captureScope)
+            val runControl = InspectionRunControl(
+                runId = runState.runId,
+                indicator = ProgressIndicatorBase(),
+            )
+            inspectionRunControlsByProject[key] = runControl
             try {
                 ApplicationManager.getApplication().executeOnPooledThread {
                     triggerInspectionAsync(
@@ -1486,10 +1529,12 @@ class InspectionHandler : HttpRequestHandler() {
                         runId = runState.runId,
                         captureScope = captureScope,
                         profileName = profile,
+                        control = runControl,
                     )
                 }
             } catch (error: Exception) {
-                finishInspectionRun(projectKey(project), runState.runId)
+                inspectionRunControlsByProject.remove(key, runControl)
+                finishInspectionRun(key, runState.runId)
                 throw error
             }
             val details = mutableMapOf<String, Any>(
@@ -1497,7 +1542,7 @@ class InspectionHandler : HttpRequestHandler() {
                 "message" to "Inspection triggered. Wait 10-15 seconds then check status",
                 "run_id" to runState.runId,
                 "session_id" to InspectionIdeSession.sessionId,
-                "project_key" to projectKey(project),
+                "project_key" to key,
                 "route" to routeMetadata(project),
                 "scope" to captureScope.scopeParam.orEmpty().ifBlank { "whole_project" },
                 "include_unversioned" to includeUnversioned,
@@ -2018,6 +2063,91 @@ class InspectionHandler : HttpRequestHandler() {
         return projectCandidatePaths(project)
             .mapNotNull { path -> runCatching { canonicalLifecycleOpenKey(Paths.get(path)) }.getOrNull() }
             .toSet()
+    }
+
+    private fun processLifecycleCloseRequest(
+        parameters: Map<String, List<String>>,
+        context: ChannelHandlerContext,
+    ) {
+        try {
+            val result = closeLifecycleProject(parameters)
+            sendJsonResponse(context, formatJsonManually(result.first), result.second)
+        } catch (error: BadRequestException) {
+            sendJsonResponse(context, formatBadRequest(error), HttpResponseStatus.BAD_REQUEST)
+        } catch (error: Exception) {
+            logger.warn("Failed to process lifecycle close request", error)
+            sendJsonResponse(
+                context,
+                """{"error": "Internal server error"}""",
+                HttpResponseStatus.INTERNAL_SERVER_ERROR,
+            )
+        }
+    }
+
+    private fun buildInspectionCancellationResponse(parameters: Map<String, List<String>>): String {
+        val resolved = resolveInspectionRoute(parameters)
+            ?: return formatJsonManually(buildMissingProjectResponse(routeProjectSelector(parameters)))
+        val key = projectKey(resolved.project)
+        val runState = inspectionRunStatesByProject[key]
+        val rawExpectedRunId = firstParameter(parameters, "inspection_run_id")
+            ?: throw BadRequestException("inspection_run_id", "Parameter 'inspection_run_id' is required.")
+        val expectedRunId = rawExpectedRunId.toLongOrNull()?.takeIf { it > 0 }
+            ?: throw BadRequestException("inspection_run_id", "Parameter 'inspection_run_id' must be a positive integer.")
+        if (runState?.inProgress != true) {
+            return formatJsonManually(
+                mapOf(
+                    "status" to "not_running",
+                    "inspection_in_progress" to false,
+                    "inspection_cancellation_requested" to false,
+                    "project_key" to key,
+                    "session_id" to InspectionIdeSession.sessionId,
+                    "route" to routeMetadata(resolved),
+                )
+            )
+        }
+        if (expectedRunId != runState.runId) {
+            return formatJsonManually(
+                mapOf(
+                    "status" to "run_changed",
+                    "inspection_in_progress" to true,
+                    "inspection_cancellation_requested" to false,
+                    "expected_inspection_run_id" to expectedRunId,
+                    "inspection_run_id" to runState.runId,
+                    "project_key" to key,
+                    "session_id" to InspectionIdeSession.sessionId,
+                    "route" to routeMetadata(resolved),
+                )
+            )
+        }
+
+        val control = inspectionRunControlsByProject[key]
+        if (control == null || control.runId != runState.runId) {
+            return formatJsonManually(
+                mapOf(
+                    "status" to "cancellation_unavailable",
+                    "inspection_in_progress" to true,
+                    "inspection_cancellation_requested" to false,
+                    "inspection_run_id" to runState.runId,
+                    "project_key" to key,
+                    "session_id" to InspectionIdeSession.sessionId,
+                    "route" to routeMetadata(resolved),
+                )
+            )
+        }
+
+        control.cancellationRequested.set(true)
+        control.indicator.cancel()
+        return formatJsonManually(
+            mapOf(
+                "status" to "cancel_requested",
+                "inspection_in_progress" to true,
+                "inspection_cancellation_requested" to true,
+                "inspection_run_id" to runState.runId,
+                "project_key" to key,
+                "session_id" to InspectionIdeSession.sessionId,
+                "route" to routeMetadata(resolved),
+            )
+        )
     }
 
     private fun closeLifecycleProject(parameters: Map<String, List<String>>): Pair<Map<String, Any?>, HttpResponseStatus> {
@@ -2841,6 +2971,9 @@ class InspectionHandler : HttpRequestHandler() {
         status["time_since_last_trigger_ms"] = timeSinceLastTrigger
         if (runState != null) {
             status["inspection_run_id"] = runState.runId
+            val runControl = inspectionRunControlsByProject[key]
+            status["inspection_cancellation_requested"] =
+                runControl?.runId == runState.runId && runControl.cancellationRequested.get()
             if (runState.inProgress && timeSinceLastTrigger >= inspectionRunExpirationMs) {
                 status["inspection_run_expired"] = true
             }
@@ -3352,6 +3485,32 @@ class InspectionHandler : HttpRequestHandler() {
         runId: Long,
         captureScope: InspectionCaptureScope,
         profileName: String? = null,
+        control: InspectionRunControl,
+    ) {
+        val key = projectKey(project)
+        if (!isCurrentInspectionRun(key, runId)) {
+            inspectionRunControlsByProject.remove(key, control)
+            return
+        }
+        try {
+            inspectionProcessRunner(
+                Runnable {
+                    runInspectionUnderProgress(project, runId, captureScope, profileName)
+                },
+                control.indicator,
+            )
+        } finally {
+            if (inspectionRunStatesByProject[key]?.inProgress != true) {
+                inspectionRunControlsByProject.remove(key, control)
+            }
+        }
+    }
+
+    private fun runInspectionUnderProgress(
+        project: Project,
+        runId: Long,
+        captureScope: InspectionCaptureScope,
+        profileName: String? = null,
     ) {
         val key = projectKey(project)
         var captureScheduled = false
@@ -3359,12 +3518,14 @@ class InspectionHandler : HttpRequestHandler() {
             if (!isCurrentInspectionRun(key, runId)) {
                 return
             }
+            checkInspectionRunCancellation(key, runId)
             resultsStore.clear(key)
 
             clearPriorInspectionResults(project)
             
             syncProjectState(project)
             waitForSmartMode(project)
+            checkInspectionRunCancellation(key, runId)
             val inspectionInputState = captureStableProjectState(project)
             val dumbAfterSync = DumbService.getInstance(project).isDumb
 
@@ -3515,15 +3676,9 @@ class InspectionHandler : HttpRequestHandler() {
             globalContext.setExternalProfile(profile)
             globalContext.currentScope = scope
             
-            com.intellij.openapi.progress.ProgressManager.getInstance().runProcessWithProgressSynchronously(
-                {
-                    @Suppress("UnstableApiUsage")
-                    globalContext.performInspectionsWithProgress(scope, false, false)
-                },
-                "Running Code Inspection",
-                true,
-                project
-            )
+            @Suppress("UnstableApiUsage")
+            globalContext.performInspectionsWithProgress(scope, false, false)
+            ProgressManager.checkCanceled()
 
             try {
                 @Suppress("UnstableApiUsage")
@@ -3534,8 +3689,9 @@ class InspectionHandler : HttpRequestHandler() {
                 } catch (_: Exception) {
                     null
                 }
-                ApplicationManager.getApplication().executeOnPooledThread {
+                run {
                     try {
+                        checkInspectionRunCancellation(key, runId)
                         val extractor = enhancedTreeExtractorFactory()
                         var extractedFromContextSucceeded = false
                         val contextExtraction = try {
@@ -3554,6 +3710,7 @@ class InspectionHandler : HttpRequestHandler() {
                                 project,
                                 targetToolShortNames,
                                 fallbackScopeFiles,
+                                cancellationCheck = { checkInspectionRunCancellation(key, runId) },
                             ).also {
                                 extractedFromContextSucceeded = true
                             }
@@ -3686,6 +3843,7 @@ class InspectionHandler : HttpRequestHandler() {
                         var viewReadyOk = false
 
                         while (System.currentTimeMillis() < deadlineMs) {
+                            checkInspectionRunCancellation(key, runId)
                             if (!isCurrentInspectionRun(key, runId)) {
                                 captureExitReason = "superseded"
                                 break
@@ -4238,6 +4396,14 @@ class InspectionHandler : HttpRequestHandler() {
         return inspectionRunStatesByProject[key]?.runId == runId
     }
 
+    private fun checkInspectionRunCancellation(key: String, runId: Long) {
+        ProgressManager.checkCanceled()
+        val control = inspectionRunControlsByProject[key]
+        if (control?.runId == runId && control.cancellationRequested.get()) {
+            throw com.intellij.openapi.progress.ProcessCanceledException()
+        }
+    }
+
     private fun finishInspectionRun(key: String, runId: Long) {
         inspectionRunStatesByProject.computeIfPresent(key) { _, state ->
             if (state.runId == runId) {
@@ -4245,6 +4411,9 @@ class InspectionHandler : HttpRequestHandler() {
             } else {
                 state
             }
+        }
+        inspectionRunControlsByProject.computeIfPresent(key) { _, control ->
+            if (control.runId == runId) null else control
         }
     }
 
@@ -5213,13 +5382,16 @@ class InspectionHandler : HttpRequestHandler() {
         project: Project,
         targetToolShortNames: Set<String> = emptySet(),
         fallbackScopeFiles: List<com.intellij.psi.PsiFile> = emptyList(),
+        cancellationCheck: () -> Unit = { ProgressManager.checkCanceled() },
     ): InspectionModelExtraction {
+        cancellationCheck()
         val app = ApplicationManager.getApplication()
         val presentationHolder = AtomicReference<InspectionModelExtraction>()
         val presentationTask = Runnable {
+            cancellationCheck()
             presentationHolder.set(
                 app.runReadAction<InspectionModelExtraction, Exception> {
-                    extractProblemsFromContext(globalContext, project, targetToolShortNames)
+                    extractProblemsFromContext(globalContext, project, targetToolShortNames, cancellationCheck)
                 }
             )
         }
@@ -5228,6 +5400,7 @@ class InspectionHandler : HttpRequestHandler() {
         } else {
             app.invokeAndWait(presentationTask)
         }
+        cancellationCheck()
         val presentationExtraction = presentationHolder.get() ?: return InspectionModelExtraction(
             problems = emptyList(),
             problemDescriptorCount = 0,
@@ -5253,6 +5426,7 @@ class InspectionHandler : HttpRequestHandler() {
             project = project,
             targetToolShortNames = targetToolShortNames,
             fallbackScopeFiles = fallbackScopeFiles,
+            cancellationCheck = cancellationCheck,
         )
     }
 
@@ -5261,7 +5435,9 @@ class InspectionHandler : HttpRequestHandler() {
         globalContext: com.intellij.codeInspection.ex.GlobalInspectionContextImpl,
         project: Project,
         targetToolShortNames: Set<String> = emptySet(),
+        cancellationCheck: () -> Unit = { ProgressManager.checkCanceled() },
     ): InspectionModelExtraction {
+        cancellationCheck()
         val problems = mutableListOf<Map<String, Any>>()
         val seen = LinkedHashSet<String>()
         val targetToolStates = linkedMapOf<String, MutableMap<String, Any?>>()
@@ -5284,12 +5460,14 @@ class InspectionHandler : HttpRequestHandler() {
         }
 
         for (toolGroup in tools) {
+            cancellationCheck()
             val scopeStates = try {
                 toolGroup.tools
             } catch (_: Exception) {
                 emptyList()
             }
             for (state in scopeStates) {
+                cancellationCheck()
                 val stateEnabled = try {
                     state.isEnabled
                 } catch (_: Exception) {
@@ -5335,6 +5513,7 @@ class InspectionHandler : HttpRequestHandler() {
                     continue
                 }
 
+                cancellationCheck()
                 try {
                     presentation.updateContent()
                 } catch (e: Exception) {
@@ -5362,6 +5541,7 @@ class InspectionHandler : HttpRequestHandler() {
                 }
 
                 for (descriptor in descriptors) {
+                    cancellationCheck()
                     val map = buildProblemMap(descriptor, wrapper, project) ?: continue
                     val key = listOf(
                         map["severity"],
@@ -5379,6 +5559,7 @@ class InspectionHandler : HttpRequestHandler() {
         }
 
         for (shortName in targetToolShortNames) {
+            cancellationCheck()
             targetToolStates.getOrPut(shortName) {
                 linkedMapOf(
                     "short_name" to shortName,
@@ -5406,7 +5587,9 @@ class InspectionHandler : HttpRequestHandler() {
         project: Project,
         targetToolShortNames: Set<String>,
         fallbackScopeFiles: List<com.intellij.psi.PsiFile>,
+        cancellationCheck: () -> Unit = { ProgressManager.checkCanceled() },
     ): InspectionModelExtraction {
+        cancellationCheck()
         val targetStates = base.targetToolStates.associate { state ->
             val mutableState = state.toMutableMap()
             mutableState["short_name"]?.toString().orEmpty() to mutableState
@@ -5415,6 +5598,7 @@ class InspectionHandler : HttpRequestHandler() {
         val fallbackProblems = mutableListOf<Map<String, Any>>()
         var fallbackDescriptorCount = 0
         for (toolShortName in targetToolShortNames) {
+            cancellationCheck()
             val state = targetStates.getOrPut(toolShortName) {
                 linkedMapOf("short_name" to toolShortName, "present" to false, "enabled" to false)
             }
@@ -5425,6 +5609,7 @@ class InspectionHandler : HttpRequestHandler() {
                     toolShortName = toolShortName,
                     fallbackScopeFiles = fallbackScopeFiles,
                     targetToolState = state,
+                    cancellationCheck = cancellationCheck,
                 )
             } else {
                 emptyList()
@@ -5432,6 +5617,7 @@ class InspectionHandler : HttpRequestHandler() {
             state["inspection_engine_descriptor_count"] = fallbackDescriptors.size
             fallbackDescriptorCount += fallbackDescriptors.size
             for ((descriptor, wrapper) in fallbackDescriptors) {
+                cancellationCheck()
                 val map = buildProblemMap(descriptor, wrapper, project) ?: continue
                 if (baseKeys.add(problemKey(map))) {
                     fallbackProblems += map
@@ -5482,12 +5668,15 @@ class InspectionHandler : HttpRequestHandler() {
         toolShortName: String,
         fallbackScopeFiles: List<com.intellij.psi.PsiFile>,
         targetToolState: MutableMap<String, Any?>,
+        cancellationCheck: () -> Unit = { ProgressManager.checkCanceled() },
     ): List<Pair<com.intellij.codeInspection.ProblemDescriptor, com.intellij.codeInspection.ex.InspectionToolWrapper<*, *>>> {
+        cancellationCheck()
         val descriptors = mutableListOf<Pair<com.intellij.codeInspection.ProblemDescriptor, com.intellij.codeInspection.ex.InspectionToolWrapper<*, *>>>()
         val errors = mutableListOf<String>()
         targetToolState["inspection_engine_file_count"] = fallbackScopeFiles.size
         ApplicationManager.getApplication().runReadAction<Unit, Exception> {
             for (psiFile in fallbackScopeFiles) {
+                cancellationCheck()
                 try {
                     val batchWrapper = com.intellij.codeInspection.ex.LocalInspectionToolWrapper.findTool2RunInBatch(
                         project,
@@ -5500,6 +5689,7 @@ class InspectionHandler : HttpRequestHandler() {
                     }
                     targetToolState["inspection_engine_wrapper_class"] = batchWrapper.javaClass.name
                     descriptors += InspectionEngine.runInspectionOnFile(psiFile, batchWrapper, globalContext).map { it to batchWrapper }
+                    cancellationCheck()
                 } catch (e: Exception) {
                     rethrowIfCanceled(e)
                     errors += formatModelUnreadableReason("inspection_engine:${psiFile.virtualFile?.path}", e)

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -21,6 +21,7 @@ import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.project.ex.ProjectManagerEx
+import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
@@ -295,6 +296,7 @@ internal data class InspectionProjectLease(
     val basePath: String?,
     val sessionId: String,
     val claimedAtMs: Long,
+    val project: Project,
 )
 
 internal fun parseGitStatusPorcelainZ(output: String): Pair<Set<String>, Set<String>> {
@@ -958,6 +960,7 @@ class InspectionHandler : HttpRequestHandler() {
     internal data class LifecycleOpenOwnership(
         val leaseId: String,
         val targetKey: String,
+        val project: Project,
     )
 
     private data class LifecycleCloseAttempt(
@@ -1469,9 +1472,16 @@ class InspectionHandler : HttpRequestHandler() {
                     val projectName = extractProjectSelector(urlDecoder, request)
                     val timeoutMs = parameters["timeout_ms"]?.firstOrNull()?.toLongOrNull()
                     val pollMs = parameters["poll_ms"]?.firstOrNull()?.toLongOrNull()
+                    val expectedRunId = firstParameter(parameters, "inspection_run_id")?.let { rawRunId ->
+                        rawRunId.toLongOrNull()?.takeIf { it > 0 }
+                            ?: throw BadRequestException(
+                                "inspection_run_id",
+                                "Parameter 'inspection_run_id' must be a positive integer.",
+                            )
+                    }
                     ApplicationManager.getApplication().executeOnPooledThread {
                         try {
-                            val result = waitForInspection(projectName, timeoutMs, pollMs)
+                            val result = waitForInspection(projectName, timeoutMs, pollMs, expectedRunId)
                             sendJsonResponse(context, result)
                         } catch (error: BadRequestException) {
                             sendJsonResponse(context, formatBadRequest(error), HttpResponseStatus.BAD_REQUEST)
@@ -1717,9 +1727,13 @@ class InspectionHandler : HttpRequestHandler() {
 
         val requestedLeaseId = firstParameter(parameters, "lease_id")
         val ownership = lifecycleOpenOwnershipByProjectInstance[actualProjectInstanceId]
+        val exactOwnership = ownership?.takeIf { it.project === resolved.project }
+        if (ownership != null && exactOwnership == null) {
+            lifecycleOpenOwnershipByProjectInstance.remove(actualProjectInstanceId, ownership)
+        }
         val ownershipProven = requestedLeaseId != null &&
-            requestedLeaseId == ownership?.leaseId &&
-            lifecycleOpenKeys(resolved.project).contains(ownership.targetKey)
+            requestedLeaseId == exactOwnership?.leaseId &&
+            lifecycleOpenKeys(resolved.project).contains(exactOwnership.targetKey)
         if (!ownershipProven) {
             return formatJsonManually(
                 mapOf(
@@ -1727,7 +1741,8 @@ class InspectionHandler : HttpRequestHandler() {
                     "ownership_proven" to false,
                     "reason" to when {
                         ownership == null -> "project_preexisted"
-                        requestedLeaseId != ownership.leaseId -> "lease_mismatch"
+                        exactOwnership == null -> "project_instance_reused"
+                        requestedLeaseId != exactOwnership.leaseId -> "lease_mismatch"
                         else -> "route_mismatch"
                     },
                     "lease_id" to requestedLeaseId,
@@ -1749,6 +1764,7 @@ class InspectionHandler : HttpRequestHandler() {
             basePath = resolved.projectIdentity["base_path"] as? String,
             sessionId = InspectionIdeSession.sessionId,
             claimedAtMs = System.currentTimeMillis(),
+            project = resolved.project,
         )
         leasesByProjectInstance[actualProjectInstanceId] = lease
 
@@ -1845,10 +1861,7 @@ class InspectionHandler : HttpRequestHandler() {
                         opened != null &&
                         initializedProject.get() === opened
                     ) {
-                        lifecycleOpenOwnershipByProjectInstance[projectInstanceId(opened)] = LifecycleOpenOwnership(
-                            leaseId = requestedLeaseId,
-                            targetKey = target.key,
-                        )
+                        registerLifecycleOpenOwnership(opened, requestedLeaseId, target.key)
                     }
                     if (opened != null) {
                         keepOpeningGuard = true
@@ -2070,6 +2083,22 @@ class InspectionHandler : HttpRequestHandler() {
             .toSet()
     }
 
+    private fun registerLifecycleOpenOwnership(project: Project, leaseId: String, targetKey: String) {
+        val instanceId = projectInstanceId(project)
+        val ownership = LifecycleOpenOwnership(
+            leaseId = leaseId,
+            targetKey = targetKey,
+            project = project,
+        )
+        lifecycleOpenOwnershipByProjectInstance[instanceId] = ownership
+        Disposer.register(project) {
+            lifecycleOpenOwnershipByProjectInstance.remove(instanceId, ownership)
+            leasesByProjectInstance[instanceId]?.takeIf { it.project === project }?.let { lease ->
+                leasesByProjectInstance.remove(instanceId, lease)
+            }
+        }
+    }
+
     private fun processLifecycleCloseRequest(
         parameters: Map<String, List<String>>,
         context: ChannelHandlerContext,
@@ -2185,14 +2214,39 @@ class InspectionHandler : HttpRequestHandler() {
                 lifecycleOpenOwnershipByProjectInstance.remove(expectedProjectInstanceId)
                 return lifecycleCloseSkipped("route_missing", "Claimed project is no longer open; cleanup is already complete.")
             }
+        if (project !== lease.project) {
+            lifecycleOpenOwnershipByProjectInstance.remove(expectedProjectInstanceId)
+            return lifecycleCloseSkipped(
+                "project_instance_reused",
+                "Claimed project instance no longer refers to the exact project that was opened by this lease.",
+                HttpResponseStatus.CONFLICT,
+            )
+        }
         if (projectKey(project) != lease.projectKey) {
             return lifecycleCloseSkipped("project_mismatch", "Claimed project key no longer matches the lifecycle claim.", HttpResponseStatus.CONFLICT)
+        }
+        if (isInspectionInProgress(project)) {
+            leasesByProjectInstance.putIfAbsent(expectedProjectInstanceId, lease)
+            val runState = inspectionRunStatesByProject[projectKey(project)]
+            return lifecycleCloseSkipped(
+                "inspection_in_progress",
+                "An inspection is still running for the claimed project; leaving it open for a later cleanup retry.",
+                HttpResponseStatus.CONFLICT,
+                details = mapOf(
+                    "project_instance_id" to expectedProjectInstanceId,
+                    "project_key" to lease.projectKey,
+                    "lease_id" to lease.leaseId,
+                    "inspection_run_id" to runState?.runId,
+                    "inspection_in_progress" to true,
+                ),
+            )
         }
 
         val closeAttempts = closeClaimedProject(project, expectedProjectInstanceId)
         val closed = closeAttempts.any { attempt -> attempt.closedVerified }
 
         if (!closed) {
+            leasesByProjectInstance.putIfAbsent(expectedProjectInstanceId, lease)
             return lifecycleCloseSkipped(
                 "close_failed",
                 "JetBrains IDE declined or failed to close the claimed project.",
@@ -2283,6 +2337,7 @@ class InspectionHandler : HttpRequestHandler() {
         message: String,
         status: HttpResponseStatus = HttpResponseStatus.OK,
         closeAttempts: List<LifecycleCloseAttempt> = emptyList(),
+        details: Map<String, Any?> = emptyMap(),
     ): Pair<Map<String, Any?>, HttpResponseStatus> {
         return mapOf(
             "status" to "skipped",
@@ -2291,7 +2346,7 @@ class InspectionHandler : HttpRequestHandler() {
             "message" to message,
             "session_id" to InspectionIdeSession.sessionId,
             "close_attempts" to closeAttemptPayload(closeAttempts).takeIf { it.isNotEmpty() },
-        ) to status
+        ) + details to status
     }
 
     private fun findOpenProjectByInstanceId(projectInstanceId: String): Project? {
@@ -3113,7 +3168,17 @@ class InspectionHandler : HttpRequestHandler() {
         return resolveActiveEditorFile(project)?.path?.let(::normalizeFileSystemPath)
     }
 
+    @Suppress("unused")
     private fun waitForInspection(projectName: String?, timeoutMsRaw: Long?, pollMsRaw: Long?): String {
+        return waitForInspection(projectName, timeoutMsRaw, pollMsRaw, null)
+    }
+
+    private fun waitForInspection(
+        projectName: String?,
+        timeoutMsRaw: Long?,
+        pollMsRaw: Long?,
+        expectedRunId: Long?,
+    ): String {
         val timeoutMs = (timeoutMsRaw ?: 180000L).coerceIn(1000L, 300000L)
         val pollMs = (pollMsRaw ?: 1000L).coerceIn(200L, 5000L).coerceAtMost(timeoutMs)
         val start = System.currentTimeMillis()
@@ -3155,6 +3220,9 @@ class InspectionHandler : HttpRequestHandler() {
         var status = ApplicationManager.getApplication().runReadAction<MutableMap<String, Any>, Exception> { buildInspectionStatus(activeProject) }
 
         while (true) {
+            if (expectedRunId != null && inspectionRunId(status) != expectedRunId) {
+                return formatWaitRunChanged(status, start, timeoutMs, pollMs, expectedRunId)
+            }
             val hasResults = status["has_inspection_results"] as? Boolean ?: false
             val inspectionTriggered = status["inspection_triggered"] as? Boolean ?: false
             val cleanInspection = status["clean_inspection"] as? Boolean ?: false
@@ -3275,6 +3343,31 @@ class InspectionHandler : HttpRequestHandler() {
 
             status = ApplicationManager.getApplication().runReadAction<MutableMap<String, Any>, Exception> { buildInspectionStatus(activeProject) }
         }
+    }
+
+    private fun inspectionRunId(status: Map<String, Any>): Long? {
+        return (status["inspection_run_id"] as? Number)?.toLong()
+    }
+
+    private fun formatWaitRunChanged(
+        status: MutableMap<String, Any>,
+        startMs: Long,
+        timeoutMs: Long,
+        pollMs: Long,
+        expectedRunId: Long,
+    ): String {
+        val response = status.toMutableMap()
+        response["status"] = "run_changed"
+        response["wait_completed"] = false
+        response["timed_out"] = false
+        response["completion_reason"] = "run_changed"
+        response["expected_inspection_run_id"] = expectedRunId
+        response["wait_ms"] = System.currentTimeMillis() - startMs
+        response["timeout_ms"] = timeoutMs
+        response["poll_ms"] = pollMs
+        response["message"] = "A different inspection run replaced the run accepted by this request; no cancellation or cleanup authority is implied."
+        addStatusInspectionVerdict(response)
+        return formatJsonManually(response)
     }
 
     private fun formatWaitResponse(

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -24,6 +24,7 @@ import com.intellij.openapi.project.ex.ProjectManagerEx
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.openapi.wm.IdeFocusManager
 import com.intellij.openapi.wm.WindowManager
 import com.intellij.psi.PsiDocumentManager
@@ -110,6 +111,10 @@ internal enum class CaptureIncompleteReason(val apiValue: String) {
 internal data class InspectionProjectStateSnapshot(
     val psiModificationCount: Long,
     val unsavedProjectDocuments: Int,
+)
+
+internal data class InspectionProjectContentEpoch(
+    val vfsModificationCount: Long,
 )
 
 internal data class InspectionCaptureScope(
@@ -240,6 +245,15 @@ internal fun buildInspectionCaptureSnapshot(input: InspectionCaptureSnapshotInpu
 private data class CurrentRunPsiChurnReconciliation(
     val snapshot: InspectionResultsSnapshot?,
     val reconciled: Boolean,
+)
+
+private data class InspectionProblemIdentity(
+    val severity: String?,
+    val inspectionType: String?,
+    val file: String?,
+    val line: Long?,
+    val column: Long?,
+    val description: String?,
 )
 
 private data class InspectionVerdict(
@@ -996,6 +1010,9 @@ class InspectionHandler : HttpRequestHandler() {
         ProgressWindow(false, true, project).apply {
             setDelayInMillis(Int.MAX_VALUE)
         }
+    }
+    internal var projectContentEpochProvider: () -> InspectionProjectContentEpoch = {
+        captureProjectContentEpoch()
     }
     internal var lifecycleCloseExecutor: (Runnable) -> Unit = { task ->
         ApplicationManager.getApplication().executeOnPooledThread(task)
@@ -3200,11 +3217,16 @@ class InspectionHandler : HttpRequestHandler() {
         }
 
         val liveExtraction = try {
-            enhancedTreeExtractorFactory().extractAllProblemsWithStatus(project)
+            ApplicationManager.getApplication().runReadAction<ProblemExtractionResult, Exception> {
+                enhancedTreeExtractorFactory().extractAllProblemsWithStatus(project)
+            }
         } catch (_: Exception) {
             return CurrentRunPsiChurnReconciliation(snapshot, false)
         }
-        if (liveExtraction.source == ProblemExtractionSource.PROBLEMS_FALLBACK) {
+        if (
+            !liveExtraction.succeeded ||
+            liveExtraction.source != ProblemExtractionSource.INSPECTION_RESULTS
+        ) {
             return CurrentRunPsiChurnReconciliation(snapshot, false)
         }
         val liveProblems = liveExtraction.problems
@@ -3222,12 +3244,73 @@ class InspectionHandler : HttpRequestHandler() {
             )
         }
         val compatibleLiveProblems = filterProblemsForScope(liveProblems, captureScopeMatcher)
-        val compatibleSnapshotProblems = filterProblemsForScope(snapshot.problems, captureScopeMatcher)
-        if (compatibleLiveProblems != compatibleSnapshotProblems) {
+        if (inspectionProblemIdentityCounts(compatibleLiveProblems) != inspectionProblemIdentityCounts(snapshot.problems)) {
             return CurrentRunPsiChurnReconciliation(snapshot, false)
         }
 
         return CurrentRunPsiChurnReconciliation(snapshot, true)
+    }
+
+    private fun publishInspectionSnapshot(
+        project: Project,
+        runId: Long,
+        snapshot: InspectionResultsSnapshot,
+        captureEndState: InspectionProjectStateSnapshot,
+        projectStateChangedDuringCapture: Boolean,
+        inspectionInputContentEpoch: InspectionProjectContentEpoch?,
+    ) {
+        val key = projectKey(project)
+        if (!isCurrentInspectionRun(key, runId)) {
+            return
+        }
+
+        val snapshotToPublish = if (
+            projectStateChangedDuringCapture &&
+            isWholeProjectCaptureScope(snapshot.captureScope) &&
+            captureEndState.unsavedProjectDocuments == 0 &&
+            inspectionInputContentEpoch != null &&
+            captureProjectState(project) == captureEndState
+        ) {
+            val reconciliation = reconcileCurrentRunPsiChurn(project, snapshot)
+            if (
+                reconciliation.reconciled &&
+                projectContentEpochProvider() == inspectionInputContentEpoch &&
+                captureProjectState(project) == captureEndState
+            ) {
+                snapshot.copy(projectState = captureEndState)
+            } else {
+                snapshot
+            }
+        } else {
+            snapshot
+        }
+
+        if (isCurrentInspectionRun(key, runId)) {
+            resultsStore.setSnapshot(key, snapshotToPublish)
+        }
+    }
+
+    private fun isWholeProjectCaptureScope(captureScope: InspectionCaptureScope?): Boolean {
+        val scope = captureScope?.scopeParam?.trim()?.lowercase().orEmpty().ifBlank { "whole_project" }
+        return scope == "whole_project" || scope == "all"
+    }
+
+    private fun inspectionProblemIdentityCounts(
+        problems: List<Map<String, Any>>,
+    ): Map<InspectionProblemIdentity, Int> {
+        return problems
+            .map { problem ->
+                InspectionProblemIdentity(
+                    severity = problem["severity"] as? String,
+                    inspectionType = problem["inspectionType"] as? String,
+                    file = normalizeFileSystemPath(problem["file"] as? String),
+                    line = (problem["line"] as? Number)?.toLong(),
+                    column = (problem["column"] as? Number)?.toLong(),
+                    description = problem["description"] as? String,
+                )
+            }
+            .groupingBy { identity -> identity }
+            .eachCount()
     }
 
     private fun SnapshotStaleness.asUnverifiedCurrentRunPsiChurn(): SnapshotStaleness {
@@ -3722,6 +3805,11 @@ class InspectionHandler : HttpRequestHandler() {
             waitForSmartMode(project)
             checkInspectionRunCancellation(key, runId)
             val inspectionInputState = captureStableProjectState(project)
+            val inspectionInputContentEpoch = if (isWholeProjectCaptureScope(captureScope)) {
+                projectContentEpochProvider()
+            } else {
+                null
+            }
             val dumbAfterSync = DumbService.getInstance(project).isDumb
 
             val profileManager = com.intellij.profile.codeInspection.InspectionProjectProfileManager.getInstance(project)
@@ -4500,9 +4588,14 @@ class InspectionHandler : HttpRequestHandler() {
                                     "lastViewObservation=${lastViewObservation?.let { "isUpdating=${it.isUpdating}, hasProblems=${it.hasProblems}, rootChildCount=${it.rootChildCount}, updateStateReadable=${it.updateStateReadable}, problemStateReadable=${it.problemStateReadable}" } ?: "null"}"
                             )
                         }
-                            if (isCurrentInspectionRun(key, runId)) {
-                                resultsStore.setSnapshot(key, snapshot)
-                            }
+                        publishInspectionSnapshot(
+                            project = project,
+                            runId = runId,
+                            snapshot = snapshot,
+                            captureEndState = captureEndState,
+                            projectStateChangedDuringCapture = projectStateChangedDuringCapture,
+                            inspectionInputContentEpoch = inspectionInputContentEpoch,
+                        )
                         } catch (e: com.intellij.openapi.progress.ProcessCanceledException) {
                             throw e
                         } catch (error: Exception) {
@@ -4731,6 +4824,12 @@ class InspectionHandler : HttpRequestHandler() {
         return InspectionProjectStateSnapshot(
             psiModificationCount = PsiModificationTracker.getInstance(project).modificationCount,
             unsavedProjectDocuments = countProjectUnsavedDocuments(project)
+        )
+    }
+
+    private fun captureProjectContentEpoch(): InspectionProjectContentEpoch {
+        return InspectionProjectContentEpoch(
+            vfsModificationCount = VirtualFileManager.getInstance().modificationCount,
         )
     }
 

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -2608,6 +2608,30 @@ class InspectionHandler : HttpRequestHandler() {
             }
             if (
                 expectedInspectionRunId != null &&
+                runState?.inProgress == true &&
+                snapshot?.runId != null &&
+                snapshot.runId != expectedInspectionRunId
+            ) {
+                val response = mutableMapOf<String, Any?>(
+                    "status" to "inspection_in_progress",
+                    "project" to project.name,
+                    "project_key" to key,
+                    "session_id" to InspectionIdeSession.sessionId,
+                    "route" to routeMetadata(project),
+                    "inspection_in_progress" to true,
+                    "inspection_run_id" to runState.runId,
+                    "snapshot_run_id" to snapshot.runId,
+                    "message" to "The accepted inspection is still running; the available snapshot belongs to an earlier run.",
+                    "total_problems" to 0,
+                    "problems_shown" to 0,
+                    "problems" to emptyList<Map<String, Any>>(),
+                )
+                addInspectionVerdict(response)
+                return@run formatJsonManually(response.filterValues { it != null })
+            }
+            if (
+                expectedInspectionRunId != null &&
+                runState?.inProgress != true &&
                 snapshot?.runId != null &&
                 snapshot.runId != expectedInspectionRunId
             ) {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.shiny.inspection.api</id>
     <name>Inspection API</name>
-    <version>1.13.16</version>
+    <version>1.13.17</version>
     <vendor email="info@shinycomputers.com" url="https://github.com/cbusillo/jetbrains-inspection-api">Shiny Computers (Chris Busillo)</vendor>
     <resource-bundle>messages.InspectionApiBundle</resource-bundle>
     

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -126,6 +126,10 @@ class InspectionHandlerTest {
             disassembly.contains("runProcessWithProgressSynchronously"),
             "Agent-triggered inspections must not block lifecycle requests behind a modal progress task.",
         )
+        assertTrue(
+            disassembly.contains("com/intellij/openapi/progress/util/ProgressWindow"),
+            "JetBrains global inspections require a non-modal ProgressWindow indicator.",
+        )
     }
     
     @BeforeEach
@@ -134,6 +138,7 @@ class InspectionHandlerTest {
         handler.trustProjectPath = {}
         handler.inspectionRunExpirationMs = 300000L
         handler.inspectionProcessRunner = { task, _ -> task.run() }
+        handler.inspectionIndicatorFactory = { mockk(relaxed = true) }
         handler.lifecycleCloseExecutor = { task -> task.run() }
         enhancedTreeExtractorFactory = { EnhancedTreeExtractor() }
         
@@ -765,6 +770,22 @@ class InspectionHandlerTest {
             queuedTasks.single().run()
         }
         verify(exactly = 0) { mockInspectionManager.createNewGlobalContext() }
+    }
+
+    @Test
+    fun `test capture failure diagnostic preserves exception details`() {
+        val method = InspectionHandler::class.java.getDeclaredMethod(
+            "captureFailureDiagnostic",
+            Exception::class.java,
+        )
+        method.isAccessible = true
+
+        @Suppress("UNCHECKED_CAST")
+        val diagnostic = method.invoke(handler, IllegalStateException("capture exploded")) as Map<String, Any>
+
+        assertEquals("helper_plugin_error", diagnostic["exit_reason"])
+        assertEquals(IllegalStateException::class.java.name, diagnostic["exception_type"])
+        assertEquals("capture exploded", diagnostic["exception_message"])
     }
 
     @Test

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -943,6 +943,7 @@ class InspectionHandlerTest {
         every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
         runPooledTasksInline()
         mockInspectionPrerequisites(mockProject)
+        InspectionResultsStore.clear(projectKey(mockProject))
         setInspectionRunState(
             projectKey(mockProject),
             InspectionRunState(
@@ -972,6 +973,7 @@ class InspectionHandlerTest {
         runPooledTasksInline()
         mockInspectionPrerequisites(mockProject)
         val key = projectKey(mockProject)
+        InspectionResultsStore.clear(key)
         setInspectionRunState(
             key,
             InspectionRunState(
@@ -1011,6 +1013,7 @@ class InspectionHandlerTest {
         every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
         runPooledTasksInline()
         mockInspectionPrerequisites(mockProject)
+        InspectionResultsStore.clear(projectKey(mockProject))
         setInspectionRunState(
             projectKey(mockProject),
             InspectionRunState(
@@ -1057,6 +1060,56 @@ class InspectionHandlerTest {
         assertTrue(body.contains("\"status\": \"run_changed\""))
         assertTrue(body.contains("\"expected_inspection_run_id\": 7"))
         assertTrue(body.contains("\"inspection_run_id\": 8"))
+    }
+
+    @Test
+    fun `test problems endpoint keeps active run while prior snapshot remains`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        runPooledTasksInline()
+        mockInspectionPrerequisites(mockProject)
+        val key = projectKey(mockProject)
+        InspectionResultsStore.clear(key)
+        setInspectionRunState(
+            key,
+            InspectionRunState(
+                runId = 7L,
+                triggerTimeMs = System.currentTimeMillis(),
+                inProgress = true,
+                captureScope = InspectionCaptureScope(scopeParam = "whole_project"),
+            ),
+        )
+        InspectionResultsStore.setSnapshot(
+            key,
+            InspectionResultsSnapshot(
+                problems = listOf(
+                    mapOf(
+                        "file" to "/tmp/TestProject/src/Old.kt",
+                        "severity" to "warning",
+                        "description" to "old run finding",
+                    ),
+                ),
+                timestamp = System.currentTimeMillis() - 10_000,
+                projectState = InspectionProjectStateSnapshot(psiModificationCount = 11L, unsavedProjectDocuments = 0),
+                outcome = InspectionSnapshotOutcome.PROBLEMS_FOUND,
+                source = "inspection_view",
+                runId = 6L,
+                captureScope = InspectionCaptureScope(scopeParam = "whole_project"),
+            ),
+        )
+
+        val response = processGetRequest(
+            "/api/inspection/problems?severity=all&inspection_run_id=7"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"status\": \"inspection_in_progress\""))
+        assertTrue(body.contains("\"inspection_in_progress\": true"))
+        assertTrue(body.contains("\"inspection_run_id\": 7"))
+        assertTrue(body.contains("\"snapshot_run_id\": 6"))
+        assertFalse(body.contains("old run finding"))
+        assertFalse(body.contains("\"status\": \"run_changed\""))
     }
 
     @Test

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -49,6 +49,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 import javax.swing.JFrame
 import javax.swing.JPanel
@@ -195,6 +196,7 @@ class InspectionHandlerTest {
         
         mockkStatic(VirtualFileManager::class)
         every { VirtualFileManager.getInstance() } returns mockVirtualFileManager
+        every { mockVirtualFileManager.modificationCount } returns 0L
         
         every { InspectionManager.getInstance(mockProject) } returns mockInspectionManager
         every { mockInspectionManager.createNewGlobalContext() } returns mockGlobalContext
@@ -645,6 +647,284 @@ class InspectionHandlerTest {
         assertTrue(body.contains("\"cached_total_problems\": 1"))
         assertFalse(body.contains("included problem"))
         assertFalse(body.contains("excluded problem"))
+    }
+
+    @Test
+    fun `test final publication reconciles verified psi churn without absorbing later edits`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        mockInspectionPrerequisites(mockProject)
+        val psiModificationCount = AtomicLong(11L)
+        every { PsiModificationTracker.getInstance(mockProject).modificationCount } answers {
+            psiModificationCount.get()
+        }
+        val key = projectKey(mockProject)
+        InspectionResultsStore.clear(key)
+        val inputContentEpoch = projectContentEpoch()
+        handler.projectContentEpochProvider = { inputContentEpoch }
+        val snapshotProblems = listOf(
+            mapOf(
+                "file" to "/tmp/TestProject/src/Included.kt",
+                "line" to 4,
+                "column" to 7,
+                "severity" to "warning",
+                "inspectionType" to "CurrentRunInspection",
+                "description" to "current run finding",
+                "source" to "inspection_context",
+            ),
+        )
+        val liveProblems = snapshotProblems.map { problem ->
+            problem + mapOf(
+                "source" to "enhanced_tree_extractor",
+                "locationKnown" to true,
+            )
+        }
+        val extractionCount = AtomicInteger()
+        val extractor = mockk<EnhancedTreeExtractor>()
+        every { extractor.extractAllProblemsWithStatus(mockProject) } answers {
+            if (extractionCount.getAndIncrement() == 0) {
+                assertNull(InspectionResultsStore.getSnapshot(key))
+            }
+            ProblemExtractionResult(
+                problems = liveProblems,
+                succeeded = true,
+                source = ProblemExtractionSource.INSPECTION_RESULTS,
+            )
+        }
+        enhancedTreeExtractorFactory = { extractor }
+        setInspectionRunState(
+            key,
+            InspectionRunState(runId = 1L, triggerTimeMs = System.currentTimeMillis(), inProgress = true),
+        )
+        val snapshot = InspectionResultsSnapshot(
+            problems = snapshotProblems,
+            timestamp = System.currentTimeMillis(),
+            projectState = InspectionProjectStateSnapshot(psiModificationCount = 10L, unsavedProjectDocuments = 0),
+            outcome = InspectionSnapshotOutcome.PROBLEMS_FOUND,
+            source = "global_context",
+            captureScope = InspectionCaptureScope(scopeParam = "whole_project"),
+            runId = 1L,
+        )
+
+        publishInspectionSnapshot(
+            runId = 1L,
+            snapshot = snapshot,
+            captureEndState = InspectionProjectStateSnapshot(psiModificationCount = 11L, unsavedProjectDocuments = 0),
+            projectStateChangedDuringCapture = true,
+            inspectionInputContentEpoch = inputContentEpoch,
+        )
+        val reconciledSnapshot = requireNotNull(InspectionResultsStore.getSnapshot(key))
+        verify(exactly = 1) {
+            mockApplication.runReadAction(any<ThrowableComputable<Any, Exception>>())
+        }
+        setInspectionRunState(
+            key,
+            InspectionRunState(runId = 1L, triggerTimeMs = System.currentTimeMillis(), inProgress = false),
+        )
+        val completedStatus = buildInspectionStatus()
+        psiModificationCount.set(12L)
+        val editedStatus = buildInspectionStatus()
+
+        assertEquals(11L, reconciledSnapshot.projectState.psiModificationCount)
+        assertEquals(false, completedStatus["results_may_be_stale"])
+        assertEquals(true, completedStatus["has_inspection_results"])
+        assertEquals(true, editedStatus["results_may_be_stale"])
+        assertEquals("project_changed_since_inspection", editedStatus["snapshot_change_kind"])
+    }
+
+    @Test
+    fun `test final publication keeps fail closed baseline for unsaved capture state`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        mockInspectionPrerequisites(mockProject)
+        val key = projectKey(mockProject)
+        InspectionResultsStore.clear(key)
+        val inputContentEpoch = projectContentEpoch()
+        handler.projectContentEpochProvider = { inputContentEpoch }
+        val snapshotProblems = listOf(
+            mapOf(
+                "file" to "/tmp/TestProject/src/Included.kt",
+                "severity" to "warning",
+                "description" to "current run finding",
+            ),
+        )
+        mockExtractor(snapshotProblems)
+        setInspectionRunState(
+            key,
+            InspectionRunState(runId = 1L, triggerTimeMs = System.currentTimeMillis(), inProgress = true),
+        )
+        val snapshot = InspectionResultsSnapshot(
+            problems = snapshotProblems,
+            timestamp = System.currentTimeMillis(),
+            projectState = InspectionProjectStateSnapshot(psiModificationCount = 10L, unsavedProjectDocuments = 0),
+            outcome = InspectionSnapshotOutcome.PROBLEMS_FOUND,
+            source = "global_context",
+            captureScope = InspectionCaptureScope(scopeParam = "whole_project"),
+            runId = 1L,
+        )
+
+        publishInspectionSnapshot(
+            runId = 1L,
+            snapshot = snapshot,
+            captureEndState = InspectionProjectStateSnapshot(psiModificationCount = 11L, unsavedProjectDocuments = 1),
+            projectStateChangedDuringCapture = true,
+            inspectionInputContentEpoch = inputContentEpoch,
+        )
+        val publishedSnapshot = requireNotNull(InspectionResultsStore.getSnapshot(key))
+        setInspectionRunState(
+            key,
+            InspectionRunState(runId = 1L, triggerTimeMs = System.currentTimeMillis(), inProgress = false),
+        )
+        val completedStatus = buildInspectionStatus()
+
+        assertEquals(10L, publishedSnapshot.projectState.psiModificationCount)
+        assertEquals(true, completedStatus["results_may_be_stale"])
+        assertEquals("project_changed_since_inspection", completedStatus["snapshot_change_kind"])
+    }
+
+    @Test
+    fun `test final publication rejects saved content changes during inspection`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        mockInspectionPrerequisites(mockProject)
+        val key = projectKey(mockProject)
+        InspectionResultsStore.clear(key)
+        val inputContentEpoch = projectContentEpoch(vfsModificationCount = 1L)
+        handler.projectContentEpochProvider = { projectContentEpoch(vfsModificationCount = 2L) }
+        val snapshotProblems = listOf(
+            mapOf(
+                "file" to "/tmp/TestProject/src/Included.kt",
+                "severity" to "warning",
+                "description" to "current run finding",
+            ),
+        )
+        mockExtractor(snapshotProblems)
+        setInspectionRunState(
+            key,
+            InspectionRunState(runId = 1L, triggerTimeMs = System.currentTimeMillis(), inProgress = true),
+        )
+        val snapshot = InspectionResultsSnapshot(
+            problems = snapshotProblems,
+            timestamp = System.currentTimeMillis(),
+            projectState = InspectionProjectStateSnapshot(psiModificationCount = 10L, unsavedProjectDocuments = 0),
+            outcome = InspectionSnapshotOutcome.PROBLEMS_FOUND,
+            source = "global_context",
+            captureScope = InspectionCaptureScope(scopeParam = "whole_project"),
+            runId = 1L,
+        )
+
+        publishInspectionSnapshot(
+            runId = 1L,
+            snapshot = snapshot,
+            captureEndState = InspectionProjectStateSnapshot(psiModificationCount = 11L, unsavedProjectDocuments = 0),
+            projectStateChangedDuringCapture = true,
+            inspectionInputContentEpoch = inputContentEpoch,
+        )
+        val publishedSnapshot = requireNotNull(InspectionResultsStore.getSnapshot(key))
+        setInspectionRunState(
+            key,
+            InspectionRunState(runId = 1L, triggerTimeMs = System.currentTimeMillis(), inProgress = false),
+        )
+        val completedStatus = buildInspectionStatus()
+
+        assertEquals(10L, publishedSnapshot.projectState.psiModificationCount)
+        assertEquals(true, completedStatus["results_may_be_stale"])
+    }
+
+    @Test
+    fun `test final publication does not promote a narrow capture scope`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        mockInspectionPrerequisites(mockProject)
+        val key = projectKey(mockProject)
+        InspectionResultsStore.clear(key)
+        val inputContentEpoch = projectContentEpoch()
+        handler.projectContentEpochProvider = { inputContentEpoch }
+        val snapshotProblems = listOf(
+            mapOf(
+                "file" to "/tmp/TestProject/src/Included.kt",
+                "severity" to "warning",
+                "description" to "current run finding",
+            ),
+        )
+        mockExtractor(snapshotProblems)
+        setInspectionRunState(
+            key,
+            InspectionRunState(runId = 1L, triggerTimeMs = System.currentTimeMillis(), inProgress = true),
+        )
+        val snapshot = InspectionResultsSnapshot(
+            problems = snapshotProblems,
+            timestamp = System.currentTimeMillis(),
+            projectState = InspectionProjectStateSnapshot(psiModificationCount = 10L, unsavedProjectDocuments = 0),
+            outcome = InspectionSnapshotOutcome.PROBLEMS_FOUND,
+            source = "global_context",
+            captureScope = InspectionCaptureScope(
+                scopeParam = "files",
+                files = listOf("src/Included.kt"),
+                resolvedFiles = listOf("/tmp/TestProject/src/Included.kt"),
+            ),
+            runId = 1L,
+        )
+
+        publishInspectionSnapshot(
+            runId = 1L,
+            snapshot = snapshot,
+            captureEndState = InspectionProjectStateSnapshot(psiModificationCount = 11L, unsavedProjectDocuments = 0),
+            projectStateChangedDuringCapture = true,
+            inspectionInputContentEpoch = inputContentEpoch,
+        )
+
+        assertEquals(10L, requireNotNull(InspectionResultsStore.getSnapshot(key)).projectState.psiModificationCount)
+    }
+
+    @Test
+    fun `test final publication requires authoritative live extraction`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        mockInspectionPrerequisites(mockProject)
+        val key = projectKey(mockProject)
+        InspectionResultsStore.clear(key)
+        val inputContentEpoch = projectContentEpoch()
+        handler.projectContentEpochProvider = { inputContentEpoch }
+        val extractor = mockk<EnhancedTreeExtractor>()
+        every { extractor.extractAllProblemsWithStatus(mockProject) } returns ProblemExtractionResult(
+            problems = emptyList(),
+            succeeded = false,
+            source = ProblemExtractionSource.NONE,
+        )
+        enhancedTreeExtractorFactory = { extractor }
+        setInspectionRunState(
+            key,
+            InspectionRunState(runId = 1L, triggerTimeMs = System.currentTimeMillis(), inProgress = true),
+        )
+        val snapshot = InspectionResultsSnapshot(
+            problems = emptyList(),
+            timestamp = System.currentTimeMillis(),
+            projectState = InspectionProjectStateSnapshot(psiModificationCount = 10L, unsavedProjectDocuments = 0),
+            outcome = InspectionSnapshotOutcome.CLEAN_CONFIRMED,
+            source = "inspection_view",
+            captureScope = InspectionCaptureScope(scopeParam = "whole_project"),
+            runId = 1L,
+        )
+
+        publishInspectionSnapshot(
+            runId = 1L,
+            snapshot = snapshot,
+            captureEndState = InspectionProjectStateSnapshot(psiModificationCount = 11L, unsavedProjectDocuments = 0),
+            projectStateChangedDuringCapture = true,
+            inspectionInputContentEpoch = inputContentEpoch,
+        )
+
+        assertEquals(10L, requireNotNull(InspectionResultsStore.getSnapshot(key)).projectState.psiModificationCount)
+    }
+
+    @Test
+    fun `test project content epoch reads the JetBrains VFS change counter`() {
+        every { mockVirtualFileManager.modificationCount } returns 42L
+
+        val epoch = handler.projectContentEpochProvider()
+
+        assertEquals(42L, epoch.vfsModificationCount)
     }
 
     @Test
@@ -3918,12 +4198,47 @@ class InspectionHandlerTest {
         return method.invoke(handler, mockProject) as MutableMap<String, Any>
     }
 
+    private fun publishInspectionSnapshot(
+        runId: Long,
+        snapshot: InspectionResultsSnapshot,
+        captureEndState: InspectionProjectStateSnapshot,
+        projectStateChangedDuringCapture: Boolean,
+        inspectionInputContentEpoch: InspectionProjectContentEpoch?,
+    ) {
+        val method = InspectionHandler::class.java.getDeclaredMethod(
+            "publishInspectionSnapshot",
+            Project::class.java,
+            Long::class.javaPrimitiveType,
+            InspectionResultsSnapshot::class.java,
+            InspectionProjectStateSnapshot::class.java,
+            Boolean::class.javaPrimitiveType,
+            InspectionProjectContentEpoch::class.java,
+        )
+        method.isAccessible = true
+        method.invoke(
+            handler,
+            mockProject,
+            runId,
+            snapshot,
+            captureEndState,
+            projectStateChangedDuringCapture,
+            inspectionInputContentEpoch,
+        )
+    }
+
+    private fun projectContentEpoch(vfsModificationCount: Long = 1L): InspectionProjectContentEpoch {
+        return InspectionProjectContentEpoch(
+            vfsModificationCount = vfsModificationCount,
+        )
+    }
+
     private fun mockExtractor(problems: List<Map<String, Any>>) {
         val extractor = mockk<EnhancedTreeExtractor>()
         every { extractor.extractAllProblems(mockProject) } returns problems
         every { extractor.extractAllProblemsWithStatus(mockProject) } returns ProblemExtractionResult(
             problems = problems,
             succeeded = true,
+            source = ProblemExtractionSource.INSPECTION_RESULTS,
         )
         enhancedTreeExtractorFactory = { extractor }
     }

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -948,6 +948,46 @@ class InspectionHandlerTest {
     }
 
     @Test
+    fun `test wait endpoint refuses a snapshot from an older run`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        runPooledTasksInline()
+        mockInspectionPrerequisites(mockProject)
+        val key = projectKey(mockProject)
+        setInspectionRunState(
+            key,
+            InspectionRunState(
+                runId = 7L,
+                triggerTimeMs = System.currentTimeMillis(),
+                inProgress = false,
+                captureScope = InspectionCaptureScope(scopeParam = "whole_project"),
+            ),
+        )
+        InspectionResultsStore.setSnapshot(
+            key,
+            InspectionResultsSnapshot(
+                problems = emptyList(),
+                timestamp = System.currentTimeMillis(),
+                projectState = InspectionProjectStateSnapshot(psiModificationCount = 11L, unsavedProjectDocuments = 0),
+                outcome = InspectionSnapshotOutcome.CLEAN_CONFIRMED,
+                source = "inspection_view",
+                runId = 6L,
+            ),
+        )
+
+        val response = processGetRequest(
+            "/api/inspection/wait?timeout_ms=1000&poll_ms=200&inspection_run_id=7"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"status\": \"run_changed\""))
+        assertTrue(body.contains("\"expected_inspection_run_id\": 7"))
+        assertTrue(body.contains("\"inspection_run_id\": 7"))
+        assertTrue(body.contains("\"snapshot_run_id\": 6"))
+    }
+
+    @Test
     fun `test problems endpoint refuses a replacement inspection run`() {
         every { mockProject.basePath } returns "/tmp/TestProject"
         every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -871,6 +871,34 @@ class InspectionHandlerTest {
     }
 
     @Test
+    fun `test wait endpoint refuses a replacement inspection run`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        runPooledTasksInline()
+        mockInspectionPrerequisites(mockProject)
+        setInspectionRunState(
+            projectKey(mockProject),
+            InspectionRunState(
+                runId = 8L,
+                triggerTimeMs = System.currentTimeMillis(),
+                inProgress = true,
+                captureScope = InspectionCaptureScope(scopeParam = "whole_project"),
+            ),
+        )
+
+        val response = processGetRequest(
+            "/api/inspection/wait?timeout_ms=1000&poll_ms=200&inspection_run_id=7"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"status\": \"run_changed\""))
+        assertTrue(body.contains("\"expected_inspection_run_id\": 7"))
+        assertTrue(body.contains("\"inspection_run_id\": 8"))
+        assertTrue(body.contains("\"timed_out\": false"))
+    }
+
+    @Test
     fun `test problems endpoint executes on pooled thread`() {
         every { mockProject.basePath } returns "/tmp/TestProject"
         every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
@@ -1590,6 +1618,36 @@ class InspectionHandlerTest {
         assertTrue(body.contains("\"status\": \"not_owned\""))
         assertTrue(body.contains("\"ownership_proven\": false"))
         assertTrue(body.contains("\"reason\": \"project_preexisted\""))
+        assertFalse(body.contains("\"close_token\""))
+    }
+
+    @Test
+    fun `test lifecycle claim rejects ownership bound to another project object`() {
+        every { mockProject.basePath } returns "/repo/app"
+        every { mockProject.projectFilePath } returns "/repo/app/.idea/misc.xml"
+        val otherProject = mockProject(
+            name = "OtherProject",
+            basePath = "/repo/app",
+            projectFilePath = "/repo/app/.idea/misc.xml",
+        )
+        val field = InspectionHandler::class.java.getDeclaredField("lifecycleOpenOwnershipByProjectInstance")
+        field.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        val ownership = field.get(handler) as MutableMap<String, InspectionHandler.LifecycleOpenOwnership>
+        ownership[projectInstanceId(mockProject)] = InspectionHandler.LifecycleOpenOwnership(
+            leaseId = "test-lease",
+            targetKey = Paths.get("/repo/app").normalize().toAbsolutePath().toString(),
+            project = otherProject,
+        )
+
+        val response = processGetRequest(
+            "/api/inspection/lifecycle/claim?worktree_path=/repo/app&project_instance_id=${projectInstanceId(mockProject)}&lease_id=test-lease"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"status\": \"not_owned\""))
+        assertTrue(body.contains("\"reason\": \"project_instance_reused\""))
         assertFalse(body.contains("\"close_token\""))
     }
 
@@ -2683,6 +2741,64 @@ class InspectionHandlerTest {
     }
 
     @Test
+    fun `test lifecycle close preserves claim while inspection is running`() {
+        every { mockProject.basePath } returns "/repo/app"
+        every { mockProject.projectFilePath } returns "/repo/app/.idea/misc.xml"
+        val instanceId = projectInstanceId(mockProject)
+        registerLifecycleOpenOwnership(mockProject)
+        val claim = processGetRequest(
+            "/api/inspection/lifecycle/claim?worktree_path=/repo/app&project_instance_id=$instanceId&lease_id=test-lease"
+        ).content().toString(Charsets.UTF_8)
+        val token = Regex("\"close_token\": \"([^\"]+)\"").find(claim)?.groupValues?.get(1)
+        assertNotNull(token)
+        setInspectionRunState(
+            projectKey(mockProject),
+            InspectionRunState(
+                runId = 7L,
+                triggerTimeMs = System.currentTimeMillis(),
+                inProgress = true,
+                captureScope = InspectionCaptureScope(scopeParam = "whole_project"),
+            ),
+        )
+        val closeCalls = AtomicInteger(0)
+        handler.forceCloseProject = { _, _ ->
+            closeCalls.incrementAndGet()
+            true
+        }
+
+        val blocked = processGetRequest(
+            "/api/inspection/lifecycle/close?project_instance_id=$instanceId&close_token=$token&lease_id=test-lease"
+        )
+
+        assertEquals(HttpResponseStatus.CONFLICT, blocked.status())
+        assertTrue(blocked.content().toString(Charsets.UTF_8).contains("\"reason\": \"inspection_in_progress\""))
+        assertTrue(blocked.content().toString(Charsets.UTF_8).contains("\"inspection_run_id\": 7"))
+        assertEquals(0, closeCalls.get())
+
+        setInspectionRunState(
+            projectKey(mockProject),
+            InspectionRunState(
+                runId = 7L,
+                triggerTimeMs = System.currentTimeMillis(),
+                inProgress = false,
+                captureScope = InspectionCaptureScope(scopeParam = "whole_project"),
+            ),
+        )
+        every { mockProjectManager.openProjects } answers {
+            if (closeCalls.get() == 0) arrayOf(mockProject) else emptyArray()
+        }
+        every { mockApplication.isDispatchThread } returns true
+
+        val closed = processGetRequest(
+            "/api/inspection/lifecycle/close?project_instance_id=$instanceId&close_token=$token&lease_id=test-lease"
+        )
+
+        assertEquals(HttpResponseStatus.OK, closed.status())
+        assertTrue(closed.content().toString(Charsets.UTF_8).contains("\"status\": \"closed\""))
+        assertEquals(1, closeCalls.get())
+    }
+
+    @Test
     fun `test lifecycle close uses claimed project instance even when route selectors drift`() {
         val mainProject = mockProject(
             name = "Main",
@@ -2790,6 +2906,7 @@ class InspectionHandlerTest {
             basePath = "/repo/app",
             sessionId = "stale-session",
             claimedAtMs = 1L,
+            project = mockProject,
         )
         val closeCalls = AtomicInteger(0)
         handler.forceCloseProject = { _, _ ->
@@ -3044,7 +3161,7 @@ class InspectionHandlerTest {
     }
 
     @Test
-    fun `test lifecycle close consumes token when close fails after retries`() {
+    fun `test lifecycle close preserves token when close fails after retries`() {
         every { mockProject.basePath } returns "/repo/app"
         every { mockProject.projectFilePath } returns "/repo/app/.idea/misc.xml"
         val instanceId = projectInstanceId(mockProject)
@@ -3069,6 +3186,13 @@ class InspectionHandlerTest {
         val first = processGetRequest(
             "/api/inspection/lifecycle/close?worktree_path=/repo/app&project_instance_id=$instanceId&close_token=$token"
         )
+        var closed = false
+        handler.forceCloseProject = { _, save ->
+            saveModes.add(save)
+            closed = true
+            true
+        }
+        every { mockProjectManager.openProjects } answers { if (closed) emptyArray() else arrayOf(mockProject) }
         val second = processGetRequest(
             "/api/inspection/lifecycle/close?worktree_path=/repo/app&project_instance_id=$instanceId&close_token=$token"
         )
@@ -3076,8 +3200,8 @@ class InspectionHandlerTest {
         assertEquals(HttpResponseStatus.CONFLICT, first.status())
         assertTrue(first.content().toString(Charsets.UTF_8).contains("\"reason\": \"close_failed\""))
         assertEquals(HttpResponseStatus.OK, second.status())
-        assertTrue(second.content().toString(Charsets.UTF_8).contains("\"reason\": \"not_claimed\""))
-        assertEquals(listOf(true, false, false), saveModes)
+        assertTrue(second.content().toString(Charsets.UTF_8).contains("\"status\": \"closed\""))
+        assertEquals(listOf(true, false, false, true), saveModes)
         assertTrue(first.content().toString(Charsets.UTF_8).contains("\"closed_verified\": false"))
     }
 
@@ -3474,7 +3598,7 @@ class InspectionHandlerTest {
         field.isAccessible = true
         val ownership = field.get(handler) as MutableMap<String, InspectionHandler.LifecycleOpenOwnership>
         val targetKey = Paths.get(requireNotNull(project.basePath)).normalize().toAbsolutePath().toString()
-        ownership[projectInstanceId(project)] = InspectionHandler.LifecycleOpenOwnership(leaseId, targetKey)
+        ownership[projectInstanceId(project)] = InspectionHandler.LifecycleOpenOwnership(leaseId, targetKey, project)
     }
 
     private fun processGetRequest(uri: String): FullHttpResponse {

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -39,6 +39,7 @@ import io.netty.handler.codec.http.FullHttpResponse
 import io.netty.handler.codec.http.HttpMethod
 import io.netty.handler.codec.http.HttpResponseStatus
 import io.netty.channel.ChannelHandlerContext
+import org.jdom.Element
 import org.jetbrains.concurrency.Promise
 import org.jetbrains.concurrency.resolvedPromise
 import org.jetbrains.concurrency.rejectedPromise
@@ -196,7 +197,6 @@ class InspectionHandlerTest {
         
         mockkStatic(VirtualFileManager::class)
         every { VirtualFileManager.getInstance() } returns mockVirtualFileManager
-        every { mockVirtualFileManager.modificationCount } returns 0L
         
         every { InspectionManager.getInstance(mockProject) } returns mockInspectionManager
         every { mockInspectionManager.createNewGlobalContext() } returns mockGlobalContext
@@ -268,7 +268,7 @@ class InspectionHandlerTest {
         every { mockApplication.isDispatchThread } returns true
         every { mockVirtualFileManager.syncRefresh() } returns 0L
         every { mockProfileManager.profiles } returns emptyList()
-        every { mockProfileManager.getProfile("RedLane") } returns mockProfile
+        every { mockProfileManager.getProfile("RedLane", false) } returns null
         every { mockApplication.executeOnPooledThread(any<Runnable>()) } answers {
             firstArg<Runnable>().run()
             mockk(relaxed = true)
@@ -280,6 +280,7 @@ class InspectionHandlerTest {
 
         assertEquals(HttpResponseStatus.OK, response.status())
         assertTrue(body.contains("\"profile\": \"RedLane\""))
+        verify(exactly = 1) { mockProfileManager.getProfile("RedLane", false) }
         verify(exactly = 0) { mockProfileManager.getProfile("RedLane") }
         verify(exactly = 0) { mockInspectionManager.createNewGlobalContext() }
         val status = buildInspectionStatus()
@@ -308,6 +309,7 @@ class InspectionHandlerTest {
         every { mockApplication.isDispatchThread } returns true
         every { mockVirtualFileManager.syncRefresh() } returns 0L
         every { mockProfileManager.profiles } returns emptyList()
+        every { mockProfileManager.getProfile("RedLane", false) } returns null
         every { mockApplication.executeOnPooledThread(any<Runnable>()) } answers {
             firstArg<Runnable>().run()
             mockk(relaxed = true)
@@ -335,36 +337,32 @@ class InspectionHandlerTest {
     }
 
     @Test
-    fun `test explicit inspection profile with unreadable profile list is unknown`() {
+    fun `test exact inspection profile works when project profile list is unreadable`() {
         every { mockProject.basePath } returns "/tmp/TestProject"
         every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
         every { mockApplication.isDispatchThread } returns true
         every { mockVirtualFileManager.syncRefresh() } returns 0L
         every { mockProfileManager.profiles } throws IllegalStateException("profiles unavailable")
+        every { mockProfileManager.getProfile("RedLane", false) } returns mockProfile
+        every { mockProfile.name } returns "RedLane"
         every { mockApplication.executeOnPooledThread(any<Runnable>()) } answers {
             firstArg<Runnable>().run()
             mockk(relaxed = true)
         }
         mockInspectionPrerequisites(mockProject)
 
-        val response = processTriggerRequest("/api/inspection/trigger?profile=RedLane")
+        val response = processTriggerRequest(
+            "/api/inspection/trigger?scope=changed_files&include_unversioned=false&profile=RedLane",
+        )
         val body = response.content().toString(Charsets.UTF_8)
 
         assertEquals(HttpResponseStatus.OK, response.status())
         assertTrue(body.contains("\"profile\": \"RedLane\""))
         verify(exactly = 0) { mockInspectionManager.createNewGlobalContext() }
         val status = buildInspectionStatus()
-        assertEquals("capture_incomplete", status["snapshot_outcome"])
-        assertEquals("profile_resolution", status["results_source"])
-        assertEquals("profile_resolution_error", status["capture_incomplete_reason"])
-        assertEquals("UNKNOWN", status["inspection_verdict"])
-        assertEquals("profile_resolution_error", status["inspection_verdict_reason"])
-        @Suppress("UNCHECKED_CAST")
-        val diagnostic = status["capture_diagnostic"] as Map<String, Any?>
-        assertEquals("RedLane", diagnostic["profile_requested"])
-        assertEquals(true, diagnostic["profile_unverified"])
-        assertEquals(false, diagnostic["profile_list_readable"])
-        assertEquals("profile_list_unreadable", diagnostic["exit_reason"])
+        assertEquals("clean_confirmed", status["snapshot_outcome"])
+        assertEquals("empty_changed_files", status["results_source"])
+        assertEquals(false, status["capture_incomplete"])
     }
     
     @Test
@@ -660,8 +658,9 @@ class InspectionHandlerTest {
         }
         val key = projectKey(mockProject)
         InspectionResultsStore.clear(key)
-        val inputContentEpoch = projectContentEpoch()
-        handler.projectContentEpochProvider = { inputContentEpoch }
+        val inputFingerprint = projectInputsFingerprint()
+        val contentTracker = FakeInspectionProjectContentTracker()
+        handler.projectInputsFingerprintProvider = { _, _ -> inputFingerprint }
         val snapshotProblems = listOf(
             mapOf(
                 "file" to "/tmp/TestProject/src/Included.kt",
@@ -711,7 +710,8 @@ class InspectionHandlerTest {
             snapshot = snapshot,
             captureEndState = InspectionProjectStateSnapshot(psiModificationCount = 11L, unsavedProjectDocuments = 0),
             projectStateChangedDuringCapture = true,
-            inspectionInputContentEpoch = inputContentEpoch,
+            inspectionInputFingerprint = inputFingerprint,
+            projectContentTracker = contentTracker,
         )
         val reconciledSnapshot = requireNotNull(InspectionResultsStore.getSnapshot(key))
         verify(exactly = 1) {
@@ -733,14 +733,227 @@ class InspectionHandlerTest {
     }
 
     @Test
+    fun `test final publication validates unchanged psi inputs before publishing`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        mockInspectionPrerequisites(mockProject)
+        every { PsiModificationTracker.getInstance(mockProject).modificationCount } returns 10L
+        val key = projectKey(mockProject)
+        InspectionResultsStore.clear(key)
+        val inputFingerprint = projectInputsFingerprint()
+        val contentTracker = FakeInspectionProjectContentTracker()
+        handler.projectInputsFingerprintProvider = { _, _ -> inputFingerprint }
+        setInspectionRunState(
+            key,
+            InspectionRunState(runId = 1L, triggerTimeMs = System.currentTimeMillis(), inProgress = true),
+        )
+        val snapshot = InspectionResultsSnapshot(
+            problems = listOf(
+                mapOf(
+                    "file" to "/tmp/TestProject/src/Included.kt",
+                    "severity" to "warning",
+                    "description" to "current run finding",
+                ),
+            ),
+            timestamp = System.currentTimeMillis(),
+            projectState = InspectionProjectStateSnapshot(psiModificationCount = 10L, unsavedProjectDocuments = 0),
+            outcome = InspectionSnapshotOutcome.PROBLEMS_FOUND,
+            source = "global_context",
+            captureScope = InspectionCaptureScope(scopeParam = "whole_project"),
+            runId = 1L,
+        )
+
+        publishInspectionSnapshot(
+            runId = 1L,
+            snapshot = snapshot,
+            captureEndState = snapshot.projectState,
+            projectStateChangedDuringCapture = false,
+            inspectionInputFingerprint = inputFingerprint,
+            projectContentTracker = contentTracker,
+        )
+
+        assertEquals(snapshot, InspectionResultsStore.getSnapshot(key))
+        verify(exactly = 1) {
+            mockApplication.runReadAction(any<ThrowableComputable<Any, Exception>>())
+        }
+    }
+
+    @Test
+    fun `test final publication closes tracker race before fresh publication`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        mockInspectionPrerequisites(mockProject)
+        every { PsiModificationTracker.getInstance(mockProject).modificationCount } returns 10L
+        val key = projectKey(mockProject)
+        InspectionResultsStore.clear(key)
+        val inputFingerprint = projectInputsFingerprint()
+        val contentTracker = FakeInspectionProjectContentTracker().apply {
+            beforeRunIfUnchanged = { changed = true }
+        }
+        handler.projectInputsFingerprintProvider = { _, _ -> inputFingerprint }
+        setInspectionRunState(
+            key,
+            InspectionRunState(runId = 1L, triggerTimeMs = System.currentTimeMillis(), inProgress = true),
+        )
+        val snapshot = InspectionResultsSnapshot(
+            problems = emptyList(),
+            timestamp = System.currentTimeMillis(),
+            projectState = InspectionProjectStateSnapshot(psiModificationCount = 10L, unsavedProjectDocuments = 0),
+            outcome = InspectionSnapshotOutcome.CLEAN_CONFIRMED,
+            source = "inspection_view",
+            captureScope = InspectionCaptureScope(scopeParam = "whole_project"),
+            runId = 1L,
+        )
+
+        publishInspectionSnapshot(
+            runId = 1L,
+            snapshot = snapshot,
+            captureEndState = snapshot.projectState,
+            projectStateChangedDuringCapture = false,
+            inspectionInputFingerprint = inputFingerprint,
+            projectContentTracker = contentTracker,
+        )
+
+        val publishedSnapshot = requireNotNull(InspectionResultsStore.getSnapshot(key))
+        assertEquals(InspectionSnapshotOutcome.CAPTURE_INCOMPLETE, publishedSnapshot.outcome)
+        assertEquals("inputs_changed", publishedSnapshot.captureDiagnostic?.get("final_input_validation"))
+    }
+
+    @Test
+    fun `test final publication rejects input drift without psi churn`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        mockInspectionPrerequisites(mockProject)
+        every { PsiModificationTracker.getInstance(mockProject).modificationCount } returns 10L
+        val key = projectKey(mockProject)
+        InspectionResultsStore.clear(key)
+        val inputFingerprint = projectInputsFingerprint()
+        val changedFingerprint = inputFingerprint.copy(
+            profileConfigurationHash = "changed-profile-configuration-hash",
+        )
+        val contentTracker = FakeInspectionProjectContentTracker()
+        handler.projectInputsFingerprintProvider = { _, _ -> changedFingerprint }
+        setInspectionRunState(
+            key,
+            InspectionRunState(runId = 1L, triggerTimeMs = System.currentTimeMillis(), inProgress = true),
+        )
+        val snapshot = InspectionResultsSnapshot(
+            problems = listOf(
+                mapOf(
+                    "file" to "/tmp/TestProject/src/Included.kt",
+                    "severity" to "warning",
+                    "description" to "current run finding",
+                ),
+            ),
+            timestamp = System.currentTimeMillis(),
+            projectState = InspectionProjectStateSnapshot(psiModificationCount = 10L, unsavedProjectDocuments = 0),
+            outcome = InspectionSnapshotOutcome.PROBLEMS_FOUND,
+            source = "global_context",
+            captureScope = InspectionCaptureScope(scopeParam = "whole_project"),
+            runId = 1L,
+        )
+
+        publishInspectionSnapshot(
+            runId = 1L,
+            snapshot = snapshot,
+            captureEndState = snapshot.projectState,
+            projectStateChangedDuringCapture = false,
+            inspectionInputFingerprint = inputFingerprint,
+            projectContentTracker = contentTracker,
+        )
+
+        val publishedSnapshot = requireNotNull(InspectionResultsStore.getSnapshot(key))
+        assertEquals(InspectionSnapshotOutcome.CAPTURE_INCOMPLETE, publishedSnapshot.outcome)
+        assertEquals("inspection_input_validation", publishedSnapshot.source)
+        assertEquals(CaptureIncompleteReason.UNKNOWN, publishedSnapshot.captureIncompleteReason)
+        assertTrue(publishedSnapshot.problems.isEmpty())
+        assertEquals("inputs_changed", publishedSnapshot.captureDiagnostic?.get("final_input_validation"))
+    }
+
+    @Test
+    fun `test final publication rejects tracked file changes without psi churn`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        mockInspectionPrerequisites(mockProject)
+        every { PsiModificationTracker.getInstance(mockProject).modificationCount } returns 10L
+        val key = projectKey(mockProject)
+        InspectionResultsStore.clear(key)
+        val inputFingerprint = projectInputsFingerprint()
+        val contentTracker = FakeInspectionProjectContentTracker(changed = true)
+        handler.projectInputsFingerprintProvider = { _, _ -> inputFingerprint }
+        setInspectionRunState(
+            key,
+            InspectionRunState(runId = 1L, triggerTimeMs = System.currentTimeMillis(), inProgress = true),
+        )
+        val snapshot = InspectionResultsSnapshot(
+            problems = emptyList(),
+            timestamp = System.currentTimeMillis(),
+            projectState = InspectionProjectStateSnapshot(psiModificationCount = 10L, unsavedProjectDocuments = 0),
+            outcome = InspectionSnapshotOutcome.CLEAN_CONFIRMED,
+            source = "inspection_view",
+            captureScope = InspectionCaptureScope(scopeParam = "whole_project"),
+            runId = 1L,
+        )
+
+        publishInspectionSnapshot(
+            runId = 1L,
+            snapshot = snapshot,
+            captureEndState = snapshot.projectState,
+            projectStateChangedDuringCapture = false,
+            inspectionInputFingerprint = inputFingerprint,
+            projectContentTracker = contentTracker,
+        )
+
+        val publishedSnapshot = requireNotNull(InspectionResultsStore.getSnapshot(key))
+        assertEquals(InspectionSnapshotOutcome.CAPTURE_INCOMPLETE, publishedSnapshot.outcome)
+        assertEquals("inputs_changed", publishedSnapshot.captureDiagnostic?.get("final_input_validation"))
+    }
+
+    @Test
+    fun `test final publication rejects unavailable validation without psi churn`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        mockInspectionPrerequisites(mockProject)
+        val key = projectKey(mockProject)
+        InspectionResultsStore.clear(key)
+        setInspectionRunState(
+            key,
+            InspectionRunState(runId = 1L, triggerTimeMs = System.currentTimeMillis(), inProgress = true),
+        )
+        val snapshot = InspectionResultsSnapshot(
+            problems = emptyList(),
+            timestamp = System.currentTimeMillis(),
+            projectState = InspectionProjectStateSnapshot(psiModificationCount = 11L, unsavedProjectDocuments = 0),
+            outcome = InspectionSnapshotOutcome.CLEAN_CONFIRMED,
+            source = "inspection_view",
+            captureScope = InspectionCaptureScope(scopeParam = "whole_project"),
+            runId = 1L,
+        )
+
+        publishInspectionSnapshot(
+            runId = 1L,
+            snapshot = snapshot,
+            captureEndState = snapshot.projectState,
+            projectStateChangedDuringCapture = false,
+            inspectionInputFingerprint = null,
+            projectContentTracker = null,
+        )
+
+        val publishedSnapshot = requireNotNull(InspectionResultsStore.getSnapshot(key))
+        assertEquals(InspectionSnapshotOutcome.CAPTURE_INCOMPLETE, publishedSnapshot.outcome)
+        assertEquals("validation_unavailable", publishedSnapshot.captureDiagnostic?.get("final_input_validation"))
+    }
+
+    @Test
     fun `test final publication keeps fail closed baseline for unsaved capture state`() {
         every { mockProject.basePath } returns "/tmp/TestProject"
         every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
         mockInspectionPrerequisites(mockProject)
         val key = projectKey(mockProject)
         InspectionResultsStore.clear(key)
-        val inputContentEpoch = projectContentEpoch()
-        handler.projectContentEpochProvider = { inputContentEpoch }
+        val inputFingerprint = projectInputsFingerprint()
+        val contentTracker = FakeInspectionProjectContentTracker()
+        handler.projectInputsFingerprintProvider = { _, _ -> inputFingerprint }
         val snapshotProblems = listOf(
             mapOf(
                 "file" to "/tmp/TestProject/src/Included.kt",
@@ -768,7 +981,8 @@ class InspectionHandlerTest {
             snapshot = snapshot,
             captureEndState = InspectionProjectStateSnapshot(psiModificationCount = 11L, unsavedProjectDocuments = 1),
             projectStateChangedDuringCapture = true,
-            inspectionInputContentEpoch = inputContentEpoch,
+            inspectionInputFingerprint = inputFingerprint,
+            projectContentTracker = contentTracker,
         )
         val publishedSnapshot = requireNotNull(InspectionResultsStore.getSnapshot(key))
         setInspectionRunState(
@@ -789,8 +1003,70 @@ class InspectionHandlerTest {
         mockInspectionPrerequisites(mockProject)
         val key = projectKey(mockProject)
         InspectionResultsStore.clear(key)
-        val inputContentEpoch = projectContentEpoch(vfsModificationCount = 1L)
-        handler.projectContentEpochProvider = { projectContentEpoch(vfsModificationCount = 2L) }
+        val inputFingerprint = projectInputsFingerprint()
+        val contentTracker = FakeInspectionProjectContentTracker()
+        handler.projectInputsFingerprintProvider = { _, _ -> inputFingerprint }
+        val snapshotProblems = listOf(
+            mapOf(
+                "file" to "/tmp/TestProject/src/Included.kt",
+                "severity" to "warning",
+                "description" to "current run finding",
+            ),
+        )
+        val extractor = mockk<EnhancedTreeExtractor>()
+        every { extractor.extractAllProblemsWithStatus(mockProject) } answers {
+            contentTracker.changed = true
+            ProblemExtractionResult(
+                problems = snapshotProblems,
+                succeeded = true,
+                source = ProblemExtractionSource.INSPECTION_RESULTS,
+            )
+        }
+        enhancedTreeExtractorFactory = { extractor }
+        setInspectionRunState(
+            key,
+            InspectionRunState(runId = 1L, triggerTimeMs = System.currentTimeMillis(), inProgress = true),
+        )
+        val snapshot = InspectionResultsSnapshot(
+            problems = snapshotProblems,
+            timestamp = System.currentTimeMillis(),
+            projectState = InspectionProjectStateSnapshot(psiModificationCount = 10L, unsavedProjectDocuments = 0),
+            outcome = InspectionSnapshotOutcome.PROBLEMS_FOUND,
+            source = "global_context",
+            captureScope = InspectionCaptureScope(scopeParam = "whole_project"),
+            runId = 1L,
+        )
+
+        publishInspectionSnapshot(
+            runId = 1L,
+            snapshot = snapshot,
+            captureEndState = InspectionProjectStateSnapshot(psiModificationCount = 11L, unsavedProjectDocuments = 0),
+            projectStateChangedDuringCapture = true,
+            inspectionInputFingerprint = inputFingerprint,
+            projectContentTracker = contentTracker,
+        )
+        val publishedSnapshot = requireNotNull(InspectionResultsStore.getSnapshot(key))
+        setInspectionRunState(
+            key,
+            InspectionRunState(runId = 1L, triggerTimeMs = System.currentTimeMillis(), inProgress = false),
+        )
+        val completedStatus = buildInspectionStatus()
+
+        assertEquals(10L, publishedSnapshot.projectState.psiModificationCount)
+        assertEquals(true, completedStatus["results_may_be_stale"])
+    }
+
+    @Test
+    fun `test final publication rejects project input changes during inspection`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        mockInspectionPrerequisites(mockProject)
+        val key = projectKey(mockProject)
+        InspectionResultsStore.clear(key)
+        val inputFingerprint = projectInputsFingerprint()
+        val changedFingerprint = inputFingerprint.copy(projectSdkVersion = "3.14")
+        val contentTracker = FakeInspectionProjectContentTracker()
+        handler.projectInputsFingerprintProvider = { _, _ -> changedFingerprint }
         val snapshotProblems = listOf(
             mapOf(
                 "file" to "/tmp/TestProject/src/Included.kt",
@@ -818,17 +1094,11 @@ class InspectionHandlerTest {
             snapshot = snapshot,
             captureEndState = InspectionProjectStateSnapshot(psiModificationCount = 11L, unsavedProjectDocuments = 0),
             projectStateChangedDuringCapture = true,
-            inspectionInputContentEpoch = inputContentEpoch,
+            inspectionInputFingerprint = inputFingerprint,
+            projectContentTracker = contentTracker,
         )
-        val publishedSnapshot = requireNotNull(InspectionResultsStore.getSnapshot(key))
-        setInspectionRunState(
-            key,
-            InspectionRunState(runId = 1L, triggerTimeMs = System.currentTimeMillis(), inProgress = false),
-        )
-        val completedStatus = buildInspectionStatus()
 
-        assertEquals(10L, publishedSnapshot.projectState.psiModificationCount)
-        assertEquals(true, completedStatus["results_may_be_stale"])
+        assertEquals(10L, requireNotNull(InspectionResultsStore.getSnapshot(key)).projectState.psiModificationCount)
     }
 
     @Test
@@ -838,8 +1108,9 @@ class InspectionHandlerTest {
         mockInspectionPrerequisites(mockProject)
         val key = projectKey(mockProject)
         InspectionResultsStore.clear(key)
-        val inputContentEpoch = projectContentEpoch()
-        handler.projectContentEpochProvider = { inputContentEpoch }
+        val inputFingerprint = projectInputsFingerprint()
+        val contentTracker = FakeInspectionProjectContentTracker()
+        handler.projectInputsFingerprintProvider = { _, _ -> inputFingerprint }
         val snapshotProblems = listOf(
             mapOf(
                 "file" to "/tmp/TestProject/src/Included.kt",
@@ -871,7 +1142,8 @@ class InspectionHandlerTest {
             snapshot = snapshot,
             captureEndState = InspectionProjectStateSnapshot(psiModificationCount = 11L, unsavedProjectDocuments = 0),
             projectStateChangedDuringCapture = true,
-            inspectionInputContentEpoch = inputContentEpoch,
+            inspectionInputFingerprint = inputFingerprint,
+            projectContentTracker = contentTracker,
         )
 
         assertEquals(10L, requireNotNull(InspectionResultsStore.getSnapshot(key)).projectState.psiModificationCount)
@@ -884,8 +1156,9 @@ class InspectionHandlerTest {
         mockInspectionPrerequisites(mockProject)
         val key = projectKey(mockProject)
         InspectionResultsStore.clear(key)
-        val inputContentEpoch = projectContentEpoch()
-        handler.projectContentEpochProvider = { inputContentEpoch }
+        val inputFingerprint = projectInputsFingerprint()
+        val contentTracker = FakeInspectionProjectContentTracker()
+        handler.projectInputsFingerprintProvider = { _, _ -> inputFingerprint }
         val extractor = mockk<EnhancedTreeExtractor>()
         every { extractor.extractAllProblemsWithStatus(mockProject) } returns ProblemExtractionResult(
             problems = emptyList(),
@@ -912,19 +1185,127 @@ class InspectionHandlerTest {
             snapshot = snapshot,
             captureEndState = InspectionProjectStateSnapshot(psiModificationCount = 11L, unsavedProjectDocuments = 0),
             projectStateChangedDuringCapture = true,
-            inspectionInputContentEpoch = inputContentEpoch,
+            inspectionInputFingerprint = inputFingerprint,
+            projectContentTracker = contentTracker,
         )
 
         assertEquals(10L, requireNotNull(InspectionResultsStore.getSnapshot(key)).projectState.psiModificationCount)
     }
 
     @Test
-    fun `test project content epoch reads the JetBrains VFS change counter`() {
-        every { mockVirtualFileManager.modificationCount } returns 42L
+    fun `test project content tracker path matching excludes metadata and sibling roots`() {
+        val roots = listOf("/tmp/TestProject", "/tmp/shared-content")
 
-        val epoch = handler.projectContentEpochProvider()
+        assertTrue(isTrackedInspectionInputPath("/tmp/TestProject", roots, "/tmp/TestProject/src/App.kt"))
+        assertTrue(isTrackedInspectionInputPath("/tmp/TestProject", roots, "/tmp/shared-content/lib.py"))
+        assertTrue(isTrackedInspectionInputPath("/tmp/TestProject", roots, "/tmp/TestProject/.idea/misc.xml"))
+        assertFalse(isTrackedInspectionInputPath("/tmp/TestProject", roots, "/tmp/TestProject/.idea"))
+        assertFalse(isTrackedInspectionInputPath("/tmp/TestProject", roots, "/tmp/TestProject/.idea/workspace.xml"))
+        assertFalse(
+            isTrackedInspectionInputPath(
+                "/tmp/TestProject",
+                roots,
+                "/tmp/TestProject/.idea/workspace.xml___jb_tmp___",
+            )
+        )
+        assertFalse(isTrackedInspectionInputPath("/tmp/TestProject", roots, "/tmp/TestProject/.git/index"))
+        assertFalse(isTrackedInspectionInputPath("/tmp/TestProject", roots, "/tmp/TestProject/modules/sub/.git/index"))
+        assertFalse(isTrackedInspectionInputPath("/tmp/TestProject", roots, "/tmp/shared-content/.git/index"))
+        assertFalse(isTrackedInspectionInputPath("/tmp/TestProject", roots, "/tmp/TestProject-copy/src/App.kt"))
+        assertFalse(
+            isTrackedInspectionInputPath(
+                projectBasePath = "/tmp/TestProject",
+                rootPaths = roots,
+                eventPath = "/tmp/TestProject/build/classes/App.class",
+                excludedRootPaths = listOf("/tmp/TestProject/build"),
+            )
+        )
+    }
 
-        assertEquals(42L, epoch.vfsModificationCount)
+    @Test
+    fun `test inspection event paths preserve both sides of moves and renames`() {
+        val moveEvent = mockk<com.intellij.openapi.vfs.newvfs.events.VFileMoveEvent>()
+        every { moveEvent.oldPath } returns "/tmp/outside/App.kt"
+        every { moveEvent.newPath } returns "/tmp/TestProject/src/App.kt"
+        val renameEvent = mockk<com.intellij.openapi.vfs.newvfs.events.VFilePropertyChangeEvent>()
+        every { renameEvent.isRename } returns true
+        every { renameEvent.oldPath } returns "/tmp/TestProject/src/Old.kt"
+        every { renameEvent.newPath } returns "/tmp/TestProject/src/New.kt"
+
+        assertEquals(
+            listOf("/tmp/outside/App.kt", "/tmp/TestProject/src/App.kt"),
+            inspectionEventPaths(moveEvent),
+        )
+        assertEquals(
+            listOf("/tmp/TestProject/src/Old.kt", "/tmp/TestProject/src/New.kt"),
+            inspectionEventPaths(renameEvent),
+        )
+    }
+
+    @Test
+    fun `test archive inspection roots map to their backing local jar`() {
+        val archiveRoot = mockk<VirtualFile>()
+        every { archiveRoot.path } returns "/tmp/sdk/lib/runtime.jar!/"
+        every { archiveRoot.isInLocalFileSystem } returns false
+
+        assertEquals("/tmp/sdk/lib/runtime.jar", localInspectionRootPath(archiveRoot))
+    }
+
+    @Test
+    fun `test inspection profile fingerprint preserves scope order and tool options`() {
+        val firstProfile = mockk<InspectionProfileImpl>()
+        val reorderedProfile = mockk<InspectionProfileImpl>()
+        val changedOptionProfile = mockk<InspectionProfileImpl>()
+        every { firstProfile.writeExternal(any()) } answers {
+            populateInspectionProfileElement(
+                target = firstArg(),
+                scopeNames = listOf("Production", "Tests"),
+                optionValue = "strict",
+            )
+        }
+        every { reorderedProfile.writeExternal(any()) } answers {
+            populateInspectionProfileElement(
+                target = firstArg(),
+                scopeNames = listOf("Tests", "Production"),
+                optionValue = "strict",
+            )
+        }
+        every { changedOptionProfile.writeExternal(any()) } answers {
+            populateInspectionProfileElement(
+                target = firstArg(),
+                scopeNames = listOf("Production", "Tests"),
+                optionValue = "lenient",
+            )
+        }
+        val method = InspectionHandler::class.java.getDeclaredMethod(
+            "inspectionProfileConfigurationHash",
+            InspectionProfileImpl::class.java,
+        )
+        method.isAccessible = true
+
+        val firstHash = method.invoke(handler, firstProfile)
+        val reorderedHash = method.invoke(handler, reorderedProfile)
+        val changedOptionHash = method.invoke(handler, changedOptionProfile)
+
+        assertNotEquals(firstHash, reorderedHash)
+        assertNotEquals(firstHash, changedOptionHash)
+    }
+
+    @Test
+    fun `test requested inspection profile resolution never falls back`() {
+        every { mockProfileManager.getProfile("RedLane", false) } returns null
+        val method = InspectionHandler::class.java.getDeclaredMethod(
+            "resolveInspectionProfile",
+            InspectionProjectProfileManager::class.java,
+            String::class.java,
+        )
+        method.isAccessible = true
+
+        val resolvedProfile = method.invoke(handler, mockProfileManager, "RedLane")
+
+        assertNull(resolvedProfile)
+        verify(exactly = 1) { mockProfileManager.getProfile("RedLane", false) }
+        verify(exactly = 0) { mockProfileManager.getProfile("RedLane") }
     }
 
     @Test
@@ -4203,7 +4584,8 @@ class InspectionHandlerTest {
         snapshot: InspectionResultsSnapshot,
         captureEndState: InspectionProjectStateSnapshot,
         projectStateChangedDuringCapture: Boolean,
-        inspectionInputContentEpoch: InspectionProjectContentEpoch?,
+        inspectionInputFingerprint: InspectionProjectInputsFingerprint?,
+        projectContentTracker: InspectionProjectContentTracker?,
     ) {
         val method = InspectionHandler::class.java.getDeclaredMethod(
             "publishInspectionSnapshot",
@@ -4212,7 +4594,8 @@ class InspectionHandlerTest {
             InspectionResultsSnapshot::class.java,
             InspectionProjectStateSnapshot::class.java,
             Boolean::class.javaPrimitiveType,
-            InspectionProjectContentEpoch::class.java,
+            InspectionProjectInputsFingerprint::class.java,
+            InspectionProjectContentTracker::class.java,
         )
         method.isAccessible = true
         method.invoke(
@@ -4222,14 +4605,64 @@ class InspectionHandlerTest {
             snapshot,
             captureEndState,
             projectStateChangedDuringCapture,
-            inspectionInputContentEpoch,
+            inspectionInputFingerprint,
+            projectContentTracker,
         )
     }
 
-    private fun projectContentEpoch(vfsModificationCount: Long = 1L): InspectionProjectContentEpoch {
-        return InspectionProjectContentEpoch(
-            vfsModificationCount = vfsModificationCount,
+    private fun projectInputsFingerprint(
+        profileName: String = "RedLane",
+        rootPaths: List<String> = listOf("/tmp/TestProject"),
+    ): InspectionProjectInputsFingerprint {
+        return InspectionProjectInputsFingerprint(
+            rootPaths = rootPaths,
+            excludedRootPaths = listOf("/tmp/TestProject/build"),
+            projectSdkName = "Test SDK",
+            projectSdkTypeName = "Python SDK",
+            projectSdkVersion = "3.13",
+            projectSdkHomePath = "/tmp/python",
+            requestedProfileName = profileName,
+            resolvedProfileName = profileName,
+            profileToolStates = listOf("CurrentRunInspection|null|true|WARNING|null"),
+            namedScopeDefinitions = emptyList(),
+            profileConfigurationHash = "profile-configuration-hash",
         )
+    }
+
+    private fun populateInspectionProfileElement(
+        target: Element,
+        scopeNames: List<String>,
+        optionValue: String,
+    ) {
+        val tool = Element("inspection_tool")
+            .setAttribute("class", "CurrentRunInspection")
+            .addContent(Element("option").setAttribute("name", "mode").setAttribute("value", optionValue))
+        scopeNames.forEach { scopeName ->
+            tool.addContent(Element("scope").setAttribute("name", scopeName))
+        }
+        target.addContent(tool)
+    }
+
+    private class FakeInspectionProjectContentTracker(
+        var changed: Boolean = false,
+    ) : InspectionProjectContentTracker {
+        var closed: Boolean = false
+        var beforeRunIfUnchanged: (() -> Unit)? = null
+
+        override fun hasChanges(): Boolean = changed
+
+        override fun runIfUnchanged(action: () -> Unit): Boolean {
+            beforeRunIfUnchanged?.invoke()
+            if (changed) {
+                return false
+            }
+            action()
+            return true
+        }
+
+        override fun close() {
+            closed = true
+        }
     }
 
     private fun mockExtractor(problems: List<Map<String, Any>>) {

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -745,6 +745,28 @@ class InspectionHandlerTest {
     }
 
     @Test
+    fun `test cancellation endpoint detects a completed replacement run`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        val key = projectKey(mockProject)
+        setInspectionRunState(
+            key,
+            InspectionRunState(runId = 8L, triggerTimeMs = System.currentTimeMillis(), inProgress = false),
+        )
+
+        val response = processGetRequest(
+            "/api/inspection/cancel?worktree_path=/tmp/TestProject&inspection_run_id=7",
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"status\": \"run_changed\""))
+        assertTrue(body.contains("\"inspection_in_progress\": false"))
+        assertTrue(body.contains("\"expected_inspection_run_id\": 7"))
+        assertTrue(body.contains("\"inspection_run_id\": 8"))
+    }
+
+    @Test
     fun `test queued inspection can be cancelled before its worker starts`() {
         every { mockProject.basePath } returns "/tmp/TestProject"
         every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
@@ -770,6 +792,33 @@ class InspectionHandlerTest {
             queuedTasks.single().run()
         }
         verify(exactly = 0) { mockInspectionManager.createNewGlobalContext() }
+    }
+
+    @Test
+    fun `test indicator creation failure releases inspection run`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        handler.inspectionIndicatorFactory = { throw IllegalStateException("indicator failed") }
+
+        val response = processTriggerRequest("/api/inspection/trigger")
+        val state = inspectionRunState(projectKey(mockProject))
+
+        assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR, response.status())
+        assertEquals(false, state?.inProgress)
+    }
+
+    @Test
+    fun `test runner setup failure releases inspection run`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        runPooledTasksInline()
+        handler.inspectionProcessRunner = { _, _ -> throw IllegalStateException("runner failed") }
+
+        val response = processTriggerRequest("/api/inspection/trigger")
+        val state = inspectionRunState(projectKey(mockProject))
+
+        assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR, response.status())
+        assertEquals(false, state?.inProgress)
     }
 
     @Test
@@ -896,6 +945,33 @@ class InspectionHandlerTest {
         assertTrue(body.contains("\"expected_inspection_run_id\": 7"))
         assertTrue(body.contains("\"inspection_run_id\": 8"))
         assertTrue(body.contains("\"timed_out\": false"))
+    }
+
+    @Test
+    fun `test problems endpoint refuses a replacement inspection run`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        runPooledTasksInline()
+        mockInspectionPrerequisites(mockProject)
+        setInspectionRunState(
+            projectKey(mockProject),
+            InspectionRunState(
+                runId = 8L,
+                triggerTimeMs = System.currentTimeMillis(),
+                inProgress = false,
+                captureScope = InspectionCaptureScope(scopeParam = "whole_project"),
+            ),
+        )
+
+        val response = processGetRequest(
+            "/api/inspection/problems?severity=all&inspection_run_id=7"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"status\": \"run_changed\""))
+        assertTrue(body.contains("\"expected_inspection_run_id\": 7"))
+        assertTrue(body.contains("\"inspection_run_id\": 8"))
     }
 
     @Test
@@ -3206,6 +3282,44 @@ class InspectionHandlerTest {
     }
 
     @Test
+    fun `test lifecycle close preserves token when verification throws`() {
+        every { mockProject.basePath } returns "/repo/app"
+        every { mockProject.projectFilePath } returns "/repo/app/.idea/misc.xml"
+        val instanceId = projectInstanceId(mockProject)
+        registerLifecycleOpenOwnership(mockProject)
+        val claim = processGetRequest(
+            "/api/inspection/lifecycle/claim?worktree_path=/repo/app&project_instance_id=$instanceId&lease_id=test-lease"
+        ).content().toString(Charsets.UTF_8)
+        val token = Regex("\"close_token\": \"([^\"]+)\"").find(claim)?.groupValues?.get(1)
+        assertNotNull(token)
+        every { mockApplication.isDispatchThread } returns false
+        every { mockApplication.invokeAndWait(any()) } answers { firstArg<Runnable>().run() }
+        handler.forceCloseProject = { _, _ -> true }
+        handler.closeVerificationSleep = { throw IllegalStateException("verification failed") }
+
+        val first = processGetRequest(
+            "/api/inspection/lifecycle/close?worktree_path=/repo/app&project_instance_id=$instanceId&close_token=$token"
+        )
+
+        assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR, first.status())
+
+        var closed = false
+        handler.forceCloseProject = { _, _ ->
+            closed = true
+            true
+        }
+        handler.closeVerificationSleep = {}
+        every { mockProjectManager.openProjects } answers { if (closed) emptyArray() else arrayOf(mockProject) }
+
+        val second = processGetRequest(
+            "/api/inspection/lifecycle/close?worktree_path=/repo/app&project_instance_id=$instanceId&close_token=$token"
+        )
+
+        assertEquals(HttpResponseStatus.OK, second.status())
+        assertTrue(second.content().toString(Charsets.UTF_8).contains("\"status\": \"closed\""))
+    }
+
+    @Test
     fun `test trigger endpoint honors project instance id over duplicate path keys`() {
         val mainProject = mockProject(
             name = "Main",
@@ -3698,6 +3812,14 @@ class InspectionHandlerTest {
         @Suppress("UNCHECKED_CAST")
         val states = field.get(handler) as MutableMap<String, InspectionRunState>
         states[projectKey] = state
+    }
+
+    private fun inspectionRunState(projectKey: String): InspectionRunState? {
+        val field = InspectionHandler::class.java.getDeclaredField("inspectionRunStatesByProject")
+        field.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        val states = field.get(handler) as Map<String, InspectionRunState>
+        return states[projectKey]
     }
 
     private fun setInspectionRunControl(projectKey: String, control: InspectionRunControl) {

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -12,12 +12,15 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.vcs.changes.ChangeListManager
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.openapi.vfs.VfsUtilCore
+import com.intellij.openapi.vfs.VirtualFileVisitor
 import com.intellij.openapi.wm.IdeFocusManager
 import com.intellij.openapi.wm.IdeFrame
 import com.intellij.openapi.wm.ToolWindow
@@ -29,7 +32,10 @@ import com.intellij.codeInspection.ui.InspectionResultsView
 import com.intellij.profile.codeInspection.InspectionProjectProfileManager
 import com.intellij.codeInspection.ex.InspectionProfileImpl
 import com.intellij.openapi.util.ThrowableComputable
+import com.intellij.psi.PsiDirectory
 import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiManager
 import com.intellij.psi.util.PsiModificationTracker
 import com.intellij.ui.content.Content
 import com.intellij.ui.content.ContentManager
@@ -2273,6 +2279,159 @@ class InspectionHandlerTest {
         assertEquals(HttpResponseStatus.BAD_REQUEST, response.status())
         assertTrue(body.contains("\"parameter\": \"dir\""))
         verify(exactly = 0) { mockApplication.executeOnPooledThread(any<Runnable>()) }
+    }
+
+    @Test
+    fun `test targeted analysis scopes are built under read actions`() {
+        val directory = mockk<VirtualFile>()
+        val currentFile = mockk<VirtualFile>()
+        val psiDirectory = mockk<PsiDirectory>()
+        val psiFile = mockk<PsiFile>()
+        val psiManager = mockk<PsiManager>()
+        mockkStatic(PsiManager::class)
+        every { PsiManager.getInstance(mockProject) } returns psiManager
+        val insideReadAction = java.util.concurrent.atomic.AtomicBoolean(false)
+        every { mockApplication.runReadAction(any<ThrowableComputable<Any, Exception>>()) } answers {
+            insideReadAction.set(true)
+            try {
+                firstArg<ThrowableComputable<Any, Exception>>().compute()
+            } finally {
+                insideReadAction.set(false)
+            }
+        }
+        every { psiManager.findDirectory(directory) } answers {
+            assertTrue(insideReadAction.get())
+            psiDirectory
+        }
+        every { psiManager.findFile(currentFile) } answers {
+            assertTrue(insideReadAction.get())
+            psiFile
+        }
+        every { psiDirectory.project } answers {
+            assertTrue(insideReadAction.get())
+            mockProject
+        }
+        every { psiFile.project } answers {
+            assertTrue(insideReadAction.get())
+            mockProject
+        }
+
+        assertNotNull(invokeTargetedAnalysisScopeResolver("analysisScopeForDirectory", directory))
+        assertNotNull(invokeTargetedAnalysisScopeResolver("analysisScopeForFile", currentFile))
+
+        verify(exactly = 2) { mockApplication.runReadAction(any<ThrowableComputable<Any, Exception>>()) }
+    }
+
+    @Test
+    fun `test active editor scope resolution uses a read action`() {
+        val currentFile = mockk<VirtualFile>()
+        val fileEditorManager = mockk<FileEditorManager>()
+        val projectFileIndex = mockk<com.intellij.openapi.roots.ProjectFileIndex>()
+        val insideReadAction = java.util.concurrent.atomic.AtomicBoolean(false)
+        every { mockApplication.runReadAction(any<ThrowableComputable<Any, Exception>>()) } answers {
+            insideReadAction.set(true)
+            try {
+                firstArg<ThrowableComputable<Any, Exception>>().compute()
+            } finally {
+                insideReadAction.set(false)
+            }
+        }
+        mockkStatic(FileEditorManager::class)
+        every { FileEditorManager.getInstance(mockProject) } answers {
+            assertTrue(insideReadAction.get())
+            fileEditorManager
+        }
+        every { fileEditorManager.selectedFiles } answers {
+            assertTrue(insideReadAction.get())
+            arrayOf(currentFile)
+        }
+        mockkStatic(com.intellij.openapi.roots.ProjectFileIndex::class)
+        every { com.intellij.openapi.roots.ProjectFileIndex.getInstance(mockProject) } answers {
+            assertTrue(insideReadAction.get())
+            projectFileIndex
+        }
+        every { currentFile.isValid } returns true
+        every { currentFile.isInLocalFileSystem } returns true
+        every { projectFileIndex.isInContent(currentFile) } answers {
+            assertTrue(insideReadAction.get())
+            true
+        }
+
+        assertSame(currentFile, invokeActiveEditorFileResolver())
+
+        verify(exactly = 1) { mockApplication.runReadAction(any<ThrowableComputable<Any, Exception>>()) }
+    }
+
+    @Test
+    fun `test directory scope supplies files to inspection engine fallback`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        val directory = mockk<VirtualFile>()
+        val pythonFile = mockk<VirtualFile>()
+        val nonSourcePythonFile = mockk<VirtualFile>()
+        val javascriptFile = mockk<VirtualFile>()
+        val psiFile = mockk<PsiFile>()
+        val localFileSystem = mockk<LocalFileSystem>()
+        mockkStatic(LocalFileSystem::class)
+        every { LocalFileSystem.getInstance() } returns localFileSystem
+        every { localFileSystem.findFileByPath("/tmp/TestProject/src") } returns directory
+        every { directory.isDirectory } returns true
+        every { pythonFile.isDirectory } returns false
+        every { pythonFile.extension } returns "py"
+        every { nonSourcePythonFile.isDirectory } returns false
+        every { nonSourcePythonFile.extension } returns "py"
+        every { javascriptFile.isDirectory } returns false
+        every { javascriptFile.extension } returns "js"
+
+        val projectFileIndex = mockk<com.intellij.openapi.roots.ProjectFileIndex>()
+        mockkStatic(com.intellij.openapi.roots.ProjectFileIndex::class)
+        every { com.intellij.openapi.roots.ProjectFileIndex.getInstance(mockProject) } returns projectFileIndex
+        every { projectFileIndex.isInSourceContent(pythonFile) } returns true
+        every { projectFileIndex.isInSourceContent(nonSourcePythonFile) } returns false
+        every { projectFileIndex.isInSourceContent(javascriptFile) } returns true
+
+        val psiManager = mockk<PsiManager>()
+        mockkStatic(PsiManager::class)
+        every { PsiManager.getInstance(mockProject) } returns psiManager
+        every { psiManager.findFile(pythonFile) } returns psiFile
+
+        mockkStatic(VfsUtilCore::class)
+        every {
+            VfsUtilCore.visitChildrenRecursively(directory, any<VirtualFileVisitor<Any>>())
+        } answers {
+            val visitor = secondArg<VirtualFileVisitor<Any>>()
+            visitor.visitFile(directory)
+            visitor.visitFile(pythonFile)
+            visitor.visitFile(nonSourcePythonFile)
+            visitor.visitFile(javascriptFile)
+            VirtualFileVisitor.CONTINUE
+        }
+
+        assertEquals(listOf(psiFile), invokeScopedPsiFilesForInspectionEngine("directory", "src", "PY"))
+        verify(exactly = 1) { localFileSystem.findFileByPath("/tmp/TestProject/src") }
+        verify(exactly = 0) { localFileSystem.findFileByPath("/tmp/TestProject") }
+        verify(exactly = 1) {
+            VfsUtilCore.visitChildrenRecursively(directory, any<VirtualFileVisitor<Any>>())
+        }
+        verify(exactly = 0) { psiManager.findFile(nonSourcePythonFile) }
+        verify(exactly = 0) { psiManager.findFile(javascriptFile) }
+    }
+
+    @Test
+    fun `test directory scope fallback fails closed when root disappears`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        val localFileSystem = mockk<LocalFileSystem>()
+        mockkStatic(LocalFileSystem::class)
+        every { LocalFileSystem.getInstance() } returns localFileSystem
+        every { localFileSystem.findFileByPath("/tmp/TestProject/src") } returns null
+
+        mockkStatic(VfsUtilCore::class)
+
+        assertTrue(invokeScopedPsiFilesForInspectionEngine("directory", "src", "PY").isEmpty())
+        verify(exactly = 1) { localFileSystem.findFileByPath("/tmp/TestProject/src") }
+        verify(exactly = 0) { localFileSystem.findFileByPath("/tmp/TestProject") }
+        verify(exactly = 0) {
+            VfsUtilCore.visitChildrenRecursively(any<VirtualFile>(), any<VirtualFileVisitor<Any>>())
+        }
     }
 
     @Test
@@ -4577,6 +4736,56 @@ class InspectionHandlerTest {
         method.isAccessible = true
         @Suppress("UNCHECKED_CAST")
         return method.invoke(handler, mockProject) as MutableMap<String, Any>
+    }
+
+    private fun invokeTargetedAnalysisScopeResolver(methodName: String, virtualFile: VirtualFile): Any? {
+        val method = InspectionHandler::class.java.getDeclaredMethod(
+            methodName,
+            Project::class.java,
+            VirtualFile::class.java,
+        )
+        method.isAccessible = true
+        return method.invoke(handler, mockProject, virtualFile)
+    }
+
+    private fun invokeActiveEditorFileResolver(): VirtualFile? {
+        val method = InspectionHandler::class.java.getDeclaredMethod(
+            "resolveActiveEditorFile",
+            Project::class.java,
+        )
+        method.isAccessible = true
+        return method.invoke(handler, mockProject) as? VirtualFile
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun invokeScopedPsiFilesForInspectionEngine(
+        scopeParam: String,
+        directoryParam: String?,
+        ideProductCode: String?,
+    ): List<PsiFile> {
+        val method = InspectionHandler::class.java.getDeclaredMethod(
+            "scopedPsiFilesForInspectionEngine",
+            Project::class.java,
+            String::class.java,
+            String::class.java,
+            List::class.java,
+            String::class.java,
+            List::class.java,
+            List::class.java,
+            String::class.java,
+        )
+        method.isAccessible = true
+        return method.invoke(
+            handler,
+            mockProject,
+            scopeParam,
+            directoryParam,
+            null,
+            null,
+            null,
+            emptyList<Map<String, Any?>>(),
+            ideProductCode,
+        ) as List<PsiFile>
     }
 
     private fun publishInspectionSnapshot(

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -136,6 +136,7 @@ class InspectionHandlerTest {
     fun setup() {
         handler = InspectionHandler()
         handler.trustProjectPath = {}
+        handler.refreshProjectRoot = {}
         handler.inspectionRunExpirationMs = 300000L
         handler.inspectionProcessRunner = { task, _ -> task.run() }
         handler.inspectionIndicatorFactory = { mockk(relaxed = true) }
@@ -901,6 +902,23 @@ class InspectionHandlerTest {
 
         assertEquals(HttpResponseStatus.OK, response.status())
         assertTrue(body.contains("\"project_name\": \"TestProject\""))
+        verify(exactly = 0) { mockVirtualFileManager.syncRefresh() }
+    }
+
+    @Test
+    fun `test inspection refreshes only the selected project root`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        every { mockApplication.isDispatchThread } returns true
+        mockInspectionPrerequisites(mockProject)
+        val refreshedProjectRoots = mutableListOf<String>()
+        handler.refreshProjectRoot = { path -> refreshedProjectRoots += path }
+        val method = InspectionHandler::class.java.getDeclaredMethod("syncProjectState", Project::class.java)
+        method.isAccessible = true
+
+        method.invoke(handler, mockProject)
+
+        assertEquals(listOf("/tmp/TestProject"), refreshedProjectRoots)
         verify(exactly = 0) { mockVirtualFileManager.syncRefresh() }
     }
 
@@ -1853,6 +1871,49 @@ class InspectionHandlerTest {
             "/api/inspection/lifecycle/claim?worktree_path=${java.net.URLEncoder.encode(tempDir.toString(), "UTF-8")}&project_instance_id=$instanceId&lease_id=owned-lease"
         )
         val claimBody = claimResponse.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, openResponse.status())
+        assertEquals(HttpResponseStatus.OK, claimResponse.status())
+        assertTrue(claimBody.contains("\"status\": \"claimed\""))
+        assertTrue(claimBody.contains("\"ownership_proven\": true"))
+        assertTrue(claimBody.contains("\"close_token\""))
+    }
+
+    @Test
+    fun `test lifecycle claim succeeds before project open call returns`() {
+        val tempDir = Files.createTempDirectory("inspection-open-claim-race")
+        val openedProject = mockProject(
+            name = "OwnedDuringOpen",
+            basePath = tempDir.toString(),
+            projectFilePath = tempDir.resolve(".idea/misc.xml").toString(),
+        )
+        var openProjects = emptyArray<Project>()
+        val scheduled = AtomicReference<Runnable?>()
+        val beforeInitComplete = CountDownLatch(1)
+        val allowOpenReturn = CountDownLatch(1)
+        every { mockProjectManager.openProjects } answers { openProjects }
+        every { mockApplication.invokeLater(any()) } answers {
+            scheduled.set(firstArg<Runnable>())
+        }
+        handler.openProjectPath = { _, beforeInit ->
+            beforeInit(openedProject)
+            openProjects = arrayOf(openedProject)
+            beforeInitComplete.countDown()
+            assertTrue(allowOpenReturn.await(5, TimeUnit.SECONDS))
+            openedProject
+        }
+
+        val openResponse = processGetRequest(lifecycleOpenUri(tempDir, "race-lease"))
+        val openThread = Thread { scheduled.get()?.run() }
+        openThread.start()
+        assertTrue(beforeInitComplete.await(5, TimeUnit.SECONDS))
+        val instanceId = projectInstanceId(openedProject)
+        val claimResponse = processGetRequest(
+            "/api/inspection/lifecycle/claim?worktree_path=${java.net.URLEncoder.encode(tempDir.toString(), "UTF-8")}&project_instance_id=$instanceId&lease_id=race-lease"
+        )
+        val claimBody = claimResponse.content().toString(Charsets.UTF_8)
+        allowOpenReturn.countDown()
+        openThread.join(5_000)
 
         assertEquals(HttpResponseStatus.OK, openResponse.status())
         assertEquals(HttpResponseStatus.OK, claimResponse.status())

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -13,6 +13,7 @@ import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.vcs.changes.ChangeListManager
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
@@ -121,6 +122,10 @@ class InspectionHandlerTest {
             disassembly.contains("com/intellij/ide/impl/OpenProjectTask.\"<init>\""),
             "The full OpenProjectTask constructor is binary-incompatible when JetBrains adds task properties.",
         )
+        assertFalse(
+            disassembly.contains("runProcessWithProgressSynchronously"),
+            "Agent-triggered inspections must not block lifecycle requests behind a modal progress task.",
+        )
     }
     
     @BeforeEach
@@ -128,6 +133,8 @@ class InspectionHandlerTest {
         handler = InspectionHandler()
         handler.trustProjectPath = {}
         handler.inspectionRunExpirationMs = 300000L
+        handler.inspectionProcessRunner = { task, _ -> task.run() }
+        handler.lifecycleCloseExecutor = { task -> task.run() }
         enhancedTreeExtractorFactory = { EnhancedTreeExtractor() }
         
         mockProject = mockk<Project>()
@@ -663,6 +670,101 @@ class InspectionHandlerTest {
         assertEquals(true, status["is_scanning"])
         assertEquals(true, status["inspection_run_expired"])
         assertEquals("capture_incomplete", status["snapshot_outcome"])
+    }
+
+    @Test
+    fun `test cancellation endpoint cancels the active inspection indicator`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        val key = projectKey(mockProject)
+        val indicator = mockk<ProgressIndicator>(relaxed = true)
+        setInspectionRunState(
+            key,
+            InspectionRunState(runId = 7L, triggerTimeMs = System.currentTimeMillis(), inProgress = true),
+        )
+        setInspectionRunControl(key, InspectionRunControl(runId = 7L, indicator = indicator))
+
+        val response = processGetRequest(
+            "/api/inspection/cancel?worktree_path=/tmp/TestProject&inspection_run_id=7",
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"status\": \"cancel_requested\""))
+        assertTrue(body.contains("\"inspection_run_id\": 7"))
+        verify(exactly = 1) { indicator.cancel() }
+    }
+
+    @Test
+    fun `test cancellation endpoint requires the inspection run id`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        val key = projectKey(mockProject)
+        val indicator = mockk<ProgressIndicator>(relaxed = true)
+        setInspectionRunState(
+            key,
+            InspectionRunState(runId = 7L, triggerTimeMs = System.currentTimeMillis(), inProgress = true),
+        )
+        setInspectionRunControl(key, InspectionRunControl(runId = 7L, indicator = indicator))
+
+        val response = processGetRequest("/api/inspection/cancel?worktree_path=/tmp/TestProject")
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.BAD_REQUEST, response.status())
+        assertTrue(body.contains("Parameter 'inspection_run_id' is required."))
+        verify(exactly = 0) { indicator.cancel() }
+    }
+
+    @Test
+    fun `test cancellation endpoint refuses to cancel a newer inspection run`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        val key = projectKey(mockProject)
+        val indicator = mockk<ProgressIndicator>(relaxed = true)
+        setInspectionRunState(
+            key,
+            InspectionRunState(runId = 8L, triggerTimeMs = System.currentTimeMillis(), inProgress = true),
+        )
+        setInspectionRunControl(key, InspectionRunControl(runId = 8L, indicator = indicator))
+
+        val response = processGetRequest(
+            "/api/inspection/cancel?worktree_path=/tmp/TestProject&inspection_run_id=7",
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"status\": \"run_changed\""))
+        assertTrue(body.contains("\"expected_inspection_run_id\": 7"))
+        assertTrue(body.contains("\"inspection_run_id\": 8"))
+        verify(exactly = 0) { indicator.cancel() }
+    }
+
+    @Test
+    fun `test queued inspection can be cancelled before its worker starts`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        val queuedTasks = mutableListOf<Runnable>()
+        every { mockApplication.executeOnPooledThread(any<Runnable>()) } answers {
+            queuedTasks += firstArg<Runnable>()
+            mockk(relaxed = true)
+        }
+
+        val triggerResponse = processTriggerRequest("/api/inspection/trigger")
+        val cancelResponse = processGetRequest(
+            "/api/inspection/cancel?worktree_path=/tmp/TestProject&inspection_run_id=1",
+        )
+        val cancelBody = cancelResponse.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, triggerResponse.status())
+        assertTrue(triggerResponse.content().toString(Charsets.UTF_8).contains("\"run_id\": 1"))
+        assertEquals(1, queuedTasks.size)
+        assertEquals(HttpResponseStatus.OK, cancelResponse.status())
+        assertTrue(cancelBody.contains("\"status\": \"cancel_requested\""))
+        assertTrue(cancelBody.contains("\"inspection_run_id\": 1"))
+        assertThrows(com.intellij.openapi.progress.ProcessCanceledException::class.java) {
+            queuedTasks.single().run()
+        }
+        verify(exactly = 0) { mockInspectionManager.createNewGlobalContext() }
     }
 
     @Test
@@ -2517,6 +2619,49 @@ class InspectionHandlerTest {
     }
 
     @Test
+    fun `test lifecycle close releases the HTTP event loop before close work`() {
+        every { mockProject.basePath } returns "/repo/app"
+        every { mockProject.projectFilePath } returns "/repo/app/.idea/misc.xml"
+        val instanceId = projectInstanceId(mockProject)
+        registerLifecycleOpenOwnership(mockProject)
+        val claim = processGetRequest(
+            "/api/inspection/lifecycle/claim?worktree_path=/repo/app&project_instance_id=$instanceId&lease_id=test-lease"
+        ).content().toString(Charsets.UTF_8)
+        val token = Regex("\"close_token\": \"([^\"]+)\"").find(claim)?.groupValues?.get(1)
+        assertNotNull(token)
+
+        val scheduled = AtomicReference<Runnable?>()
+        handler.lifecycleCloseExecutor = { task -> scheduled.set(task) }
+        every { mockApplication.isDispatchThread } returns true
+        var closed = false
+        handler.forceCloseProject = { _, _ ->
+            closed = true
+            true
+        }
+        every { mockProjectManager.openProjects } answers { if (closed) emptyArray() else arrayOf(mockProject) }
+        val uri = "/api/inspection/lifecycle/close?worktree_path=/repo/app&project_instance_id=$instanceId&close_token=$token"
+        val urlDecoder = QueryStringDecoder(uri)
+        val request = mockk<FullHttpRequest>()
+        val context = mockk<ChannelHandlerContext>()
+        val responses = mutableListOf<FullHttpResponse>()
+        every { request.uri() } returns uri
+        every { context.writeAndFlush(any()) } answers {
+            responses.add(firstArg())
+            mockk(relaxed = true)
+        }
+
+        assertTrue(handler.process(urlDecoder, request, context))
+        assertTrue(responses.isEmpty())
+        assertNotNull(scheduled.get())
+
+        scheduled.get()?.run()
+
+        assertEquals(1, responses.size)
+        assertEquals(HttpResponseStatus.OK, responses.single().status())
+        assertTrue(responses.single().content().toString(Charsets.UTF_8).contains("\"status\": \"closed\""))
+    }
+
+    @Test
     fun `test lifecycle close uses claimed project instance even when route selectors drift`() {
         val mainProject = mockProject(
             name = "Main",
@@ -3408,6 +3553,14 @@ class InspectionHandlerTest {
         @Suppress("UNCHECKED_CAST")
         val states = field.get(handler) as MutableMap<String, InspectionRunState>
         states[projectKey] = state
+    }
+
+    private fun setInspectionRunControl(projectKey: String, control: InspectionRunControl) {
+        val field = InspectionHandler::class.java.getDeclaredField("inspectionRunControlsByProject")
+        field.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        val controls = field.get(handler) as MutableMap<String, InspectionRunControl>
+        controls[projectKey] = control
     }
 
     private fun mockProject(name: String, basePath: String?, projectFilePath: String): Project {

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -1006,6 +1006,33 @@ class InspectionHandlerTest {
     }
 
     @Test
+    fun `test wait endpoint keeps accepted run while its snapshot is pending`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        runPooledTasksInline()
+        mockInspectionPrerequisites(mockProject)
+        setInspectionRunState(
+            projectKey(mockProject),
+            InspectionRunState(
+                runId = 7L,
+                triggerTimeMs = System.currentTimeMillis(),
+                inProgress = false,
+                captureScope = InspectionCaptureScope(scopeParam = "whole_project"),
+            ),
+        )
+
+        val response = processGetRequest(
+            "/api/inspection/wait?timeout_ms=1000&poll_ms=200&inspection_run_id=7"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"completion_reason\": \"timeout\""))
+        assertTrue(body.contains("\"inspection_run_id\": 7"))
+        assertFalse(body.contains("\"status\": \"run_changed\""))
+    }
+
+    @Test
     fun `test problems endpoint refuses a replacement inspection run`() {
         every { mockProject.basePath } returns "/tmp/TestProject"
         every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionScopeResolutionTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionScopeResolutionTest.kt
@@ -1,16 +1,38 @@
 package com.shiny.inspectionmcp
 
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import io.mockk.*
+import com.intellij.openapi.application.Application
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.roots.ProjectFileIndex
+import com.intellij.openapi.util.ThrowableComputable
 import java.lang.reflect.InvocationTargetException
 
 class InspectionScopeResolutionTest {
+
+    private lateinit var application: Application
+
+    @BeforeEach
+    fun setUp() {
+        application = mockk()
+        mockkStatic(ApplicationManager::class)
+        every { ApplicationManager.getApplication() } returns application
+        every { application.runReadAction(any<ThrowableComputable<Any, Exception>>()) } answers {
+            firstArg<ThrowableComputable<Any, Exception>>().compute()
+        }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkAll()
+    }
 
     private fun mockProject(name: String = "TestProject"): Project {
         val p = mockk<Project>(relaxed = true)


### PR DESCRIPTION
## Summary
- move inspection work off modal/event-loop paths and add run-bound cancellation
- bind lifecycle open/claim/close to the exact lease, session, project instance, and project object
- publish ownership before a new project route becomes visible and refresh only the selected project root
- bind wait/problems snapshots to the accepted inspection run without treating a missing snapshot as run drift
- preserve leases across exceptional close paths and keep cleanup failure-atomic
- reconcile inspection-induced PSI churn only after scoped VFS, SDK/root, profile/tool-option, and named-scope validation
- fail closed on real input drift while excluding module/compiler output churn
- construct PSI-backed targeted analysis scopes and resolve active-editor project membership inside read actions
- keep directory-scope inspection-engine fallback confined to the validated directory and fail closed if it disappears

## Validation
- `./scripts/commit-gate.sh --ci`
- `./scripts/release-compatibility-gate.sh` across IU 251, 252, 253, 261, and 262
- full plugin test suite plus targeted read-action and directory-boundary regression coverage
- independent GPT and Gemini-family final audits: no blockers
- pre-commit exact-code RED lanes: PyCharm, IntelliJ IDEA, and WebStorm all returned expected current findings with no threading assertion errors
- clean committed-artifact PyCharm RED lane on `0524f82a41af-clean`: 2 current duplicate-key findings, no threading assertion errors
- exact codex-lab IntelliJ rerun returned GREEN after the prior startup/indexing UNKNOWN
- forced 1 ms timeout: cancellation requested and settled, cleanup `closed`
- 9/9 concurrent `list-projects` probes succeeded in at most 162 ms while timeout handling was active
- final residue: 0 helper-owned matching projects, leases, or new lease files
- GitHub CI and all CodeQL jobs green on `0524f82a41af28c57fa941ce13930495c2852b43`

## Dogfood install
- plugin `1.13.17`, commit `0524f82a41af28c57fa941ce13930495c2852b43`, fingerprint `0524f82a41af-clean`
- latest clean artifact built July 16, 2026 at `2026-07-16T12:19:57.350511Z`; ZIP SHA-256 `e8411f5de47596af7ec11126d8723390cf14071b153e4f2fd0d7752e054b7a40`
- identical plugin jar SHA-256 `df8af446bcf98a7778a4b7e21500998a446b5a473d518e286ff42f2b99f78334` installed to IntelliJ IDEA, PyCharm, and WebStorm 2026.1/2026.2 config directories
- all live IntelliJ IDEA, PyCharm, and WebStorm 2026.1 routes report `0524f82a41af-clean`; no product restart is required
- rollback copies and deployment evidence are preserved under the local JetBrains inspection deployment archive

Coordinated helper changes: https://github.com/cbusillo/codex-skills/pull/409
