### PR TITLE
Ignore generated JetBrains project name metadata

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,4 +1,5 @@
 # Default ignored files
+/.name
 /shelf/
 /workspace.xml
 # Editor-based HTTP Client requests


### PR DESCRIPTION
## Summary

- ignore JetBrains-generated `.idea/.name` so helper-opened worktrees do not treat local project-name metadata as `changed_files` source input
- preserve tracked `.idea` project configuration and fail-closed semantic coverage for real source files

## Validation

- full Java 21 commit gate passed, including plugin, inspection-core, MCP server, release-contract tests, and `buildPlugin`
- `git check-ignore -v --no-index .idea/.name` resolves to `.idea/.gitignore`
- landed helper `f77438085b3499fd610765170683e97f9e5e168b` against a patched disposable IntelliJ IDEA 2026.2 worktree returned GREEN with plugin `1.13.17@2b6227d6c08c-clean` and cleanup closed
- final-pair RED lanes returned actionable findings with cleanup closed in IntelliJ IDEA 2026.2, PyCharm 2026.1.4, and WebStorm 2026.2

Refs #216