### PR TITLE
Fix changed-files snapshot freshness proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Notes:
 - `status: "no_results"` uses the same pagination, filters, `total_problems`, `problems_shown`, and `problems` fields as result responses, with an empty problems list.
 - `status: "capture_incomplete"` means an inspection finished, but the plugin could not conclusively capture the IDE results. Re-run the inspection or open the Problems/Inspection Results view before treating the project as clean. `capture_incomplete_reason` is a stable machine-readable bucket: `view_not_ready`, `view_updating_unreadable`, `unreadable_tree`, `extractor_failure`, `non_empty_unmapped_tree`, `scope_not_covered`, `current_run_psi_churn`, `timeout`, `profile_resolution_error`, `inspection_trigger_empty_model`, `helper_plugin_error`, or `unknown`. Use `capture_diagnostic` only when debugging capture or extractor behavior; normal agent workflows should use the external helper's compact `agent_result` envelope.
 - `status: "stale_results"` means project files changed after the last inspection. It is not a clean result. Cached findings are withheld by default; call `/problems?include_stale=true` only when explicitly diagnosing cached data.
-- `snapshot_change_kind` explains freshness classification when present. `snapshot_predates_current_trigger` and `unsaved_documents` are stale. `current_run_psi_churn` is reserved for a PSI tick while the originating inspection is still active; changes after a completed run make its snapshot stale.
+- `snapshot_change_kind` explains freshness classification when present. `snapshot_predates_current_trigger` and `unsaved_documents` are stale. `current_run_psi_churn` means the plugin proved that a PSI tick was benign for the originating inspection; `changed_files` captures require an exact resolved file set, unchanged inspection inputs, and matching scoped results. Later unverified changes still make the snapshot stale.
 - `session_drift: true` means the client sent an old `session_id`; the IDE/plugin session restarted or the port was reused.
 
 ## API Reference
@@ -558,7 +558,7 @@ The status endpoint includes a `clean_inspection` field that makes the outcome e
 **Status Indicators**:
 - `is_scanning: true` → Inspection running, wait
 - `results_may_be_stale: true` → Project changed after the last inspection; trigger again before trusting results
-- `snapshot_change_kind: "current_run_psi_churn"` → The active run observed a PSI modification-count tick while capturing results and keeps waiting for stable evidence. A tick after the run completes makes the snapshot stale.
+- `snapshot_change_kind: "current_run_psi_churn"` → The plugin observed a PSI modification-count tick from the originating run. During an active run it is still verifying the result; for a completed `changed_files` run, the marker means exact scope, input, and result equivalence was proven. Any later unverified tick makes the snapshot stale.
 - `capture_incomplete_reason: "..."` → The subsystem bucket behind an inconclusive capture. IDE-state/retry buckets are `view_not_ready`, `view_updating_unreadable`, `unreadable_tree`, `scope_not_covered`, `current_run_psi_churn`, `timeout`, and `inspection_trigger_empty_model`; profile configuration bucket is `profile_resolution_error`; plugin/helper investigation buckets are `extractor_failure`, `non_empty_unmapped_tree`, `helper_plugin_error`, and `unknown`.
 - `clean_inspection: true` → Inspection complete; `inspection_verdict` is `GREEN` for the selected scope/filter
 - `has_inspection_results: true` → Problems found, retrieve with `/problems`

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -187,6 +187,7 @@ internal data class InspectionResultsSnapshot(
     val captureIncompleteReason: CaptureIncompleteReason? = null,
     val runId: Long? = null,
     val triggerTimeMs: Long? = null,
+    val reconciliationChangeKind: String? = null,
 )
 
 internal data class InspectionViewObservation(
@@ -707,9 +708,16 @@ internal fun inspectionCaptureScopeCoversRequest(
                 else -> false
             }
         }
