### PR TITLE
Add end-to-end UNKNOWN attribution contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ closes, or the IDE built-in HTTP server event loop.
 - `project` (optional): Blank or omitted uses the focused or active open project. Nonblank values must match an open project.
 - `project_key`, `project_path`, `worktree_path`, `cwd` (optional): Route selectors for stateless clients.
 - `session_id` (optional): Expected IDE session; mismatches return HTTP 409 with `session_drift: true`.
+- `client_run_id` (optional): Caller-owned UUID used to correlate a multi-request helper or MCP run. Non-UUID values are returned only as a short SHA-256 correlation hash.
 
 For stale responses, the same scope filters are applied before cached counts and
 optional cached findings are returned. A scoped `include_stale=true` response is
@@ -383,7 +384,23 @@ values return HTTP 400 with `error`, `parameter`, and `message` fields. Explicit
 `files`, `directory`, `current_file`, and `changed_files` scopes are resolved
 before filtering; missing or invalid targets return HTTP 400 instead of widening
 to whole-project findings. An empty valid changed-file set matches zero findings.
-Unexpected endpoint failures return HTTP 500 with a generic error body.
+Unexpected endpoint failures return HTTP 500 with a generic public message and
+an `UNKNOWN` verdict. The exception remains private to the IDE log.
+
+### UNKNOWN Attribution
+
+Every plugin-generated `UNKNOWN` or lifecycle cleanup anomaly includes a bounded
+`inspection_attribution` object with `schema_version: 1`. The stable fields are
+`source`, `classification`, `code`, `phase`, `endpoint`, `http_status`,
+`request_id`, optional `client_run_id`, session/project/run evidence IDs, and
+plugin/IDE provenance. `classification` is one of `configuration_blocked`,
+`legitimate_fail_closed`, `tool_caused`, or `unattributed`.
+
+The plugin generates a new `request_id` for each HTTP request and logs internal
+exceptions against that ID plus endpoint, session, project instance, and
+inspection run context. Responses never include stack traces or exception
+messages. Close tokens and unrestricted selector paths are excluded from the
+attribution object; project keys are represented by a bounded hash.
 
 **Examples**:
 ```bash

--- a/mcp-server-jvm/src/main/kotlin/com/shiny/inspectionmcp/mcpserver/Main.kt
+++ b/mcp-server-jvm/src/main/kotlin/com/shiny/inspectionmcp/mcpserver/Main.kt
@@ -30,6 +30,7 @@ import java.net.http.HttpResponse
 import java.net.http.HttpTimeoutException
 import java.nio.charset.StandardCharsets
 import java.time.Duration
+import java.util.UUID
 
 private const val SERVER_NAME = "jetbrains-inspection-mcp"
 private const val DEFAULT_PROTOCOL_VERSION = "2024-11-05"
@@ -394,7 +395,8 @@ internal class ToolExecutor(
         timeoutSeconds: Long = 10,
     ): Pair<JsonElement, InspectionTarget> {
         var target = targetResolver.resolve(args)
-        val requestParams = params.withRoutingSelector(args, target)
+        val clientRunId = UUID.randomUUID().toString()
+        val requestParams = params.withRoutingSelector(args, target) + ("client_run_id" to clientRunId)
         try {
             return httpGet(buildUrl("${target.baseUrl}/$endpoint", requestParams), timeoutSeconds, target.idePort) to target
         } catch (error: RuntimeException) {
@@ -404,7 +406,7 @@ internal class ToolExecutor(
             val excludedSessionIds = target.identity?.get("session_id")?.jsonPrimitive?.contentOrNull?.let(::setOf)
                 ?: emptySet()
             target = targetResolver.resolve(args, excludedSessionIds = excludedSessionIds)
-            val retryParams = params.withRoutingSelector(args, target)
+            val retryParams = params.withRoutingSelector(args, target) + ("client_run_id" to clientRunId)
             return httpGet(buildUrl("${target.baseUrl}/$endpoint", retryParams), timeoutSeconds, target.idePort) to target
         }
     }
@@ -1218,6 +1220,45 @@ private fun summarizeErrorBody(body: String): String? {
         parsedBody["error"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }?.let { parts += it }
         parsedBody["parameter"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }?.let { parts += "Parameter: $it" }
         parsedBody["message"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }?.let { parts += it }
+        val verdict = parsedBody["inspection_verdict"]?.jsonPrimitive?.contentOrNull
+        val verdictReason = parsedBody["inspection_verdict_reason"]?.jsonPrimitive?.contentOrNull
+        val verdictMessage = parsedBody["inspection_verdict_message"]?.jsonPrimitive?.contentOrNull
+        val verdictNextAction = parsedBody["inspection_verdict_next_action"]?.jsonPrimitive?.contentOrNull
+        if (!verdict.isNullOrBlank()) {
+            parts += buildString {
+                append("VERDICT: ")
+                append(verdict)
+                if (!verdictReason.isNullOrBlank()) {
+                    append(" reason=")
+                    append(verdictReason)
+                }
+            }
+            if (!verdictMessage.isNullOrBlank()) {
+                parts += "MESSAGE: $verdictMessage"
+            }
+            if (!verdictNextAction.isNullOrBlank()) {
+                parts += "NEXT_ACTION: $verdictNextAction"
+            }
+        }
+        val attribution = parsedBody["inspection_attribution"] as? JsonObject
+        if (attribution != null) {
+            val fields = listOf(
+                "classification",
+                "code",
+                "phase",
+                "endpoint",
+                "http_status",
+                "request_id",
+                "client_run_id",
+            ).mapNotNull { name ->
+                attribution[name]?.jsonPrimitive?.contentOrNull
+                    ?.takeIf { value -> value.isNotBlank() }
+                    ?.let { value -> "$name=$value" }
+            }
+            if (fields.isNotEmpty()) {
+                parts += "ATTRIBUTION: ${fields.joinToString(" ")}"
+            }
+        }
         parsedBody["suggested_open_projects"]?.jsonArray
             ?.mapNotNull { element -> element.jsonPrimitive.contentOrNull }
             ?.takeIf { suggestions -> suggestions.isNotEmpty() }

--- a/mcp-server-jvm/src/test/kotlin/com/shiny/inspectionmcp/mcpserver/McpServerTest.kt
+++ b/mcp-server-jvm/src/test/kotlin/com/shiny/inspectionmcp/mcpserver/McpServerTest.kt
@@ -382,6 +382,29 @@ class McpServerTest {
     }
 
     @Test
+    fun mcpPreservesGoldenAttributionForPluginUnknowns() {
+        attributionCases()
+            .filter { contract -> contract.mcpTool != null }
+            .forEach { contract ->
+                val path = "/api/inspection/${contract.endpoint}"
+                MockIdeServer(mapOf(path to MockResponse(contract.payloadText, contract.httpStatus))).use { server ->
+                    server.start()
+                    val executor = ToolExecutor(server.baseUrl, HttpClient.newHttpClient(), server.port.toString())
+
+                    val result = executor.handleToolCall(
+                        buildToolCall(contract.mcpTool ?: error("Missing MCP tool"), buildJsonObject { })
+                    )
+                    val text = result.firstText()
+
+                    assertEquals(contract.httpStatus >= 400, result.isError(), contract.name)
+                    contract.expected.stringArray("mcp_contains").forEach { expectedText ->
+                        assertTrue(text.contains(expectedText), "${contract.name} missing $expectedText in:\n$text")
+                    }
+                }
+            }
+    }
+
+    @Test
     fun inspectionGetProblemsHandlesZeroResults() {
         val response = """{"status":"results_available","total_problems":0,"problems_shown":0,"problems":[]}"""
         MockIdeServer(mapOf("/api/inspection/problems" to MockResponse(response))).use { server ->
@@ -527,8 +550,9 @@ class McpServerTest {
                 ),
             )
 
-            val query = server.lastQuery.get()
-            assertTrue(query.isNullOrEmpty())
+            val query = server.lastQuery.get().orEmpty()
+            assertFalse(query.contains("project="))
+            assertTrue(query.contains("client_run_id="))
         }
     }
 
@@ -722,8 +746,9 @@ class McpServerTest {
             val executor = ToolExecutor(server.baseUrl, HttpClient.newHttpClient(), server.port.toString())
 
             executor.handleToolCall(buildToolCall("inspection_wait", buildJsonObject { }))
-            val query = server.lastQuery.get()
-            assertTrue(query.isNullOrEmpty())
+            val query = server.lastQuery.get().orEmpty()
+            assertFalse(query.contains("project="))
+            assertTrue(query.contains("client_run_id="))
         }
     }
 
@@ -742,8 +767,9 @@ class McpServerTest {
                 ),
             )
 
-            val query = server.lastQuery.get()
-            assertTrue(query.isNullOrEmpty())
+            val query = server.lastQuery.get().orEmpty()
+            assertFalse(query.contains("project="))
+            assertTrue(query.contains("client_run_id="))
         }
     }
 
@@ -1074,7 +1100,7 @@ class McpServerTest {
                 val status = executor.handleToolCall(buildToolCall("inspection_get_status", buildJsonObject { }))
 
                 assertFalse(trigger.isError())
-                assertFalse(status.isError())
+                assertFalse(status.isError(), status.firstText())
                 assertTrue(first.lastQuery.get()?.contains("session_id=first-${first.port}") == true)
             }
         }
@@ -1567,6 +1593,35 @@ private data class ContractCase(
     val payloadText: String,
     val expected: JsonObject,
 )
+
+private data class AttributionCase(
+    val name: String,
+    val endpoint: String,
+    val httpStatus: Int,
+    val mcpTool: String?,
+    val payloadText: String,
+    val expected: JsonObject,
+)
+
+private fun attributionCases(): List<AttributionCase> {
+    val relative = Path.of("test-fixtures/contract-attribution/cases.json")
+    val path = generateSequence(Path.of("").toAbsolutePath()) { current -> current.parent }
+        .map { root -> root.resolve(relative) }
+        .firstOrNull { candidate -> Files.exists(candidate) }
+        ?: error("Missing contract fixture: $relative")
+    return Json.parseToJsonElement(Files.readString(path)).jsonArray.map { element ->
+        val root = element.jsonObject
+        val payload = root["payload"]?.jsonObject ?: error("Missing attribution payload")
+        AttributionCase(
+            name = root.string("name") ?: error("Missing attribution case name"),
+            endpoint = root.string("endpoint") ?: "status",
+            httpStatus = root["http_status"]?.jsonPrimitive?.intOrNull ?: 200,
+            mcpTool = root.string("mcp_tool"),
+            payloadText = Json.encodeToString(JsonElement.serializer(), payload),
+            expected = root["expected"]?.jsonObject ?: error("Missing attribution expected values"),
+        )
+    }
+}
 
 private fun contractCase(name: String): ContractCase {
     val path = contractFixturePath(name)

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -63,6 +63,14 @@ import io.netty.buffer.Unpooled
 import io.netty.channel.ChannelHandlerContext
 import io.netty.handler.codec.http.*
 import com.intellij.openapi.diagnostic.Logger
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.longOrNull
 import org.jdom.Element
 import org.jetbrains.ide.HttpRequestHandler
 import java.awt.Component
@@ -83,6 +91,11 @@ import javax.swing.tree.TreeNode
 private const val EXACT_PROJECT_PATH_SELECTOR_PREFIX = "exact-project-path:"
 private const val EXACT_WORKTREE_PATH_SELECTOR_PREFIX = "exact-worktree-path:"
 internal const val LIFECYCLE_OWNERSHIP_PROTOCOL = "lease_bound_v1"
+private const val INSPECTION_ATTRIBUTION_SCHEMA_VERSION = 1
+private val CLIENT_RUN_ID_PATTERN = Regex(
+    "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+)
+private val INSPECTION_RESPONSE_JSON = Json { prettyPrint = true }
 
 internal fun lifecycleOpenProjectTask(openPath: Path, onBeforeInit: (Project) -> Unit): OpenProjectTask =
     OpenProjectTaskCompat.build(openPath, onBeforeInit)
@@ -1148,6 +1161,13 @@ internal fun classifyCaptureIncompleteReason(
 class InspectionHandler : HttpRequestHandler() {
     private val logger = Logger.getInstance(InspectionHandler::class.java)
 
+    private data class InspectionRequestAttribution(
+        val requestId: String,
+        val clientRunId: String?,
+        val endpoint: String,
+        val phase: String,
+    )
+
     private data class ProjectSuggestion(
         val name: String,
         val path: String,
@@ -1487,6 +1507,231 @@ class InspectionHandler : HttpRequestHandler() {
         return InspectionProof(proof, failures.distinct())
     }
 
+    private fun requestAttribution(
+        path: String,
+        parameters: Map<String, List<String>>,
+    ): InspectionRequestAttribution {
+        val endpoint = path.takeIf { it.startsWith("/api/inspection/") } ?: "/api/inspection/unknown"
+        val phase = endpoint.removePrefix("/api/inspection/")
+            .replace('/', '_')
+            .ifBlank { "unknown" }
+        return InspectionRequestAttribution(
+            requestId = UUID.randomUUID().toString(),
+            clientRunId = normalizedClientRunId(firstParameter(parameters, "client_run_id")),
+            endpoint = endpoint,
+            phase = phase,
+        )
+    }
+
+    private fun normalizedClientRunId(value: String?): String? {
+        val trimmed = value?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+        if (CLIENT_RUN_ID_PATTERN.matches(trimmed)) {
+            return trimmed.lowercase()
+        }
+        return "sha256:${sha256(trimmed).take(16)}"
+    }
+
+    private fun addInspectionAttribution(
+        target: MutableMap<String, Any?>,
+        request: InspectionRequestAttribution?,
+        code: String,
+        httpStatus: HttpResponseStatus,
+        parameters: Map<String, List<String>> = emptyMap(),
+    ) {
+        if (request == null) {
+            return
+        }
+        val route = target["route"] as? Map<*, *>
+        val identity = safeInspectionIdentity()
+        val projectKey = (target["project_key"] as? String)
+            ?: (route?.get("project_key") as? String)
+            ?: firstParameter(parameters, "project_key")
+        val projectInstanceId = (target["project_instance_id"] as? String)
+            ?: (route?.get("project_instance_id") as? String)
+            ?: firstParameter(parameters, "project_instance_id")
+        val inspectionRunId = (target["inspection_run_id"] as? Number)?.toLong()
+            ?: (target["run_id"] as? Number)?.toLong()
+            ?: firstParameter(parameters, "inspection_run_id")?.toLongOrNull()
+        val attribution = mapOf(
+            "schema_version" to INSPECTION_ATTRIBUTION_SCHEMA_VERSION,
+            "source" to "plugin",
+            "classification" to attributionClassification(code),
+            "code" to code,
+            "phase" to request.phase,
+            "endpoint" to request.endpoint,
+            "http_status" to httpStatus.code(),
+            "request_id" to request.requestId,
+            "client_run_id" to request.clientRunId,
+            "session_id" to (target["session_id"] ?: route?.get("session_id") ?: identity["session_id"]),
+            "project_instance_id" to projectInstanceId,
+            "project_key_hash" to projectKey?.let { "sha256:${sha256(it).take(16)}" },
+            "inspection_run_id" to inspectionRunId,
+            "plugin_build_fingerprint" to identity["plugin_build_fingerprint"],
+            "plugin_version" to identity["plugin_version"],
+            "ide_product_code" to identity["ide_product_code"],
+            "ide_version" to identity["ide_version"],
+        ).filterValues { value -> value != null }
+        target["inspection_attribution"] = attribution
+    }
+
+    private fun attributionClassification(code: String): String {
+        return when (code) {
+            "inspection_api_http_error",
+            "invalid_api_response",
+            "extractor_failure",
+            "helper_plugin_error",
+            "inspection_proof_failed",
+            "inspection_trigger_empty_model",
+            "non_empty_unmapped_tree",
+            "open_schedule_failed" -> "tool_caused"
+            "timeout",
+            "inspection_api_timeout",
+            "inspection_api_unavailable",
+            "missing_session_id",
+            "no_project",
+            "profile_resolution_error",
+            "ide_selection_required",
+            "ide_config_ambiguous",
+            "ide_config_missing",
+            "implicit_eap_selection",
+            "ide_not_ready_timeout" -> "configuration_blocked"
+            "ambiguous_route",
+            "already_opening",
+            "capture_incomplete",
+            "close_failed",
+            "current_run_psi_churn",
+            "inspection_in_progress",
+            "inspection_still_running",
+            "interrupted",
+            "lease_mismatch",
+            "not_claimed",
+            "no_recent_inspection",
+            "no_results",
+            "open_state_unknown",
+            "ownership_not_proven",
+            "project_not_open",
+            "project_preexisted",
+            "project_instance_reused",
+            "project_mismatch",
+            "route_missing",
+            "route_mismatch",
+            "run_changed",
+            "scope_mismatch",
+            "scope_not_covered",
+            "session_drift",
+            "stale_results",
+            "token_mismatch",
+            "unreadable_tree",
+            "view_not_ready",
+            "view_updating_unreadable" -> "legitimate_fail_closed"
+            else -> "unattributed"
+        }
+    }
+
+    private fun sendInternalServerError(
+        context: ChannelHandlerContext,
+        request: InspectionRequestAttribution,
+        parameters: Map<String, List<String>>,
+        error: Throwable,
+    ) {
+        val response = mutableMapOf<String, Any?>(
+            "status" to "error",
+            "error" to "Internal server error",
+            "error_reason" to "inspection_api_http_error",
+            "completion_reason" to "inspection_api_http_error",
+        )
+        addInspectionVerdict(response)
+        addInspectionAttribution(
+            target = response,
+            request = request,
+            code = "inspection_api_http_error",
+            httpStatus = HttpResponseStatus.INTERNAL_SERVER_ERROR,
+            parameters = parameters,
+        )
+        val attribution = response["inspection_attribution"] as? Map<*, *>
+        logger.warn(
+            "Inspection API failure request_id=${request.requestId} " +
+                "client_run_id=${request.clientRunId ?: "none"} endpoint=${request.endpoint} " +
+                "session_id=${attribution?.get("session_id") ?: "unknown"} " +
+                "project_instance_id=${attribution?.get("project_instance_id") ?: "unknown"} " +
+                "inspection_run_id=${attribution?.get("inspection_run_id") ?: "unknown"}",
+            error,
+        )
+        sendJsonResponse(
+            context,
+            formatJsonManually(response),
+            HttpResponseStatus.INTERNAL_SERVER_ERROR,
+        )
+    }
+
+    private fun sendInspectionJsonResponse(
+        context: ChannelHandlerContext,
+        jsonContent: String,
+        status: HttpResponseStatus,
+        request: InspectionRequestAttribution,
+        parameters: Map<String, List<String>>,
+    ) {
+        sendJsonResponse(
+            context,
+            ensureInspectionAttribution(jsonContent, status, request, parameters),
+            status,
+        )
+    }
+
+    private fun ensureInspectionAttribution(
+        jsonContent: String,
+        status: HttpResponseStatus,
+        request: InspectionRequestAttribution,
+        parameters: Map<String, List<String>>,
+    ): String {
+        val payload = runCatching {
+            INSPECTION_RESPONSE_JSON.parseToJsonElement(jsonContent) as? JsonObject
+        }.getOrNull() ?: return jsonContent
+        if (
+            (payload["inspection_verdict"] as? JsonPrimitive)?.contentOrNull != "UNKNOWN" ||
+            payload["inspection_attribution"] is JsonObject
+        ) {
+            return jsonContent
+        }
+        val route = payload["route"] as? JsonObject
+        fun stringField(name: String): String? {
+            return (payload[name] as? JsonPrimitive)?.contentOrNull
+                ?: (route?.get(name) as? JsonPrimitive)?.contentOrNull
+        }
+        val code = stringField("inspection_verdict_reason") ?: "unattributed_unknown"
+        val responseContext = mutableMapOf<String, Any?>(
+            "session_id" to stringField("session_id"),
+            "project_instance_id" to stringField("project_instance_id"),
+            "project_key" to stringField("project_key"),
+            "inspection_run_id" to (payload["inspection_run_id"] as? JsonPrimitive)?.longOrNull,
+        )
+        addInspectionAttribution(
+            target = responseContext,
+            request = request,
+            code = code,
+            httpStatus = status,
+            parameters = parameters,
+        )
+        val attribution = responseContext["inspection_attribution"] as? Map<*, *> ?: return jsonContent
+        val attributedPayload = payload.toMutableMap()
+        attributedPayload["inspection_attribution"] = attributionJsonElement(attribution)
+        return INSPECTION_RESPONSE_JSON.encodeToString(JsonElement.serializer(), JsonObject(attributedPayload))
+    }
+
+    private fun attributionJsonElement(value: Any?): JsonElement {
+        return when (value) {
+            null -> JsonNull
+            is Boolean -> JsonPrimitive(value)
+            is Number -> JsonPrimitive(value)
+            is String -> JsonPrimitive(value)
+            is Map<*, *> -> JsonObject(
+                value.entries.associate { (key, item) -> key.toString() to attributionJsonElement(item) }
+            )
+            is Iterable<*> -> JsonArray(value.map(::attributionJsonElement))
+            else -> JsonPrimitive(value.toString())
+        }
+    }
+
     override fun isSupported(request: FullHttpRequest): Boolean {
         return request.uri().startsWith("/api/inspection") && request.method() == HttpMethod.GET
     }
@@ -1497,9 +1742,14 @@ class InspectionHandler : HttpRequestHandler() {
         request: FullHttpRequest,
         context: ChannelHandlerContext,
     ): Boolean {
+        var path = "/api/inspection/unknown"
+        var parameters = emptyMap<String, List<String>>()
+        var requestAttribution = requestAttribution(path, parameters)
         try {
-            val path = urlDecoder.path()
-            val parameters = urlDecoder.parameters() ?: emptyMap()
+            path = urlDecoder.path()
+            requestAttribution = requestAttribution(path, parameters)
+            parameters = urlDecoder.parameters() ?: emptyMap()
+            requestAttribution = requestAttribution(path, parameters)
             when (path) {
                 "/api/inspection/identity" -> {
                     val result = ApplicationManager.getApplication().runReadAction<String, Exception> {
@@ -1508,59 +1758,61 @@ class InspectionHandler : HttpRequestHandler() {
                     sendJsonResponse(context, result)
                 }
                 "/api/inspection/route" -> {
-                    responseHasSessionDrift(parameters)?.let {
+                    responseHasSessionDrift(parameters, requestAttribution)?.let {
                         sendJsonResponse(context, it, HttpResponseStatus.CONFLICT)
                         return true
                     }
                     val result = ApplicationManager.getApplication().runReadAction<String, Exception> {
                         buildRouteResponse(parameters)
                     }
-                    sendJsonResponse(context, result)
+                    sendInspectionJsonResponse(context, result, HttpResponseStatus.OK, requestAttribution, parameters)
                 }
                 "/api/inspection/lifecycle/claim" -> {
-                    responseHasSessionDrift(parameters)?.let {
+                    responseHasSessionDrift(parameters, requestAttribution)?.let {
                         sendJsonResponse(context, it, HttpResponseStatus.CONFLICT)
                         return true
                     }
                     val result = ApplicationManager.getApplication().runReadAction<String, Exception> {
                         buildLifecycleClaimResponse(parameters)
                     }
-                    sendJsonResponse(context, result)
+                    sendInspectionJsonResponse(context, result, HttpResponseStatus.OK, requestAttribution, parameters)
                 }
                 "/api/inspection/lifecycle/open" -> {
-                    responseHasSessionDrift(parameters)?.let {
+                    responseHasSessionDrift(parameters, requestAttribution)?.let {
                         sendJsonResponse(context, it, HttpResponseStatus.CONFLICT)
                         return true
                     }
                     val result = openLifecycleProject(parameters)
-                    sendJsonResponse(context, formatJsonManually(result.first), result.second)
+                    sendInspectionJsonResponse(
+                        context,
+                        formatJsonManually(result.first),
+                        result.second,
+                        requestAttribution,
+                        parameters,
+                    )
                 }
                 "/api/inspection/lifecycle/close" -> {
-                    val scheduled = runCatching {
+                    val schedulingFailure = runCatching {
                         lifecycleCloseExecutor(Runnable {
-                            processLifecycleCloseRequest(parameters, context)
+                            processLifecycleCloseRequest(parameters, context, requestAttribution)
                         })
-                    }.isSuccess
-                    if (!scheduled) {
-                        sendJsonResponse(
-                            context,
-                            """{"error": "Internal server error"}""",
-                            HttpResponseStatus.INTERNAL_SERVER_ERROR,
-                        )
+                    }.exceptionOrNull()
+                    if (schedulingFailure != null) {
+                        sendInternalServerError(context, requestAttribution, parameters, schedulingFailure)
                     }
                 }
                 "/api/inspection/cancel" -> {
-                    responseHasSessionDrift(parameters)?.let {
+                    responseHasSessionDrift(parameters, requestAttribution)?.let {
                         sendJsonResponse(context, it, HttpResponseStatus.CONFLICT)
                         return true
                     }
                     val result = ApplicationManager.getApplication().runReadAction<String, Exception> {
                         buildInspectionCancellationResponse(parameters)
                     }
-                    sendJsonResponse(context, result)
+                    sendInspectionJsonResponse(context, result, HttpResponseStatus.OK, requestAttribution, parameters)
                 }
                 "/api/inspection/problems" -> {
-                    responseHasSessionDrift(parameters)?.let {
+                    responseHasSessionDrift(parameters, requestAttribution)?.let {
                         sendJsonResponse(context, it, HttpResponseStatus.CONFLICT)
                         return true
                     }
@@ -1585,7 +1837,13 @@ class InspectionHandler : HttpRequestHandler() {
                     val projectName = extractProjectSelector(urlDecoder, request)
                     ApplicationManager.getApplication().executeOnPooledThread {
                         try {
-                            withCurrentProject(context, projectName, refreshProjectState = false) { project ->
+                            withCurrentProject(
+                                context,
+                                projectName,
+                                refreshProjectState = false,
+                                requestAttribution = requestAttribution,
+                                parameters = parameters,
+                            ) { project ->
                                 val validatedRequestScope = validateInspectionScopeRequest(
                                     project = project,
                                     scopeParam = scope,
@@ -1615,18 +1873,23 @@ class InspectionHandler : HttpRequestHandler() {
                                         expectedRunId,
                                     )
                                 }
-                                sendJsonResponse(context, result)
+                                sendInspectionJsonResponse(
+                                    context,
+                                    result,
+                                    HttpResponseStatus.OK,
+                                    requestAttribution,
+                                    parameters,
+                                )
                             }
                         } catch (error: BadRequestException) {
                             sendJsonResponse(context, formatBadRequest(error), HttpResponseStatus.BAD_REQUEST)
                         } catch (error: Exception) {
-                            logger.warn("Failed to process inspection problems request", error)
-                            sendJsonResponse(context, """{"error": "Internal server error"}""", HttpResponseStatus.INTERNAL_SERVER_ERROR)
+                            sendInternalServerError(context, requestAttribution, parameters, error)
                         }
                     }
                 }
                 "/api/inspection/trigger" -> {
-                    responseHasSessionDrift(parameters)?.let {
+                    responseHasSessionDrift(parameters, requestAttribution)?.let {
                         sendJsonResponse(context, it, HttpResponseStatus.CONFLICT)
                         return true
                     }
@@ -1654,18 +1917,15 @@ class InspectionHandler : HttpRequestHandler() {
                                 changedFilesMode = changedFilesMode,
                                 maxFiles = maxFiles,
                                 profile = profile,
+                                requestAttribution = requestAttribution,
+                                parameters = parameters,
                             )
                         } catch (error: InspectionRunConflictException) {
                             sendInspectionRunConflict(context, error)
                         } catch (error: BadRequestException) {
                             sendJsonResponse(context, formatBadRequest(error), HttpResponseStatus.BAD_REQUEST)
                         } catch (error: Exception) {
-                            logger.warn("Failed to process inspection trigger request", error)
-                            sendJsonResponse(
-                                context,
-                                """{"error": "Internal server error"}""",
-                                HttpResponseStatus.INTERNAL_SERVER_ERROR,
-                            )
+                            sendInternalServerError(context, requestAttribution, parameters, error)
                         }
                     }
                     val requestedScope = scope?.lowercase()?.trim().orEmpty().ifBlank {
@@ -1682,20 +1942,31 @@ class InspectionHandler : HttpRequestHandler() {
                     }
                 }
                 "/api/inspection/status" -> {
-                    responseHasSessionDrift(parameters)?.let {
+                    responseHasSessionDrift(parameters, requestAttribution)?.let {
                         sendJsonResponse(context, it, HttpResponseStatus.CONFLICT)
                         return true
                     }
                     val projectName = extractProjectSelector(urlDecoder, request)
-                    withCurrentProject(context, projectName) { project ->
+                    withCurrentProject(
+                        context,
+                        projectName,
+                        requestAttribution = requestAttribution,
+                        parameters = parameters,
+                    ) { project ->
                         val result = ApplicationManager.getApplication().runReadAction<String, Exception> {
                             getInspectionStatus(project)
                         }
-                        sendJsonResponse(context, result)
+                        sendInspectionJsonResponse(
+                            context,
+                            result,
+                            HttpResponseStatus.OK,
+                            requestAttribution,
+                            parameters,
+                        )
                     }
                 }
                 "/api/inspection/wait" -> {
-                    responseHasSessionDrift(parameters)?.let {
+                    responseHasSessionDrift(parameters, requestAttribution)?.let {
                         sendJsonResponse(context, it, HttpResponseStatus.CONFLICT)
                         return true
                     }
@@ -1705,12 +1976,18 @@ class InspectionHandler : HttpRequestHandler() {
                     val expectedRunId = parseOptionalPositiveLongParameter(parameters, "inspection_run_id")
                     ApplicationManager.getApplication().executeOnPooledThread {
                         try {
-                            val result = waitForInspection(projectName, timeoutMs, pollMs, expectedRunId)
-                            sendJsonResponse(context, result)
+                            val result = waitForInspection(projectName, timeoutMs, pollMs, expectedRunId, requestAttribution)
+                            sendInspectionJsonResponse(
+                                context,
+                                result,
+                                HttpResponseStatus.OK,
+                                requestAttribution,
+                                parameters,
+                            )
                         } catch (error: BadRequestException) {
                             sendJsonResponse(context, formatBadRequest(error), HttpResponseStatus.BAD_REQUEST)
-                        } catch (_: Exception) {
-                            sendJsonResponse(context, """{"error": "Internal server error"}""", HttpResponseStatus.INTERNAL_SERVER_ERROR)
+                        } catch (error: Exception) {
+                            sendInternalServerError(context, requestAttribution, parameters, error)
                         }
                     }
                 }
@@ -1726,8 +2003,7 @@ class InspectionHandler : HttpRequestHandler() {
             sendJsonResponse(context, formatBadRequest(error), HttpResponseStatus.BAD_REQUEST)
             return true
         } catch (error: Exception) {
-            logger.warn("Failed to process inspection API request", error)
-            sendJsonResponse(context, """{"error": "Internal server error"}""", HttpResponseStatus.INTERNAL_SERVER_ERROR)
+            sendInternalServerError(context, requestAttribution, parameters, error)
             return true
         }
     }
@@ -1742,8 +2018,15 @@ class InspectionHandler : HttpRequestHandler() {
         changedFilesMode: String?,
         maxFiles: Int?,
         profile: String?,
+        requestAttribution: InspectionRequestAttribution,
+        parameters: Map<String, List<String>>,
     ) {
-        withCurrentProject(context, projectName) { project ->
+        withCurrentProject(
+            context,
+            projectName,
+            requestAttribution = requestAttribution,
+            parameters = parameters,
+        ) { project ->
             val captureScope = validateInspectionScopeRequest(
                 project = project,
                 scopeParam = scope,
@@ -1921,7 +2204,10 @@ class InspectionHandler : HttpRequestHandler() {
         )
     }
 
-    private fun responseHasSessionDrift(parameters: Map<String, List<String>>): String? {
+    private fun responseHasSessionDrift(
+        parameters: Map<String, List<String>>,
+        requestAttribution: InspectionRequestAttribution? = null,
+    ): String? {
         val expectedSessionId = firstParameter(parameters, "session_id") ?: return null
         if (expectedSessionId == InspectionIdeSession.sessionId) {
             return null
@@ -1935,6 +2221,14 @@ class InspectionHandler : HttpRequestHandler() {
                 "message" to "The JetBrains IDE session changed. Resolve the route again and re-trigger inspection before trusting cached results.",
             )
         addStatusInspectionVerdict(response)
+        @Suppress("UNCHECKED_CAST")
+        addInspectionAttribution(
+            target = response as MutableMap<String, Any?>,
+            request = requestAttribution,
+            code = "session_drift",
+            httpStatus = HttpResponseStatus.CONFLICT,
+            parameters = parameters,
+        )
         return formatJsonManually(response)
     }
 
@@ -2336,19 +2630,25 @@ class InspectionHandler : HttpRequestHandler() {
     private fun processLifecycleCloseRequest(
         parameters: Map<String, List<String>>,
         context: ChannelHandlerContext,
+        requestAttribution: InspectionRequestAttribution,
     ) {
         try {
             val result = closeLifecycleProject(parameters)
-            sendJsonResponse(context, formatJsonManually(result.first), result.second)
+            val response = result.first.toMutableMap()
+            if (response["status"] != "closed") {
+                addInspectionAttribution(
+                    target = response,
+                    request = requestAttribution,
+                    code = response["reason"]?.toString() ?: "cleanup_failed",
+                    httpStatus = result.second,
+                    parameters = parameters,
+                )
+            }
+            sendJsonResponse(context, formatJsonManually(response), result.second)
         } catch (error: BadRequestException) {
             sendJsonResponse(context, formatBadRequest(error), HttpResponseStatus.BAD_REQUEST)
         } catch (error: Exception) {
-            logger.warn("Failed to process lifecycle close request", error)
-            sendJsonResponse(
-                context,
-                """{"error": "Internal server error"}""",
-                HttpResponseStatus.INTERNAL_SERVER_ERROR,
-            )
+            sendInternalServerError(context, requestAttribution, parameters, error)
         }
     }
 
@@ -3204,16 +3504,25 @@ class InspectionHandler : HttpRequestHandler() {
         context: ChannelHandlerContext,
         projectName: String?,
         refreshProjectState: Boolean = false,
+        requestAttribution: InspectionRequestAttribution? = null,
+        parameters: Map<String, List<String>> = emptyMap(),
         action: (Project) -> Unit,
     ) {
         val resolvedProjectName = normalizeProjectSelector(projectName)
         val project = ApplicationManager.getApplication().runReadAction<Project?, Exception> { getCurrentProject(resolvedProjectName) }
         if (project == null) {
-            sendJsonResponse(
-                context,
-                formatJsonManually(buildMissingProjectResponse(resolvedProjectName)),
-                HttpResponseStatus.NOT_FOUND,
-            )
+            val response = formatJsonManually(buildMissingProjectResponse(resolvedProjectName))
+            if (requestAttribution == null) {
+                sendJsonResponse(context, response, HttpResponseStatus.NOT_FOUND)
+            } else {
+                sendInspectionJsonResponse(
+                    context,
+                    response,
+                    HttpResponseStatus.NOT_FOUND,
+                    requestAttribution,
+                    parameters,
+                )
+            }
             return
         }
         if (refreshProjectState && !isInspectionInProgress(project)) {
@@ -3657,7 +3966,7 @@ class InspectionHandler : HttpRequestHandler() {
 
     @Suppress("unused")
     private fun waitForInspection(projectName: String?, timeoutMsRaw: Long?, pollMsRaw: Long?): String {
-        return waitForInspection(projectName, timeoutMsRaw, pollMsRaw, null)
+        return waitForInspection(projectName, timeoutMsRaw, pollMsRaw, null, null)
     }
 
     private fun waitForInspection(
@@ -3665,6 +3974,7 @@ class InspectionHandler : HttpRequestHandler() {
         timeoutMsRaw: Long?,
         pollMsRaw: Long?,
         expectedRunId: Long?,
+        requestAttribution: InspectionRequestAttribution? = null,
     ): String {
         val timeoutMs = (timeoutMsRaw ?: 180000L).coerceIn(1000L, 300000L)
         val pollMs = (pollMsRaw ?: 1000L).coerceIn(200L, 5000L).coerceAtMost(timeoutMs)
@@ -3678,7 +3988,8 @@ class InspectionHandler : HttpRequestHandler() {
                     start,
                     timeoutMs,
                     pollMs,
-                    "no_project"
+                    "no_project",
+                    requestAttribution,
                 )
             }
 
@@ -3690,7 +4001,8 @@ class InspectionHandler : HttpRequestHandler() {
                     start,
                     timeoutMs,
                     pollMs,
-                    "interrupted"
+                    "interrupted",
+                    requestAttribution,
                 )
             }
 
@@ -3708,10 +4020,10 @@ class InspectionHandler : HttpRequestHandler() {
 
         while (true) {
             if (expectedRunId != null && inspectionRunId(status) != expectedRunId) {
-                return formatWaitRunChanged(status, start, timeoutMs, pollMs, expectedRunId)
+                return formatWaitRunChanged(status, start, timeoutMs, pollMs, expectedRunId, requestAttribution)
             }
             if (expectedRunId != null && waitSnapshotRunChanged(status, expectedRunId)) {
-                return formatWaitRunChanged(status, start, timeoutMs, pollMs, expectedRunId)
+                return formatWaitRunChanged(status, start, timeoutMs, pollMs, expectedRunId, requestAttribution)
             }
             val hasResults = status["has_inspection_results"] as? Boolean ?: false
             val inspectionTriggered = status["inspection_triggered"] as? Boolean ?: false
@@ -3730,7 +4042,7 @@ class InspectionHandler : HttpRequestHandler() {
 
             if (resultsMayBeStale && !isScanning && !inProgress) {
                 status["wait_note"] = "Cached inspection results are stale because the project changed after the last run. Trigger a new inspection before trusting these findings."
-                return formatWaitResponse(status, start, timeoutMs, pollMs, true, "stale_results")
+                return formatWaitResponse(status, start, timeoutMs, pollMs, true, "stale_results", requestAttribution)
             }
 
             if (cleanInspection && !isScanning && !inProgress) {
@@ -3738,7 +4050,7 @@ class InspectionHandler : HttpRequestHandler() {
                     cleanStableSince = now
                 }
                 if (cleanWaitHasSettled(now, resultsTimestampMs, cleanStableSince, timeSinceTrigger, minStableMs)) {
-                    return formatWaitResponse(status, start, timeoutMs, pollMs, true, "clean")
+                    return formatWaitResponse(status, start, timeoutMs, pollMs, true, "clean", requestAttribution)
                 }
             } else {
                 cleanStableSince = null
@@ -3749,7 +4061,7 @@ class InspectionHandler : HttpRequestHandler() {
                     status["snapshot_note"] as? String
                         ?: "Inspection finished, but the plugin could not conclusively capture the IDE results. Re-run the inspection or open the Inspection Results tool window."
                     )
-                return formatWaitResponse(status, start, timeoutMs, pollMs, true, "capture_incomplete")
+                return formatWaitResponse(status, start, timeoutMs, pollMs, true, "capture_incomplete", requestAttribution)
             }
 
             if (
@@ -3759,7 +4071,7 @@ class InspectionHandler : HttpRequestHandler() {
                 !inspectionTriggered
             ) {
                 status["wait_note"] = "No recent inspection - trigger inspection first."
-                return formatWaitError(status, start, timeoutMs, pollMs, "no_recent_inspection")
+                return formatWaitError(status, start, timeoutMs, pollMs, "no_recent_inspection", requestAttribution)
             }
 
             val toolWindowNoResults = resultsSource == "tool_window" &&
@@ -3775,7 +4087,7 @@ class InspectionHandler : HttpRequestHandler() {
                 noResultsObservationCount += 1
                 if (noResultsWaitHasSettled(now, noResultsStableSince, timeSinceTrigger, minStableMs)) {
                     status["wait_note"] = "Inspection finished but no trustworthy result was captured. Treat this as UNKNOWN, not clean; rerun inspection or open the Inspection Results tool window for the exact worktree."
-                    return formatWaitResponse(status, start, timeoutMs, pollMs, true, "no_results")
+                    return formatWaitResponse(status, start, timeoutMs, pollMs, true, "no_results", requestAttribution)
                 }
             } else {
                 noResultsStableSince = null
@@ -3801,10 +4113,10 @@ class InspectionHandler : HttpRequestHandler() {
                     }
 
                     if (resultsWaitHasSettled(now, stableSince, timeSinceTrigger, minStableMs)) {
-                        return formatWaitResponse(status, start, timeoutMs, pollMs, true, "results")
+                        return formatWaitResponse(status, start, timeoutMs, pollMs, true, "results", requestAttribution)
                     }
                 } else {
-                    return formatWaitResponse(status, start, timeoutMs, pollMs, true, "results")
+                    return formatWaitResponse(status, start, timeoutMs, pollMs, true, "results", requestAttribution)
                 }
             }
 
@@ -3820,15 +4132,15 @@ class InspectionHandler : HttpRequestHandler() {
                     noResultsObservationCount >= 2
                 ) {
                     status["wait_note"] = "Inspection finished but no trustworthy result was captured. Treat this as UNKNOWN, not clean; rerun inspection or open the Inspection Results tool window for the exact worktree."
-                    return formatWaitResponse(status, start, timeoutMs, pollMs, true, "no_results")
+                    return formatWaitResponse(status, start, timeoutMs, pollMs, true, "no_results", requestAttribution)
                 }
-                return formatWaitResponse(status, start, timeoutMs, pollMs, false, "timeout")
+                return formatWaitResponse(status, start, timeoutMs, pollMs, false, "timeout", requestAttribution)
             }
 
             try {
                 TimeUnit.MILLISECONDS.sleep(pollMs)
             } catch (_: Exception) {
-                return formatWaitResponse(status, start, timeoutMs, pollMs, false, "interrupted")
+                return formatWaitResponse(status, start, timeoutMs, pollMs, false, "interrupted", requestAttribution)
             }
 
             status = ApplicationManager.getApplication().runReadAction<MutableMap<String, Any>, Exception> { buildInspectionStatus(activeProject) }
@@ -3853,6 +4165,7 @@ class InspectionHandler : HttpRequestHandler() {
         timeoutMs: Long,
         pollMs: Long,
         expectedRunId: Long,
+        requestAttribution: InspectionRequestAttribution? = null,
     ): String {
         val response = status.toMutableMap()
         response["status"] = "run_changed"
@@ -3865,6 +4178,13 @@ class InspectionHandler : HttpRequestHandler() {
         response["poll_ms"] = pollMs
         response["message"] = "A different inspection run replaced the run accepted by this request; no cancellation or cleanup authority is implied."
         addStatusInspectionVerdict(response)
+        @Suppress("UNCHECKED_CAST")
+        addInspectionAttribution(
+            target = response as MutableMap<String, Any?>,
+            request = requestAttribution,
+            code = "run_changed",
+            httpStatus = HttpResponseStatus.OK,
+        )
         return formatJsonManually(response)
     }
 
@@ -3874,7 +4194,8 @@ class InspectionHandler : HttpRequestHandler() {
         timeoutMs: Long,
         pollMs: Long,
         completed: Boolean,
-        reason: String
+        reason: String,
+        requestAttribution: InspectionRequestAttribution? = null,
     ): String {
         val response = status.toMutableMap()
         if (reason == "stale_results") {
@@ -3891,6 +4212,15 @@ class InspectionHandler : HttpRequestHandler() {
         response["timeout_ms"] = timeoutMs
         response["poll_ms"] = pollMs
         addStatusInspectionVerdict(response)
+        if (response["inspection_verdict"] == "UNKNOWN") {
+            @Suppress("UNCHECKED_CAST")
+            addInspectionAttribution(
+                target = response as MutableMap<String, Any?>,
+                request = requestAttribution,
+                code = response["inspection_verdict_reason"]?.toString() ?: reason,
+                httpStatus = HttpResponseStatus.OK,
+            )
+        }
         return formatJsonManually(response)
     }
 
@@ -3899,7 +4229,8 @@ class InspectionHandler : HttpRequestHandler() {
         startMs: Long,
         timeoutMs: Long,
         pollMs: Long,
-        reason: String
+        reason: String,
+        requestAttribution: InspectionRequestAttribution? = null,
     ): String {
         val response = responseData.toMutableMap()
         response["wait_completed"] = false
@@ -3913,6 +4244,13 @@ class InspectionHandler : HttpRequestHandler() {
         response["timeout_ms"] = timeoutMs
         response["poll_ms"] = pollMs
         addStatusInspectionVerdict(response)
+        @Suppress("UNCHECKED_CAST")
+        addInspectionAttribution(
+            target = response as MutableMap<String, Any?>,
+            request = requestAttribution,
+            code = response["inspection_verdict_reason"]?.toString() ?: reason,
+            httpStatus = HttpResponseStatus.OK,
+        )
         return formatJsonManually(response)
     }
 

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -451,24 +451,18 @@ class InspectionHandlerTest {
     @Test
     fun `test process handles missing project gracefully`() {
         every { mockProjectManager.openProjects } returns emptyArray()
-        runPooledTasksInline()
-        
-        val mockUrlDecoder = mockk<QueryStringDecoder>()
-        val mockRequest = mockk<FullHttpRequest>()
-        val mockContext = mockk<ChannelHandlerContext>()
-        
-        every { mockUrlDecoder.path() } returns "/api/inspection/problems"
-        every { mockUrlDecoder.parameters() } returns mapOf(
-            "scope" to listOf("whole_project"),
-            "severity" to listOf("all")
+
+        val response = processGetRequest(
+            "/api/inspection/route?project_key=path:/missing&client_run_id=abababab-abab-4bab-8bab-abababababab"
         )
-        
-        every { mockContext.writeAndFlush(any()) } returns mockk()
-        
-        val result = handler.process(mockUrlDecoder, mockRequest, mockContext)
-        
-        assertTrue(result)
-        verify { mockContext.writeAndFlush(any()) }
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"inspection_verdict\": \"UNKNOWN\""), body)
+        assertTrue(body.contains("\"code\": \"no_project\""), body)
+        assertTrue(body.contains("\"classification\": \"configuration_blocked\""), body)
+        assertTrue(body.contains("\"phase\": \"route\""), body)
+        assertTrue(body.contains("\"client_run_id\": \"abababab-abab-4bab-8bab-abababababab\""), body)
     }
     
     @Test
@@ -1596,11 +1590,16 @@ class InspectionHandlerTest {
         runPooledTasksInline()
         mockInspectionPrerequisites(mockProject)
 
-        val response = processGetRequest("/api/inspection/wait?timeout_ms=1000&poll_ms=200")
+        val response = processGetRequest(
+            "/api/inspection/wait?timeout_ms=1000&poll_ms=200&client_run_id=aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+        )
         val body = response.content().toString(Charsets.UTF_8)
 
         assertEquals(HttpResponseStatus.OK, response.status())
         assertTrue(body.contains("\"completion_reason\":"))
+        assertTrue(body.contains("\"inspection_attribution\":"), body)
+        assertTrue(body.contains("\"schema_version\": 1"), body)
+        assertTrue(body.contains("\"client_run_id\": \"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa\""), body)
         verify(exactly = 1) { mockApplication.executeOnPooledThread(any<Runnable>()) }
     }
 
@@ -2503,10 +2502,20 @@ class InspectionHandlerTest {
         mockkStatic(ToolWindowManager::class)
         every { ToolWindowManager.getInstance(mockProject) } throws IllegalStateException("boom")
 
-        val response = processGetRequest("/api/inspection/status")
+        val response = processGetRequest(
+            "/api/inspection/status?client_run_id=aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
 
         assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR, response.status())
-        assertTrue(response.content().toString(Charsets.UTF_8).contains("Internal server error"))
+        assertTrue(body.contains("Internal server error"))
+        assertTrue(body.contains("\"inspection_verdict\": \"UNKNOWN\""), body)
+        assertTrue(body.contains("\"inspection_verdict_reason\": \"inspection_api_http_error\""), body)
+        assertTrue(body.contains("\"classification\": \"tool_caused\""), body)
+        assertTrue(body.contains("\"phase\": \"status\""), body)
+        assertTrue(body.contains("\"http_status\": 500"), body)
+        assertTrue(body.contains("\"client_run_id\": \"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa\""), body)
+        assertFalse(body.contains("boom"), body)
     }
 
     @Test
@@ -2515,15 +2524,23 @@ class InspectionHandlerTest {
         every { mockApplication.runReadAction(any<ThrowableComputable<Any, Exception>>()) } throws
             IllegalStateException("boom")
 
-        val response = processGetRequest("/api/inspection/problems")
+        val response = processGetRequest(
+            "/api/inspection/problems?client_run_id=bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
 
         assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR, response.status())
-        assertTrue(response.content().toString(Charsets.UTF_8).contains("Internal server error"))
+        assertTrue(body.contains("Internal server error"))
+        assertTrue(body.contains("\"endpoint\": \"/api/inspection/problems\""), body)
+        assertTrue(body.contains("\"client_run_id\": \"bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb\""), body)
+        assertFalse(body.contains("boom"), body)
     }
 
     @Test
     fun `test route endpoint reports session drift as conflict`() {
-        val response = processGetRequest("/api/inspection/route?session_id=old-session")
+        val response = processGetRequest(
+            "/api/inspection/route?session_id=old-session&client_run_id=cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+        )
         val body = response.content().toString(Charsets.UTF_8)
 
         assertEquals(HttpResponseStatus.CONFLICT, response.status())
@@ -2531,6 +2548,22 @@ class InspectionHandlerTest {
         assertTrue(body.contains("\"inspection_verdict\": \"UNKNOWN\""))
         assertTrue(body.contains("\"inspection_verdict_reason\": \"session_drift\""))
         assertTrue(body.contains("\"expected_session_id\": \"old-session\""))
+        assertTrue(body.contains("\"classification\": \"legitimate_fail_closed\""), body)
+        assertTrue(body.contains("\"phase\": \"route\""), body)
+        assertTrue(body.contains("\"http_status\": 409"), body)
+        assertTrue(body.contains("\"client_run_id\": \"cccccccc-cccc-4ccc-8ccc-cccccccccccc\""), body)
+    }
+
+    @Test
+    fun `test attribution hashes non uuid caller correlation`() {
+        val response = processGetRequest(
+            "/api/inspection/route?session_id=old-session&client_run_id=sensitive-value-not-an-id"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.CONFLICT, response.status())
+        assertTrue(body.contains("\"client_run_id\": \"sha256:"), body)
+        assertFalse(body.contains("sensitive-value-not-an-id"), body)
     }
 
     @Test
@@ -4077,7 +4110,7 @@ class InspectionHandlerTest {
         }
 
         val first = processGetRequest(
-            "/api/inspection/lifecycle/close?worktree_path=/repo/app&project_instance_id=$instanceId&close_token=$token"
+            "/api/inspection/lifecycle/close?worktree_path=/repo/app&project_instance_id=$instanceId&close_token=$token&client_run_id=dddddddd-dddd-4ddd-8ddd-dddddddddddd"
         )
         val second = processGetRequest(
             "/api/inspection/lifecycle/close?worktree_path=/repo/app&project_instance_id=$instanceId&close_token=$token"
@@ -4261,7 +4294,7 @@ class InspectionHandlerTest {
         }
 
         val first = processGetRequest(
-            "/api/inspection/lifecycle/close?worktree_path=/repo/app&project_instance_id=$instanceId&close_token=$token"
+            "/api/inspection/lifecycle/close?worktree_path=/repo/app&project_instance_id=$instanceId&close_token=$token&client_run_id=dddddddd-dddd-4ddd-8ddd-dddddddddddd"
         )
         var closed = false
         handler.forceCloseProject = { _, save ->
@@ -4276,6 +4309,9 @@ class InspectionHandlerTest {
 
         assertEquals(HttpResponseStatus.CONFLICT, first.status())
         assertTrue(first.content().toString(Charsets.UTF_8).contains("\"reason\": \"close_failed\""))
+        assertTrue(first.content().toString(Charsets.UTF_8).contains("\"classification\": \"legitimate_fail_closed\""))
+        assertTrue(first.content().toString(Charsets.UTF_8).contains("\"phase\": \"lifecycle_close\""))
+        assertTrue(first.content().toString(Charsets.UTF_8).contains("\"client_run_id\": \"dddddddd-dddd-4ddd-8ddd-dddddddddddd\""))
         assertEquals(HttpResponseStatus.OK, second.status())
         assertTrue(second.content().toString(Charsets.UTF_8).contains("\"status\": \"closed\""))
         assertEquals(listOf(true, false, false, true), saveModes)
@@ -4299,10 +4335,15 @@ class InspectionHandlerTest {
         handler.closeVerificationSleep = { throw IllegalStateException("verification failed") }
 
         val first = processGetRequest(
-            "/api/inspection/lifecycle/close?worktree_path=/repo/app&project_instance_id=$instanceId&close_token=$token"
+            "/api/inspection/lifecycle/close?worktree_path=/repo/app&project_instance_id=$instanceId&close_token=$token&client_run_id=eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee"
         )
 
         assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR, first.status())
+        val firstBody = first.content().toString(Charsets.UTF_8)
+        assertTrue(firstBody.contains("\"inspection_verdict_reason\": \"inspection_api_http_error\""), firstBody)
+        assertTrue(firstBody.contains("\"phase\": \"lifecycle_close\""), firstBody)
+        assertFalse(firstBody.contains("verification failed"), firstBody)
+        assertFalse(firstBody.contains(requireNotNull(token)), firstBody)
 
         var closed = false
         handler.forceCloseProject = { _, _ ->

--- a/test-fixtures/contract-attribution/cases.json
+++ b/test-fixtures/contract-attribution/cases.json
@@ -1,0 +1,251 @@
+[
+  {
+    "name": "plugin-http-500",
+    "endpoint": "status",
+    "http_status": 500,
+    "mcp_tool": "inspection_get_status",
+    "payload": {
+      "status": "error",
+      "error": "Internal server error",
+      "error_reason": "inspection_api_http_error",
+      "completion_reason": "inspection_api_http_error",
+      "inspection_verdict": "UNKNOWN",
+      "inspection_verdict_reason": "inspection_api_http_error",
+      "inspection_verdict_message": "Inspection did not produce a trustworthy GREEN or RED result.",
+      "inspection_verdict_next_action": "Do not report GREEN or RED. Rerun inspection and include diagnostics if it remains UNKNOWN.",
+      "inspection_attribution": {
+        "schema_version": 1,
+        "source": "plugin",
+        "classification": "tool_caused",
+        "code": "inspection_api_http_error",
+        "phase": "status",
+        "endpoint": "/api/inspection/status",
+        "http_status": 500,
+        "request_id": "11111111-1111-4111-8111-111111111111",
+        "client_run_id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        "session_id": "session-http-500",
+        "plugin_build_fingerprint": "fixture-fingerprint"
+      }
+    },
+    "expected": {
+      "classification": "tool_caused",
+      "code": "inspection_api_http_error",
+      "phase": "status",
+      "helper_bucket": "tool_bug",
+      "mcp_contains": [
+        "VERDICT: UNKNOWN reason=inspection_api_http_error",
+        "NEXT_ACTION:",
+        "classification=tool_caused",
+        "request_id=11111111-1111-4111-8111-111111111111"
+      ]
+    }
+  },
+  {
+    "name": "readiness-timeout",
+    "payload": {
+      "status": "error",
+      "error_reason": "ide_not_ready_timeout",
+      "client_run_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+      "readiness": {
+        "attempts": 12,
+        "elapsed_ms": 300000
+      }
+    },
+    "expected": {
+      "classification": "configuration_blocked",
+      "code": "ide_not_ready_timeout",
+      "phase": "readiness_wait",
+      "helper_bucket": "environment_blocked"
+    }
+  },
+  {
+    "name": "wait-timeout",
+    "endpoint": "wait",
+    "http_status": 200,
+    "mcp_tool": "inspection_wait",
+    "payload": {
+      "status": "running",
+      "wait_completed": false,
+      "timed_out": true,
+      "completion_reason": "timeout",
+      "inspection_verdict": "UNKNOWN",
+      "inspection_verdict_reason": "timeout",
+      "inspection_verdict_message": "Inspection did not produce a trustworthy GREEN or RED result.",
+      "inspection_verdict_next_action": "Wait for indexing/scanning to settle or rerun with a larger timeout.",
+      "inspection_attribution": {
+        "schema_version": 1,
+        "source": "plugin",
+        "classification": "configuration_blocked",
+        "code": "timeout",
+        "phase": "wait",
+        "endpoint": "/api/inspection/wait",
+        "http_status": 200,
+        "request_id": "22222222-2222-4222-8222-222222222222",
+        "client_run_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+        "inspection_run_id": 42
+      }
+    },
+    "expected": {
+      "classification": "configuration_blocked",
+      "code": "timeout",
+      "phase": "wait",
+      "helper_bucket": "ide_not_ready",
+      "mcp_contains": [
+        "VERDICT: UNKNOWN reason=timeout",
+        "\"inspection_attribution\"",
+        "22222222-2222-4222-8222-222222222222"
+      ]
+    }
+  },
+  {
+    "name": "selection-required",
+    "payload": {
+      "status": "error",
+      "error_reason": "ide_selection_required",
+      "client_run_id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
+    },
+    "expected": {
+      "classification": "configuration_blocked",
+      "code": "ide_selection_required",
+      "phase": "selection",
+      "helper_bucket": "policy_required"
+    }
+  },
+  {
+    "name": "session-drift",
+    "endpoint": "status",
+    "http_status": 409,
+    "mcp_tool": "inspection_get_status",
+    "payload": {
+      "error": "IDE session changed",
+      "session_drift": true,
+      "session_id": "session-new",
+      "inspection_verdict": "UNKNOWN",
+      "inspection_verdict_reason": "session_drift",
+      "inspection_verdict_message": "Inspection did not produce a trustworthy GREEN or RED result.",
+      "inspection_verdict_next_action": "Resolve the route again and rerun; the IDE/plugin session changed.",
+      "inspection_attribution": {
+        "schema_version": 1,
+        "source": "plugin",
+        "classification": "legitimate_fail_closed",
+        "code": "session_drift",
+        "phase": "status",
+        "endpoint": "/api/inspection/status",
+        "http_status": 409,
+        "request_id": "33333333-3333-4333-8333-333333333333",
+        "client_run_id": "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+        "session_id": "session-new"
+      }
+    },
+    "expected": {
+      "classification": "legitimate_fail_closed",
+      "code": "session_drift",
+      "phase": "status",
+      "helper_bucket": "route_not_ready",
+      "mcp_contains": [
+        "VERDICT: UNKNOWN reason=session_drift",
+        "classification=legitimate_fail_closed",
+        "request_id=33333333-3333-4333-8333-333333333333"
+      ]
+    }
+  },
+  {
+    "name": "malformed-response",
+    "payload": {
+      "status": "error",
+      "error_reason": "invalid_api_response",
+      "endpoint": "problems",
+      "http_status": 200,
+      "response_code": "invalid_api_response",
+      "client_run_id": "ffffffff-ffff-4fff-8fff-ffffffffffff"
+    },
+    "expected": {
+      "classification": "tool_caused",
+      "code": "invalid_api_response",
+      "phase": "problems",
+      "helper_bucket": "tool_bug"
+    }
+  },
+  {
+    "name": "cleanup-failure",
+    "payload": {
+      "status": "clean",
+      "clean": true,
+      "inspection_result": {
+        "verdict": "GREEN",
+        "reason": "clean_confirmed"
+      },
+      "cleanup_failed": true,
+      "cleanup": {
+        "status": "failed",
+        "reason": "close_failed",
+        "inspection_attribution": {
+          "schema_version": 1,
+          "source": "plugin",
+          "classification": "legitimate_fail_closed",
+          "code": "close_failed",
+          "phase": "lifecycle_close",
+          "endpoint": "/api/inspection/lifecycle/close",
+          "http_status": 409,
+          "request_id": "44444444-4444-4444-8444-444444444444",
+          "client_run_id": "99999999-9999-4999-8999-999999999999",
+          "project_instance_id": "project-instance-fixture"
+        }
+      }
+    },
+    "expected": {
+      "classification": "legitimate_fail_closed",
+      "code": "close_failed",
+      "phase": "lifecycle_close",
+      "helper_bucket": "cleanup_not_clean"
+    }
+  },
+  {
+    "name": "profile-resolution-error",
+    "payload": {
+      "status": "capture_incomplete",
+      "capture_incomplete": true,
+      "capture_incomplete_reason": "profile_resolution_error",
+      "command": "get-problems",
+      "client_run_id": "12121212-1212-4212-8212-121212121212"
+    },
+    "expected": {
+      "classification": "configuration_blocked",
+      "code": "profile_resolution_error",
+      "phase": "problems",
+      "helper_bucket": "policy_required"
+    }
+  },
+  {
+    "name": "scope-not-covered",
+    "payload": {
+      "status": "scope_mismatch",
+      "inspection_verdict": "UNKNOWN",
+      "inspection_verdict_reason": "scope_not_covered",
+      "inspection_verdict_message": "Inspection did not cover the requested scope.",
+      "inspection_verdict_next_action": "Trigger a fresh inspection for the requested scope.",
+      "command": "get-problems",
+      "client_run_id": "13131313-1313-4313-8313-131313131313"
+    },
+    "expected": {
+      "classification": "legitimate_fail_closed",
+      "code": "scope_not_covered",
+      "phase": "problems",
+      "helper_bucket": "capture_not_ready"
+    }
+  },
+  {
+    "name": "unattributed-unknown",
+    "payload": {
+      "status": "mystery",
+      "command": "get-status",
+      "client_run_id": "14141414-1414-4414-8414-141414141414"
+    },
+    "expected": {
+      "classification": "unattributed",
+      "code": "unattributed_unknown",
+      "phase": "status",
+      "helper_bucket": "tool_bug"
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- add bounded `inspection_attribution` schema v1 to every plugin UNKNOWN and lifecycle cleanup anomaly
- correlate caller `client_run_id` with per-request plugin IDs while hashing unsafe caller IDs and project keys
- return redacted, classified HTTP 500 evidence and log endpoint/session/project-instance/run context privately
- preserve verdict, reason, next action, classification, and correlation through MCP errors
- add shared golden fixtures and tests for HTTP 500, readiness/wait timeout, selection-required, session drift, malformed responses, cleanup failure, profile/scope blockers, and unattributed UNKNOWN
- document the public attribution and redaction contract

## Companion helper
- cbusillo/codex-skills#421

## Validation
- `./scripts/commit-gate.sh --ci`
  - release contract tests
  - 351 plugin tests
  - inspection-core tests
  - MCP tests
  - `buildPlugin`
- source helper `inspect-closeout --scope changed_files`: GREEN, zero findings
- independent Claude and GPT review findings resolved; final Antigravity review reported no blocking findings

Closes #207.