-        "files", "current_file", "changed_files" -> when (requestKind) {
+        "files", "current_file" -> when (requestKind) {
             "files", "current_file" -> requestFiles.isNotEmpty() && captureFiles.containsAll(requestFiles)
-            "changed_files" -> captureFiles.containsAll(requestFiles)
+            "changed_files" -> requestFiles.isNotEmpty() && captureFiles.containsAll(requestFiles)
+            else -> false
+        }
+        "changed_files" -> when (requestKind) {
+            "files", "current_file" -> requestFiles.isNotEmpty() && captureFiles.containsAll(requestFiles)
+            "changed_files" -> captureScope.resolvedFiles != null &&
+                requestScope.resolvedFiles != null &&
+                captureFiles == requestFiles
             else -> false
         }
         else -> false
@@ -3162,7 +3170,10 @@ class InspectionHandler : HttpRequestHandler() {
                 return@run formatInspectionRunChangedResponse(project, expectedInspectionRunId, runState, snapshot)
             }
             var staleness = resolveSnapshotStaleness(project, snapshot)
-            if (staleness.changeKind == "current_run_psi_churn") {
+            if (
+                staleness.changeKind == "current_run_psi_churn" &&
+                staleness.reasons.contains("project_changed_since_inspection")
+            ) {
                 val reconciliation = reconcileCurrentRunPsiChurn(project, snapshot)
                 snapshot = reconciliation.snapshot
                 staleness = if (reconciliation.reconciled) {
@@ -3566,7 +3577,10 @@ class InspectionHandler : HttpRequestHandler() {
         var snapshot = resultsStore.getSnapshot(key)
         val hasInspectionSnapshot = snapshot != null
         var staleness = resolveSnapshotStaleness(project, snapshot)
-        if (staleness.changeKind == "current_run_psi_churn") {
+        if (
+            staleness.changeKind == "current_run_psi_churn" &&
+            staleness.reasons.contains("project_changed_since_inspection")
+        ) {
             val reconciliation = reconcileCurrentRunPsiChurn(project, snapshot)
             snapshot = reconciliation.snapshot
             staleness = if (reconciliation.reconciled) {
@@ -3792,13 +3806,13 @@ class InspectionHandler : HttpRequestHandler() {
             return
         }
 
-        val wholeProjectCapture = isWholeProjectCaptureScope(snapshot.captureScope)
+        val stableInputValidationScope = supportsStableInputValidation(snapshot.captureScope)
         val hasInputValidation = inspectionInputFingerprint != null && projectContentTracker != null
         val canAttemptReconciliation = projectStateChangedDuringCapture &&
-            wholeProjectCapture &&
+            stableInputValidationScope &&
             captureEndState.unsavedProjectDocuments == 0 &&
             hasInputValidation
-        val requiresStableInputValidation = wholeProjectCapture && !projectStateChangedDuringCapture
+        val requiresStableInputValidation = stableInputValidationScope && !projectStateChangedDuringCapture
         if (!canAttemptReconciliation && !requiresStableInputValidation) {
             if (!project.isDisposed && isCurrentInspectionRun(key, runId)) {
                 resultsStore.setSnapshot(key, snapshot)
@@ -3822,14 +3836,20 @@ class InspectionHandler : HttpRequestHandler() {
             ApplicationManager.getApplication().runReadAction<Unit, Exception> {
                 val contentChangedBeforeVerification = contentTracker.hasChanges()
                 val stateStableBeforeVerification = captureProjectState(project) == captureEndState
+                val scopeMatchedBeforeVerification = changedFilesCaptureScopeMatchesCurrent(project, snapshot.captureScope)
                 val reconciliation = if (
                     canAttemptReconciliation &&
                     !project.isDisposed &&
                     !contentChangedBeforeVerification &&
                     stateStableBeforeVerification &&
+                    scopeMatchedBeforeVerification &&
                     isCurrentInspectionRun(key, runId)
                 ) {
-                    reconcileCurrentRunPsiChurnUnderReadAction(project, snapshot)
+                    if (isExactEmptyChangedFilesSnapshot(snapshot)) {
+                        CurrentRunPsiChurnReconciliation(snapshot, true)
+                    } else {
+                        reconcileCurrentRunPsiChurnUnderReadAction(project, snapshot)
+                    }
                 } else {
                     CurrentRunPsiChurnReconciliation(snapshot, false)
                 }
@@ -3846,10 +3866,13 @@ class InspectionHandler : HttpRequestHandler() {
                 }
                 val contentChangedAfterVerification = contentTracker.hasChanges()
                 val stateStableAfterVerification = captureProjectState(project) == captureEndState
+                val scopeMatchedAfterVerification = changedFilesCaptureScopeMatchesCurrent(project, snapshot.captureScope)
                 val inputsMatched = currentFingerprint == inputFingerprint
                 val finalValidationPassed =
                     !contentChangedAfterVerification &&
                     stateStableAfterVerification &&
+                    scopeMatchedBeforeVerification &&
+                    scopeMatchedAfterVerification &&
                     inputsMatched &&
                     !project.isDisposed &&
                     isCurrentInspectionRun(key, runId)
@@ -3863,12 +3886,21 @@ class InspectionHandler : HttpRequestHandler() {
                         "contentChangedAfter=$contentChangedAfterVerification, " +
                         "stateStableBefore=$stateStableBeforeVerification, " +
                         "stateStableAfter=$stateStableAfterVerification, " +
+                        "scopeMatchedBefore=$scopeMatchedBeforeVerification, " +
+                        "scopeMatchedAfter=$scopeMatchedAfterVerification, " +
                         "inputsMatched=$inputsMatched, " +
                         "unchangedPublished=$shouldPublishUnchangedSnapshot, " +
                         "promoted=$shouldReconcile"
                 )
                 val snapshotToPublish = if (shouldReconcile) {
-                    snapshot.copy(projectState = captureEndState)
+                    snapshot.copy(
+                        projectState = captureEndState,
+                        reconciliationChangeKind = if (isChangedFilesCaptureScope(snapshot.captureScope)) {
+                            CaptureIncompleteReason.CURRENT_RUN_PSI_CHURN.apiValue
+                        } else {
+                            snapshot.reconciliationChangeKind
+                        },
+                    )
                 } else if (shouldPublishUnchangedSnapshot || projectStateChangedDuringCapture) {
                     snapshot
                 } else {
@@ -3876,9 +3908,15 @@ class InspectionHandler : HttpRequestHandler() {
                 }
                 if (!project.isDisposed && isCurrentInspectionRun(key, runId)) {
                     val publicationRequiresStableTracker = shouldReconcile || shouldPublishUnchangedSnapshot
+                    var scopeMatchedAtPublication = !publicationRequiresStableTracker
                     val publishedWithStableTracker = if (publicationRequiresStableTracker) {
                         contentTracker.runIfUnchanged {
-                            if (!project.isDisposed && isCurrentInspectionRun(key, runId)) {
+                            scopeMatchedAtPublication = changedFilesCaptureScopeMatchesCurrent(project, snapshot.captureScope)
+                            if (
+                                scopeMatchedAtPublication &&
+                                !project.isDisposed &&
+                                isCurrentInspectionRun(key, runId)
+                            ) {
                                 resultsStore.setSnapshot(key, snapshotToPublish)
                             }
                         }
@@ -3886,7 +3924,11 @@ class InspectionHandler : HttpRequestHandler() {
                         resultsStore.setSnapshot(key, snapshotToPublish)
                         true
                     }
-                    if (!publishedWithStableTracker && !project.isDisposed && isCurrentInspectionRun(key, runId)) {
+                    if (
+                        (!publishedWithStableTracker || !scopeMatchedAtPublication) &&
+                        !project.isDisposed &&
+                        isCurrentInspectionRun(key, runId)
+                    ) {
                         val fallbackSnapshot = if (projectStateChangedDuringCapture) {
                             snapshot
                         } else {
@@ -3928,6 +3970,55 @@ class InspectionHandler : HttpRequestHandler() {
     private fun isWholeProjectCaptureScope(captureScope: InspectionCaptureScope?): Boolean {
         val scope = captureScope?.scopeParam?.trim()?.lowercase().orEmpty().ifBlank { "whole_project" }
         return scope == "whole_project" || scope == "all"
+    }
+
+    private fun isChangedFilesCaptureScope(captureScope: InspectionCaptureScope?): Boolean {
+        return captureScope?.scopeParam?.trim()?.lowercase() == "changed_files"
+    }
+
+    private fun supportsStableInputValidation(captureScope: InspectionCaptureScope?): Boolean {
+        return isWholeProjectCaptureScope(captureScope) || isChangedFilesCaptureScope(captureScope)
+    }
+
+    private fun changedFilesCaptureScopeMatchesCurrent(
+        project: Project,
+        captureScope: InspectionCaptureScope?,
+    ): Boolean {
+        if (!isChangedFilesCaptureScope(captureScope)) {
+            return true
+        }
+        val resolvedCaptureScope = captureScope ?: return false
+        val capturedFiles = normalizeResolvedFileSet(resolvedCaptureScope.resolvedFiles) ?: return false
+        val currentFiles = try {
+            resolveChangedFilesScopeFiles(
+                project = project,
+                includeUnversioned = resolvedCaptureScope.includeUnversioned,
+                changedFilesMode = resolvedCaptureScope.changedFilesMode,
+                maxFiles = resolvedCaptureScope.maxFiles,
+            ).map { file -> file.path }
+        } catch (_: Exception) {
+            return false
+        }
+        return capturedFiles == normalizeResolvedFileSet(currentFiles)
+    }
+
+    private fun normalizeResolvedFileSet(paths: List<String>?): Set<String>? {
+        if (paths == null) {
+            return null
+        }
+        val normalizedPaths = linkedSetOf<String>()
+        for (path in paths) {
+            normalizedPaths += normalizeFileSystemPath(path) ?: return null
+        }
+        return normalizedPaths
+    }
+
+    private fun isExactEmptyChangedFilesSnapshot(snapshot: InspectionResultsSnapshot): Boolean {
+        return isChangedFilesCaptureScope(snapshot.captureScope) &&
+            snapshot.captureScope?.resolvedFiles?.isEmpty() == true &&
+            snapshot.problems.isEmpty() &&
+            snapshot.outcome == InspectionSnapshotOutcome.CLEAN_CONFIRMED &&
+            snapshot.source == "empty_changed_files"
     }
 
     private fun inspectionProblemIdentityCounts(
@@ -4535,10 +4626,89 @@ class InspectionHandler : HttpRequestHandler() {
             inspectionRunStatesByProject.computeIfPresent(key) { _, state ->
                 if (state.runId == runId) state.copy(captureScope = effectiveCaptureScope) else state
             }
-            if (changedFilesScopeFiles != null && changedFilesScopeFiles.isEmpty()) {
+            var profile = resolveInspectionProfile(profileManager, requestedProfileName)
+            if (profile == null) {
                 resultsStore.setSnapshot(
                     key,
                     InspectionResultsSnapshot(
+                        problems = emptyList(),
+                        timestamp = System.currentTimeMillis(),
+                        projectState = inspectionInputState,
+                        outcome = InspectionSnapshotOutcome.CAPTURE_INCOMPLETE,
+                        source = "profile_resolution",
+                        note = if (requestedProfileName != null) {
+                            "Requested inspection profile '$requestedProfileName' was no longer available."
+                        } else {
+                            "The current inspection profile was unavailable."
+                        },
+                        captureScope = effectiveCaptureScope,
+                        captureDiagnostic = mapOf(
+                            "profile_requested" to requestedProfileName,
+                            "profile_missing" to true,
+                            "exit_reason" to "profile_disappeared",
+                        ),
+                        captureIncompleteReason = CaptureIncompleteReason.PROFILE_RESOLUTION_ERROR,
+                        runId = runId,
+                        triggerTimeMs = inspectionRunStatesByProject[key]?.triggerTimeMs,
+                    ),
+                )
+                return
+            }
+            if (supportsStableInputValidation(effectiveCaptureScope)) {
+                val initialFingerprint = projectInputsFingerprintProvider(project, requestedProfileName)
+                val tracker = initialFingerprint?.let { fingerprint ->
+                    projectContentTrackerFactory(project, fingerprint)
+                }
+                val confirmedProfile = if (tracker != null) {
+                    resolveInspectionProfile(profileManager, requestedProfileName)
+                } else {
+                    null
+                }
+                val confirmedFingerprint = confirmedProfile?.let {
+                    projectInputsFingerprintProvider(project, requestedProfileName)
+                }
+                val trackerChangedDuringPreflight = tracker?.hasChanges() ?: true
+                if (
+                    tracker != null &&
+                    !trackerChangedDuringPreflight &&
+                    initialFingerprint == confirmedFingerprint
+                ) {
+                    projectContentTracker = tracker
+                    inspectionInputFingerprint = confirmedFingerprint
+                    profile = requireNotNull(confirmedProfile)
+                } else {
+                    tracker?.close()
+                    resultsStore.setSnapshot(
+                        key,
+                        InspectionResultsSnapshot(
+                            problems = emptyList(),
+                            timestamp = System.currentTimeMillis(),
+                            projectState = inspectionInputState,
+                            outcome = InspectionSnapshotOutcome.CAPTURE_INCOMPLETE,
+                            source = "inspection_input_validation",
+                            note = "Project inspection inputs could not be captured consistently before inspection.",
+                            captureScope = effectiveCaptureScope,
+                            captureDiagnostic = mapOf(
+                                "initial_fingerprint_available" to (initialFingerprint != null),
+                                "tracker_available" to (tracker != null),
+                                "tracker_changed" to trackerChangedDuringPreflight,
+                                "confirmed_profile_available" to (confirmedProfile != null),
+                                "fingerprints_matched" to (initialFingerprint == confirmedFingerprint),
+                            ),
+                            captureIncompleteReason = CaptureIncompleteReason.UNKNOWN,
+                            runId = runId,
+                            triggerTimeMs = inspectionRunStatesByProject[key]?.triggerTimeMs,
+                        ),
+                    )
+                    return
+                }
+            }
+            if (changedFilesScopeFiles != null && changedFilesScopeFiles.isEmpty()) {
+                val captureEndState = captureStableProjectState(project)
+                publishInspectionSnapshot(
+                    project = project,
+                    runId = runId,
+                    snapshot = InspectionResultsSnapshot(
                         problems = emptyList(),
                         timestamp = System.currentTimeMillis(),
                         projectState = inspectionInputState,
@@ -4548,7 +4718,11 @@ class InspectionHandler : HttpRequestHandler() {
                         captureScope = effectiveCaptureScope,
                         runId = runId,
                         triggerTimeMs = inspectionRunStatesByProject[key]?.triggerTimeMs,
-                    )
+                    ),
+                    captureEndState = captureEndState,
+                    projectStateChangedDuringCapture = captureEndState != inspectionInputState,
+                    inspectionInputFingerprint = inspectionInputFingerprint,
+                    projectContentTracker = projectContentTracker,
                 )
                 return
             }
@@ -4587,92 +4761,6 @@ class InspectionHandler : HttpRequestHandler() {
                 resolvedChangedFiles = changedFilesScopeFiles,
                 resolvedScope = effectiveCaptureScope,
             )
-            
-            var profile = resolveInspectionProfile(profileManager, requestedProfileName)
-            if (profile == null) {
-                resultsStore.setSnapshot(
-                    key,
-                    InspectionResultsSnapshot(
-                        problems = emptyList(),
-                        timestamp = System.currentTimeMillis(),
-                        projectState = inspectionInputState,
-                        outcome = InspectionSnapshotOutcome.CAPTURE_INCOMPLETE,
-                        source = "profile_resolution",
-                        note = if (requestedProfileName != null) {
-                            "Requested inspection profile '$requestedProfileName' was no longer available."
-                        } else {
-                            "The current inspection profile was unavailable."
-                        },
-                        captureScope = effectiveCaptureScope,
-                        captureDiagnostic = mapOf(
-                            "profile_requested" to requestedProfileName,
-                            "profile_missing" to true,
-                            "exit_reason" to "profile_disappeared",
-                        ),
-                        captureIncompleteReason = CaptureIncompleteReason.PROFILE_RESOLUTION_ERROR,
-                        runId = runId,
-                        triggerTimeMs = inspectionRunStatesByProject[key]?.triggerTimeMs,
-                    ),
-                )
-                return
-            }
-            if (isWholeProjectCaptureScope(effectiveCaptureScope)) {
-                val initialFingerprint = captureInspectionProjectInputs(
-                    project = project,
-                    selectedProfile = profile,
-                    profileName = requestedProfileName,
-                )
-                val tracker = initialFingerprint?.let { fingerprint ->
-                    projectContentTrackerFactory(project, fingerprint)
-                }
-                val confirmedProfile = if (tracker != null) {
-                    resolveInspectionProfile(profileManager, requestedProfileName)
-                } else {
-                    null
-                }
-                val confirmedFingerprint = confirmedProfile?.let { resolvedProfile ->
-                    captureInspectionProjectInputs(
-                        project = project,
-                        selectedProfile = resolvedProfile,
-                        profileName = requestedProfileName,
-                    )
-                }
-                val trackerChangedDuringPreflight = tracker?.hasChanges() ?: true
-                if (
-                    tracker != null &&
-                    !trackerChangedDuringPreflight &&
-                    initialFingerprint == confirmedFingerprint
-                ) {
-                    projectContentTracker = tracker
-                    inspectionInputFingerprint = confirmedFingerprint
-                    profile = requireNotNull(confirmedProfile)
-                } else {
-                    tracker?.close()
-                    resultsStore.setSnapshot(
-                        key,
-                        InspectionResultsSnapshot(
-                            problems = emptyList(),
-                            timestamp = System.currentTimeMillis(),
-                            projectState = inspectionInputState,
-                            outcome = InspectionSnapshotOutcome.CAPTURE_INCOMPLETE,
-                            source = "inspection_input_validation",
-                            note = "Project inspection inputs could not be captured consistently before inspection.",
-                            captureScope = effectiveCaptureScope,
-                            captureDiagnostic = mapOf(
-                                "initial_fingerprint_available" to (initialFingerprint != null),
-                                "tracker_available" to (tracker != null),
-                                "tracker_changed" to trackerChangedDuringPreflight,
-                                "confirmed_profile_available" to (confirmedProfile != null),
-                                "fingerprints_matched" to (initialFingerprint == confirmedFingerprint),
-                            ),
-                            captureIncompleteReason = CaptureIncompleteReason.UNKNOWN,
-                            runId = runId,
-                            triggerTimeMs = inspectionRunStatesByProject[key]?.triggerTimeMs,
-                        ),
-                    )
-                    return
-                }
-            }
             val resolvedProfileName = try {
                 profile.name
             } catch (_: Exception) {
@@ -5748,7 +5836,11 @@ class InspectionHandler : HttpRequestHandler() {
             reasons += "project_changed_since_inspection"
         }
         if (reasons.isEmpty()) {
-            return SnapshotStaleness(false, emptyList())
+            return SnapshotStaleness(
+                false,
+                emptyList(),
+                snapshot.reconciliationChangeKind ?: "fresh",
+            )
         }
 
         val currentRunState = inspectionRunStatesByProject[projectKey(project)]
@@ -6165,7 +6257,9 @@ class InspectionHandler : HttpRequestHandler() {
             } catch (_: Exception) {
             }
         }
-        val unique = changeFiles.distinct()
+        val unique = changeFiles
+            .distinctBy { file -> normalizeFileSystemPath(file.path) ?: file.path }
+            .sortedBy { file -> normalizeFileSystemPath(file.path) ?: file.path }
         return if (maxFiles != null && maxFiles > 0) unique.take(maxFiles) else unique
     }
 

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -15,6 +15,7 @@ import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.vcs.changes.Change
 import com.intellij.openapi.vcs.changes.ChangeListManager
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
@@ -252,6 +253,10 @@ class InspectionHandlerTest {
         every { DumbService.getInstance(mockProject) } returns dumbService
         every { dumbService.isDumb } returns false
 
+        val inputFingerprint = projectInputsFingerprint(profileName = "TestProfile")
+        handler.projectInputsFingerprintProvider = { _, _ -> inputFingerprint }
+        handler.projectContentTrackerFactory = { _, _ -> FakeInspectionProjectContentTracker() }
+
         val response = processTriggerRequest("/api/inspection/trigger?scope=changed_files&include_unversioned=false")
         val body = response.content().toString(Charsets.UTF_8)
 
@@ -356,6 +361,9 @@ class InspectionHandlerTest {
             mockk(relaxed = true)
         }
         mockInspectionPrerequisites(mockProject)
+        val inputFingerprint = projectInputsFingerprint(profileName = "RedLane")
+        handler.projectInputsFingerprintProvider = { _, _ -> inputFingerprint }
+        handler.projectContentTrackerFactory = { _, _ -> FakeInspectionProjectContentTracker() }
 
         val response = processTriggerRequest(
             "/api/inspection/trigger?scope=changed_files&include_unversioned=false&profile=RedLane",
@@ -727,9 +735,278 @@ class InspectionHandlerTest {
 
         assertEquals(11L, reconciledSnapshot.projectState.psiModificationCount)
         assertEquals(false, completedStatus["results_may_be_stale"])
+        assertEquals("fresh", completedStatus["snapshot_change_kind"])
         assertEquals(true, completedStatus["has_inspection_results"])
         assertEquals(true, editedStatus["results_may_be_stale"])
         assertEquals("project_changed_since_inspection", editedStatus["snapshot_change_kind"])
+    }
+
+    @Test
+    fun `test changed files final publication reconciles verified psi churn`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        mockInspectionPrerequisites(mockProject)
+        val psiModificationCount = AtomicLong(11L)
+        every { PsiModificationTracker.getInstance(mockProject).modificationCount } answers {
+            psiModificationCount.get()
+        }
+        mockChangedFiles(listOf("/tmp/TestProject/src/Included.kt"))
+        val key = projectKey(mockProject)
+        InspectionResultsStore.clear(key)
+        val inputFingerprint = projectInputsFingerprint()
+        handler.projectInputsFingerprintProvider = { _, _ -> inputFingerprint }
+        val snapshotProblems = listOf(changedFileProblem())
+        mockExtractor(snapshotProblems)
+        setInspectionRunState(
+            key,
+            InspectionRunState(runId = 1L, triggerTimeMs = System.currentTimeMillis(), inProgress = true),
+        )
+
+        publishInspectionSnapshot(
+            runId = 1L,
+            snapshot = changedFilesSnapshot(snapshotProblems),
+            captureEndState = InspectionProjectStateSnapshot(psiModificationCount = 11L, unsavedProjectDocuments = 0),
+            projectStateChangedDuringCapture = true,
+            inspectionInputFingerprint = inputFingerprint,
+            projectContentTracker = FakeInspectionProjectContentTracker(),
+        )
+
+        val reconciledSnapshot = requireNotNull(InspectionResultsStore.getSnapshot(key))
+        assertEquals(11L, reconciledSnapshot.projectState.psiModificationCount)
+        assertEquals("current_run_psi_churn", reconciledSnapshot.reconciliationChangeKind)
+        setInspectionRunState(
+            key,
+            InspectionRunState(runId = 1L, triggerTimeMs = System.currentTimeMillis(), inProgress = false),
+        )
+        val completedStatus = buildInspectionStatus()
+        assertEquals(false, completedStatus["results_may_be_stale"])
+        assertEquals("current_run_psi_churn", completedStatus["snapshot_change_kind"])
+
+        psiModificationCount.set(12L)
+        val editedStatus = buildInspectionStatus()
+        assertEquals(true, editedStatus["results_may_be_stale"])
+        assertEquals("project_changed_since_inspection", editedStatus["snapshot_change_kind"])
+    }
+
+    @Test
+    fun `test empty changed files final publication reconciles verified psi churn without extraction`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        mockInspectionPrerequisites(mockProject)
+        every { PsiModificationTracker.getInstance(mockProject).modificationCount } returns 11L
+        mockChangedFiles(emptyList())
+        val key = projectKey(mockProject)
+        InspectionResultsStore.clear(key)
+        val inputFingerprint = projectInputsFingerprint()
+        handler.projectInputsFingerprintProvider = { _, _ -> inputFingerprint }
+        val extractor = mockk<EnhancedTreeExtractor>()
+        enhancedTreeExtractorFactory = { extractor }
+        setInspectionRunState(
+            key,
+            InspectionRunState(runId = 1L, triggerTimeMs = System.currentTimeMillis(), inProgress = true),
+        )
+
+        publishInspectionSnapshot(
+            runId = 1L,
+            snapshot = changedFilesSnapshot(
+                problems = emptyList(),
+                resolvedFiles = emptyList(),
+                source = "empty_changed_files",
+                outcome = InspectionSnapshotOutcome.CLEAN_CONFIRMED,
+            ),
+            captureEndState = InspectionProjectStateSnapshot(psiModificationCount = 11L, unsavedProjectDocuments = 0),
+            projectStateChangedDuringCapture = true,
+            inspectionInputFingerprint = inputFingerprint,
+            projectContentTracker = FakeInspectionProjectContentTracker(),
+        )
+
+        val reconciledSnapshot = requireNotNull(InspectionResultsStore.getSnapshot(key))
+        assertEquals(11L, reconciledSnapshot.projectState.psiModificationCount)
+        assertEquals("empty_changed_files", reconciledSnapshot.source)
+        assertEquals("current_run_psi_churn", reconciledSnapshot.reconciliationChangeKind)
+        verify(exactly = 0) { extractor.extractAllProblemsWithStatus(any()) }
+    }
+
+    @Test
+    fun `test changed files final publication rejects changed resolved scope`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        mockInspectionPrerequisites(mockProject)
+        every { PsiModificationTracker.getInstance(mockProject).modificationCount } returns 11L
+        mockChangedFiles(
+            listOf(
+                "/tmp/TestProject/src/Included.kt",
+                "/tmp/TestProject/src/Added.kt",
+            )
+        )
+        val key = projectKey(mockProject)
+        InspectionResultsStore.clear(key)
+        val inputFingerprint = projectInputsFingerprint()
+        handler.projectInputsFingerprintProvider = { _, _ -> inputFingerprint }
+        val extractor = mockk<EnhancedTreeExtractor>()
+        enhancedTreeExtractorFactory = { extractor }
+        setInspectionRunState(
+            key,
+            InspectionRunState(runId = 1L, triggerTimeMs = System.currentTimeMillis(), inProgress = true),
+        )
+
+        publishInspectionSnapshot(
+            runId = 1L,
+            snapshot = changedFilesSnapshot(listOf(changedFileProblem())),
+            captureEndState = InspectionProjectStateSnapshot(psiModificationCount = 11L, unsavedProjectDocuments = 0),
+            projectStateChangedDuringCapture = true,
+            inspectionInputFingerprint = inputFingerprint,
+            projectContentTracker = FakeInspectionProjectContentTracker(),
+        )
+
+        val publishedSnapshot = requireNotNull(InspectionResultsStore.getSnapshot(key))
+        assertEquals(10L, publishedSnapshot.projectState.psiModificationCount)
+        assertNull(publishedSnapshot.reconciliationChangeKind)
+        verify(exactly = 0) { extractor.extractAllProblemsWithStatus(any()) }
+    }
+
+    @Test
+    fun `test changed files final publication rejects unsaved documents`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        mockInspectionPrerequisites(mockProject)
+        val key = projectKey(mockProject)
+        InspectionResultsStore.clear(key)
+        val inputFingerprint = projectInputsFingerprint()
+        setInspectionRunState(
+            key,
+            InspectionRunState(runId = 1L, triggerTimeMs = System.currentTimeMillis(), inProgress = true),
+        )
+
+        publishInspectionSnapshot(
+            runId = 1L,
+            snapshot = changedFilesSnapshot(listOf(changedFileProblem())),
+            captureEndState = InspectionProjectStateSnapshot(psiModificationCount = 11L, unsavedProjectDocuments = 1),
+            projectStateChangedDuringCapture = true,
+            inspectionInputFingerprint = inputFingerprint,
+            projectContentTracker = FakeInspectionProjectContentTracker(),
+        )
+
+        val publishedSnapshot = requireNotNull(InspectionResultsStore.getSnapshot(key))
+        assertEquals(10L, publishedSnapshot.projectState.psiModificationCount)
+        assertNull(publishedSnapshot.reconciliationChangeKind)
+    }
+
+    @Test
+    fun `test changed files final publication does not replace a newer run`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        mockInspectionPrerequisites(mockProject)
+        val key = projectKey(mockProject)
+        InspectionResultsStore.clear(key)
+        setInspectionRunState(
+            key,
+            InspectionRunState(runId = 2L, triggerTimeMs = System.currentTimeMillis(), inProgress = true),
+        )
+
+        publishInspectionSnapshot(
+            runId = 1L,
+            snapshot = changedFilesSnapshot(listOf(changedFileProblem())),
+            captureEndState = InspectionProjectStateSnapshot(psiModificationCount = 11L, unsavedProjectDocuments = 0),
+            projectStateChangedDuringCapture = true,
+            inspectionInputFingerprint = projectInputsFingerprint(),
+            projectContentTracker = FakeInspectionProjectContentTracker(),
+        )
+
+        assertNull(InspectionResultsStore.getSnapshot(key))
+    }
+
+    @Test
+    fun `test changed files final publication rejects unreadable live extraction`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        mockInspectionPrerequisites(mockProject)
+        every { PsiModificationTracker.getInstance(mockProject).modificationCount } returns 11L
+        mockChangedFiles(listOf("/tmp/TestProject/src/Included.kt"))
+        val key = projectKey(mockProject)
+        InspectionResultsStore.clear(key)
+        val inputFingerprint = projectInputsFingerprint()
+        handler.projectInputsFingerprintProvider = { _, _ -> inputFingerprint }
+        mockExtractorFailure()
+        setInspectionRunState(
+            key,
+            InspectionRunState(runId = 1L, triggerTimeMs = System.currentTimeMillis(), inProgress = true),
+        )
+
+        publishInspectionSnapshot(
+            runId = 1L,
+            snapshot = changedFilesSnapshot(listOf(changedFileProblem())),
+            captureEndState = InspectionProjectStateSnapshot(psiModificationCount = 11L, unsavedProjectDocuments = 0),
+            projectStateChangedDuringCapture = true,
+            inspectionInputFingerprint = inputFingerprint,
+            projectContentTracker = FakeInspectionProjectContentTracker(),
+        )
+
+        val publishedSnapshot = requireNotNull(InspectionResultsStore.getSnapshot(key))
+        assertEquals(10L, publishedSnapshot.projectState.psiModificationCount)
+        assertNull(publishedSnapshot.reconciliationChangeKind)
+    }
+
+    @Test
+    fun `test changed files final publication rejects live identity mismatch`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        mockInspectionPrerequisites(mockProject)
+        every { PsiModificationTracker.getInstance(mockProject).modificationCount } returns 11L
+        mockChangedFiles(listOf("/tmp/TestProject/src/Included.kt"))
+        val key = projectKey(mockProject)
+        InspectionResultsStore.clear(key)
+        val inputFingerprint = projectInputsFingerprint()
+        handler.projectInputsFingerprintProvider = { _, _ -> inputFingerprint }
+        mockExtractor(listOf(changedFileProblem(description = "different live finding")))
+        setInspectionRunState(
+            key,
+            InspectionRunState(runId = 1L, triggerTimeMs = System.currentTimeMillis(), inProgress = true),
+        )
+
+        publishInspectionSnapshot(
+            runId = 1L,
+            snapshot = changedFilesSnapshot(listOf(changedFileProblem())),
+            captureEndState = InspectionProjectStateSnapshot(psiModificationCount = 11L, unsavedProjectDocuments = 0),
+            projectStateChangedDuringCapture = true,
+            inspectionInputFingerprint = inputFingerprint,
+            projectContentTracker = FakeInspectionProjectContentTracker(),
+        )
+
+        val publishedSnapshot = requireNotNull(InspectionResultsStore.getSnapshot(key))
+        assertEquals(10L, publishedSnapshot.projectState.psiModificationCount)
+        assertNull(publishedSnapshot.reconciliationChangeKind)
+    }
+
+    @Test
+    fun `test changed files final publication rejects project input mismatch`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        mockInspectionPrerequisites(mockProject)
+        every { PsiModificationTracker.getInstance(mockProject).modificationCount } returns 11L
+        mockChangedFiles(listOf("/tmp/TestProject/src/Included.kt"))
+        val key = projectKey(mockProject)
+        InspectionResultsStore.clear(key)
+        val inputFingerprint = projectInputsFingerprint()
+        handler.projectInputsFingerprintProvider = { _, _ -> projectInputsFingerprint(profileName = "ChangedProfile") }
+        mockExtractor(listOf(changedFileProblem()))
+        setInspectionRunState(
+            key,
+            InspectionRunState(runId = 1L, triggerTimeMs = System.currentTimeMillis(), inProgress = true),
+        )
+
+        publishInspectionSnapshot(
+            runId = 1L,
+            snapshot = changedFilesSnapshot(listOf(changedFileProblem())),
+            captureEndState = InspectionProjectStateSnapshot(psiModificationCount = 11L, unsavedProjectDocuments = 0),
+            projectStateChangedDuringCapture = true,
+            inspectionInputFingerprint = inputFingerprint,
+            projectContentTracker = FakeInspectionProjectContentTracker(),
+        )
+
+        val publishedSnapshot = requireNotNull(InspectionResultsStore.getSnapshot(key))
+        assertEquals(10L, publishedSnapshot.projectState.psiModificationCount)
+        assertNull(publishedSnapshot.reconciliationChangeKind)
     }
 
     @Test
@@ -4877,6 +5154,58 @@ class InspectionHandlerTest {
             namedScopeDefinitions = emptyList(),
             profileConfigurationHash = "profile-configuration-hash",
         )
+    }
+
+    private fun changedFilesSnapshot(
+        problems: List<Map<String, Any>>,
+        resolvedFiles: List<String> = listOf("/tmp/TestProject/src/Included.kt"),
+        psiModificationCount: Long = 10L,
+        source: String = "global_context",
+        outcome: InspectionSnapshotOutcome = InspectionSnapshotOutcome.PROBLEMS_FOUND,
+    ): InspectionResultsSnapshot {
+        return InspectionResultsSnapshot(
+            problems = problems,
+            timestamp = System.currentTimeMillis(),
+            projectState = InspectionProjectStateSnapshot(
+                psiModificationCount = psiModificationCount,
+                unsavedProjectDocuments = 0,
+            ),
+            outcome = outcome,
+            source = source,
+            captureScope = InspectionCaptureScope(
+                scopeParam = "changed_files",
+                resolvedFiles = resolvedFiles,
+                includeUnversioned = false,
+            ),
+            runId = 1L,
+        )
+    }
+
+    private fun changedFileProblem(
+        file: String = "/tmp/TestProject/src/Included.kt",
+        description: String = "current run finding",
+    ): Map<String, Any> {
+        return mapOf(
+            "file" to file,
+            "line" to 4,
+            "column" to 7,
+            "severity" to "warning",
+            "inspectionType" to "CurrentRunInspection",
+            "description" to description,
+        )
+    }
+
+    private fun mockChangedFiles(paths: List<String>): ChangeListManager {
+        val changeListManager = mockk<ChangeListManager>(relaxed = true)
+        every { ChangeListManager.getInstance(mockProject) } returns changeListManager
+        every { changeListManager.allChanges } returns paths.map { path ->
+            val file = mockk<VirtualFile>()
+            every { file.path } returns path
+            val change = mockk<Change>()
+            every { change.virtualFile } returns file
+            change
+        }
+        return changeListManager
     }
 
     private fun populateInspectionProfileElement(

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionSnapshotStateTest.kt
@@ -123,12 +123,35 @@ class InspectionSnapshotStateTest {
             scopeParam = "files",
             resolvedFiles = listOf("/tmp/TestProject/test/AppTest.kt"),
         )
+        val changedFiles = InspectionCaptureScope(
+            scopeParam = "changed_files",
+            resolvedFiles = listOf(
+                "/tmp/TestProject/src/App.kt",
+                "/tmp/TestProject/src/Util.kt",
+            ),
+        )
+        val changedAppFile = InspectionCaptureScope(
+            scopeParam = "changed_files",
+            resolvedFiles = listOf("/tmp/TestProject/src/App.kt"),
+        )
+        val noChangedFiles = InspectionCaptureScope(
+            scopeParam = "changed_files",
+            resolvedFiles = emptyList(),
+        )
 
         assertTrue(inspectionCaptureScopeCoversRequest(wholeProject, otherFile))
         assertTrue(inspectionCaptureScopeCoversRequest(directory, appFile))
+        assertTrue(inspectionCaptureScopeCoversRequest(directory, changedAppFile))
         assertTrue(inspectionCaptureScopeCoversRequest(files, appFile))
+        assertTrue(inspectionCaptureScopeCoversRequest(changedFiles, files))
+        assertTrue(inspectionCaptureScopeCoversRequest(changedFiles, changedFiles))
+        assertTrue(inspectionCaptureScopeCoversRequest(noChangedFiles, noChangedFiles))
         assertFalse(inspectionCaptureScopeCoversRequest(files, wholeProject))
+        assertFalse(inspectionCaptureScopeCoversRequest(changedFiles, wholeProject))
         assertFalse(inspectionCaptureScopeCoversRequest(files, otherFile))
+        assertFalse(inspectionCaptureScopeCoversRequest(files, noChangedFiles))
+        assertFalse(inspectionCaptureScopeCoversRequest(changedFiles, changedAppFile))
+        assertFalse(inspectionCaptureScopeCoversRequest(changedAppFile, changedFiles))
         assertFalse(inspectionCaptureScopeCoversRequest(directory, otherFile))
     }
 


### PR DESCRIPTION
## Summary

- extend final snapshot input validation and PSI-churn reconciliation to `changed_files` captures
- require exact resolved changed-file scope, stable project/profile inputs, authoritative scoped identity equivalence, and a current run before promotion
- route the intentional empty-changed-files fast path through the same proof gate without creating an IDE inspection context
- make changed-file truncation deterministic and same-scope coverage exact
- document the completed `current_run_psi_churn` proof marker

## Validation

- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./scripts/commit-gate.sh --ci`
- focused `InspectionHandlerTest` + `InspectionSnapshotStateTest`
- independent GPT/Claude/Google-family adversarial reviews; final diff review clean
- IntelliJ IDEA 2026.2 live closeout, build `2b6227d6c08c-clean`: `empty_changed_files`, `results_fresh=true`, `results_may_be_stale=false`, GREEN, cleanup closed
- WebStorm 2026.2 live closeout, build `2b6227d6c08c-clean`: `empty_changed_files`, `results_fresh=true`, `results_may_be_stale=false`, GREEN, cleanup closed

Closes #215
