### PR TITLE
Fix helper-owned content root stabilization

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,9 +335,17 @@ clients should keep using `/route`, `/trigger`, `/wait`, `/status`, and
   `ownership_proven: true`; preexisting, coalesced, mismatched, and untracked
   projects return `status: "not_owned"` without a close token. Helper-owned
   routes and claims also include `lifecycle_readiness`; automation must wait
-  for `ready: true` before inspection. A project that remains
+  for `ready: true` before inspection. For a helper-owned raw directory whose
+  configurators leave no usable module/content root, the plugin may install a
+  non-persistent fallback module rooted at the requested worktree. Repair is
+  limited to the exact lease-bound project instance; preexisting, coalesced,
+  and outside-root projects remain untouched. The fallback exists only for that
+  IDE project instance and does not create tracked `.idea` or `.iml` files. A
+  project that remains
   `no_content_roots` or `content_roots_outside_target` fails preparation while
-  retaining lease-bound close authority for cleanup.
+  retaining lease-bound close authority for cleanup. Readiness that appears too
+  close to the guard deadline remains fail-closed as
+  `project_configuration_unstable` until cleanup.
 - `GET /api/inspection/lifecycle/close`: requires `project_key`,
   `project_instance_id`, `session_id`, and `close_token`, and accepts the
   original `lease_id` for an additional binding check. It closes the project

--- a/TESTING.md
+++ b/TESTING.md
@@ -94,10 +94,17 @@ field without that proof is not sufficient to close a project. Regression tests
 must cover a user project appearing between open acceptance and IDE-thread
 execution, and must prove that such a project receives no close token.
 Helper-owned routes expose `lifecycle_readiness`; readiness requires a content
-root covering the requested worktree for two consecutive status observations.
-If import never establishes that model, preparation must fail with
+root covering the requested worktree after project configuration stabilizes.
+If configurators remove the initial raw-directory module, the plugin repairs
+the exact lease-bound helper-owned project with a non-persistent fallback module
+and reports `fallback_module_count`; the fallback must not create tracked
+project files or alter a preexisting, coalesced, or outside-root project.
+If neither the project model nor that bounded repair establishes coverage,
+preparation must fail with
 `project_content_roots_missing` and close the helper-owned project before any
-inspection trigger.
+inspection trigger. A project model that becomes ready but misses the required
+stabilization window must remain unresolved as `project_configuration_unstable`
+rather than becoming ready on the next lifecycle poll.
 
 The helper treats `capture_incomplete`, stale results, timeouts, indexing,
 session drift, route ambiguity, wrong-worktree routes, and cleanup failures as

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -14,10 +14,12 @@ import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.module.EmptyModuleType
 import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.module.ModuleUtilCore
 import com.intellij.openapi.roots.CompilerModuleExtension
 import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.roots.ModuleRootModificationUtil
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.util.ProgressWindow
@@ -93,6 +95,7 @@ private const val EXACT_WORKTREE_PATH_SELECTOR_PREFIX = "exact-worktree-path:"
 private const val MAX_SCOPE_FILE_DIAGNOSTICS = 25
 private const val SCOPE_FILE_SEMANTIC_COVERAGE_SCHEMA_VERSION = 1
 private const val SCOPE_SEMANTIC_COVERAGE_MISSING_REASON = "scope_semantic_coverage_missing"
+private const val LIFECYCLE_FALLBACK_MODULE_PREFIX = "__jetbrains_inspection_api_lifecycle_fallback__"
 internal const val LIFECYCLE_OWNERSHIP_PROTOCOL = "lease_bound_v1"
 private const val INSPECTION_ATTRIBUTION_SCHEMA_VERSION = 1
 private val NON_SEMANTIC_SCOPE_FILE_VALUES = setOf("text", "plaintext", "textmate")
@@ -1381,6 +1384,7 @@ class InspectionHandler : HttpRequestHandler() {
         val contentRootCount: Int = 0,
         val sourceRootCount: Int = 0,
         val moduleCount: Int = 0,
+        val fallbackModuleCount: Int = 0,
         val targetInsideContent: Boolean = false,
         val contentRootInsideTarget: Boolean = false,
         val contentRoots: List<String> = emptyList(),
@@ -1409,7 +1413,10 @@ class InspectionHandler : HttpRequestHandler() {
     internal var closeVerificationNow: () -> Long = { System.currentTimeMillis() }
     internal var closeVerificationSleep: (Long) -> Unit = { millis -> Thread.sleep(millis) }
     internal var lifecycleOpenGuardPollMs: Long = 200
-    internal var lifecycleOpenGuardTimeoutMs: Long = 10_000
+    internal var lifecycleOpenGuardTimeoutMs: Long = 30_000
+    internal var lifecycleOpenRootStabilizationMs: Long = 10_000
+    internal var lifecycleFallbackRootStabilizationMs: Long = 2_000
+    internal var lifecycleFallbackFailureThreshold: Int = 3
     internal var lifecycleOpenGuardNow: () -> Long = { System.currentTimeMillis() }
     internal var lifecycleOpenGuardSleep: (Long) -> Unit = { millis -> Thread.sleep(millis) }
     internal var inspectionRunExpirationMs: Long = 300000L
@@ -1442,6 +1449,15 @@ class InspectionHandler : HttpRequestHandler() {
     }
     internal var lifecycleContentRootReadinessProvider: (Project, String) -> LifecycleContentRootReadiness =
         { project, targetKey -> inspectLifecycleContentRootReadiness(project, targetKey) }
+    internal var lifecycleProjectSmartProvider: (Project) -> Boolean = { project ->
+        !DumbService.getInstance(project).isDumb
+    }
+    internal var lifecycleFallbackContentRootInstaller: (Project, String) -> Boolean = { project, targetKey ->
+        installLifecycleFallbackContentRoot(project, targetKey)
+    }
+    internal var lifecycleFallbackContentRootCreator: (Project, VirtualFile) -> Boolean = { project, targetRoot ->
+        createLifecycleFallbackContentRoot(project, targetRoot)
+    }
     internal var openProjectPath: (Path, (Project) -> Unit) -> Project? = { path, beforeInit ->
         val openPath = canonicalTrustPath(path)
         ProjectManagerEx.getInstanceEx().openProject(
@@ -2528,7 +2544,7 @@ class InspectionHandler : HttpRequestHandler() {
             )
         }
 
-        val lifecycleReadiness = lifecycleContentRootReadinessProvider(
+        val lifecycleReadiness = lifecycleContentRootReadinessForOwnership(
             resolved.project,
             requireNotNull(exactOwnership).targetKey,
         )
@@ -2570,23 +2586,31 @@ class InspectionHandler : HttpRequestHandler() {
             ?: throw BadRequestException("worktree_path", "Parameter 'worktree_path' must be a valid local path.")
         val path = Paths.get(normalizedPath)
         findOpenProjectForLifecycleOpen(path.toString())?.let { project ->
+            unresolvedLifecycleOpenProjects.entries
+                .firstOrNull { entry -> entry.value === project }
+                ?.let { entry ->
+                    if (isUnresolvedLifecycleOpenActive(project)) {
+                        val projectRoot = Paths.get(entry.key)
+                        return lifecycleOpenStateUnknown(
+                            LifecycleOpenTarget(path, projectRoot, projectRoot, entry.key),
+                            project,
+                        )
+                    }
+                    unresolvedLifecycleOpenProjects.remove(entry.key, project)
+                }
             return lifecycleOpenAlreadyOpen(project)
         }
         val target = resolveLifecycleOpenTarget(path)
+        unresolvedLifecycleOpenProjects[target.key]?.let { project ->
+            if (isUnresolvedLifecycleOpenActive(project)) {
+                return lifecycleOpenStateUnknown(target, project)
+            }
+            unresolvedLifecycleOpenProjects.remove(target.key, project)
+        }
         if (target.projectRoot != target.path) {
             findOpenProjectForLifecycleOpen(target.projectRoot.toString())?.let { project ->
                 return lifecycleOpenAlreadyOpen(project)
             }
-        }
-        unresolvedLifecycleOpenProjects[target.key]?.let { project ->
-            if (isUnresolvedLifecycleOpenActive(project)) {
-                if (isLifecycleOpenProjectUsable(target.key, project)) {
-                    unresolvedLifecycleOpenProjects.remove(target.key, project)
-                    return lifecycleOpenAlreadyOpen(project)
-                }
-                return lifecycleOpenStateUnknown(target, project)
-            }
-            unresolvedLifecycleOpenProjects.remove(target.key, project)
         }
         findOpenProjectForLifecycleOpenKey(target.key)?.let { project ->
             unresolvedLifecycleOpenProjects.remove(target.key)
@@ -2686,11 +2710,6 @@ class InspectionHandler : HttpRequestHandler() {
             unresolvedLifecycleOpenProjects.remove(key)
             return
         }
-        if (isLifecycleOpenProjectUsable(key, project)) {
-            openingProjectRequests.remove(key, request)
-            unresolvedLifecycleOpenProjects.remove(key)
-            return
-        }
         val submitted = runCatching {
             ApplicationManager.getApplication().executeOnPooledThread {
                 var unresolvedOpenState = false
@@ -2698,17 +2717,61 @@ class InspectionHandler : HttpRequestHandler() {
                     val startedAtMs = lifecycleOpenGuardNow()
                     val deadlineMs = startedAtMs + lifecycleOpenGuardTimeoutMs
                     var observedOpenProject = false
+                    var stableReadySinceMs: Long? = null
+                    var previousStabilizationMs: Long? = null
+                    var contentRootFailureCount = 0
+                    var fallbackAttemptCount = 0
                     while (openingProjectRequests.containsKey(key)) {
                         val nowMs = lifecycleOpenGuardNow()
                         val lifecycleComplete = runCatching {
                             val readiness = lifecycleContentRootReadinessProvider(project, key)
                             val isOpenProject = readiness.reason != "project_not_open"
                             observedOpenProject = observedOpenProject || isOpenProject
-                            unresolvedOpenState = !readiness.ready && nowMs >= deadlineMs
-                            project.isDisposed ||
-                                readiness.ready ||
-                                (observedOpenProject && !isOpenProject) ||
-                                unresolvedOpenState
+                            when {
+                                project.isDisposed -> true
+                                observedOpenProject && !isOpenProject -> true
+                                readiness.ready -> {
+                                    contentRootFailureCount = 0
+                                    val stabilizationMs = when {
+                                        readiness.fallbackModuleCount > 0 -> lifecycleFallbackRootStabilizationMs
+                                        readiness.sourceRootCount == 0 -> lifecycleOpenRootStabilizationMs
+                                        else -> 0L
+                                    }
+                                    if (
+                                        previousStabilizationMs != null &&
+                                        stabilizationMs > requireNotNull(previousStabilizationMs)
+                                    ) {
+                                        stableReadySinceMs = null
+                                    }
+                                    previousStabilizationMs = stabilizationMs
+                                    stableReadySinceMs = stableReadySinceMs ?: nowMs
+                                    val stabilized = nowMs - requireNotNull(stableReadySinceMs) >= stabilizationMs
+                                    unresolvedOpenState = !stabilized && nowMs >= deadlineMs
+                                    stabilized || unresolvedOpenState
+                                }
+                                else -> {
+                                    stableReadySinceMs = null
+                                    previousStabilizationMs = null
+                                    val fallbackOwned = hasExactLifecycleFallbackOwnership(project, key, request)
+                                    val contentRootFailure = readiness.reason == "no_content_roots"
+                                    if (contentRootFailure && fallbackOwned && lifecycleProjectSmartProvider(project)) {
+                                        contentRootFailureCount += 1
+                                        if (
+                                            contentRootFailureCount >= lifecycleFallbackFailureThreshold &&
+                                            fallbackAttemptCount == 0
+                                        ) {
+                                            contentRootFailureCount = 0
+                                            if (lifecycleFallbackContentRootInstaller(project, key)) {
+                                                fallbackAttemptCount += 1
+                                            }
+                                        }
+                                    } else {
+                                        contentRootFailureCount = 0
+                                    }
+                                    unresolvedOpenState = nowMs >= deadlineMs
+                                    unresolvedOpenState
+                                }
+                            }
                         }.getOrDefault(false)
                         if (lifecycleComplete) {
                             return@executeOnPooledThread
@@ -2716,18 +2779,18 @@ class InspectionHandler : HttpRequestHandler() {
                         lifecycleOpenGuardSleep(lifecycleOpenGuardPollMs)
                     }
                 } finally {
-                    openingProjectRequests.remove(key, request)
                     if (unresolvedOpenState && isUnresolvedLifecycleOpenActive(project)) {
                         unresolvedLifecycleOpenProjects[key] = project
                     }
+                    openingProjectRequests.remove(key, request)
                 }
             }
         }.isSuccess
         if (!submitted) {
-            openingProjectRequests.remove(key, request)
             if (isUnresolvedLifecycleOpenActive(project)) {
                 unresolvedLifecycleOpenProjects[key] = project
             }
+            openingProjectRequests.remove(key, request)
         }
     }
 
@@ -2739,8 +2802,79 @@ class InspectionHandler : HttpRequestHandler() {
         }.getOrDefault(!project.isDisposed)
     }
 
-    private fun isLifecycleOpenProjectUsable(key: String, project: Project): Boolean {
-        return lifecycleContentRootReadinessProvider(project, key).ready
+    private fun lifecycleContentRootReadinessForOwnership(
+        project: Project,
+        targetKey: String,
+    ): LifecycleContentRootReadiness {
+        val readiness = lifecycleContentRootReadinessProvider(project, targetKey)
+        return when {
+            openingProjectRequests.containsKey(targetKey) ->
+                readiness.copy(ready = false, reason = "project_configuring")
+            unresolvedLifecycleOpenProjects[targetKey] === project && readiness.ready ->
+                readiness.copy(ready = false, reason = "project_configuration_unstable")
+            else -> readiness
+        }
+    }
+
+    private fun installLifecycleFallbackContentRoot(project: Project, targetKey: String): Boolean {
+        val request = openingProjectRequests[targetKey] ?: return false
+        if (!hasExactLifecycleFallbackOwnership(project, targetKey, request)) return false
+        val targetPath = runCatching { canonicalTrustPath(Paths.get(targetKey)) }.getOrNull() ?: return false
+        if (!Files.isDirectory(targetPath)) return false
+        val targetRoot = LocalFileSystem.getInstance().refreshAndFindFileByNioFile(targetPath) ?: return false
+        val application = ApplicationManager.getApplication()
+        return runCatching {
+            application.invokeLater {
+                val activeRequest = openingProjectRequests[targetKey]
+                if (
+                    activeRequest !== request ||
+                    !hasExactLifecycleFallbackOwnership(project, targetKey, request)
+                ) {
+                    return@invokeLater
+                }
+                val readiness = lifecycleContentRootReadinessProvider(project, targetKey)
+                if (readiness.reason != "no_content_roots") {
+                    return@invokeLater
+                }
+                lifecycleFallbackContentRootCreator(project, targetRoot)
+            }
+            true
+        }.getOrDefault(false)
+    }
+
+    private fun hasExactLifecycleFallbackOwnership(
+        project: Project,
+        targetKey: String,
+        request: LifecycleOpenRequest,
+    ): Boolean {
+        val leaseId = request.leaseId ?: return false
+        val ownership = lifecycleOpenOwnershipByProjectInstance[projectInstanceId(project)] ?: return false
+        return !project.isDisposed &&
+            ownership.project === project &&
+            ownership.targetKey == targetKey &&
+            ownership.leaseId == leaseId
+    }
+
+    private fun createLifecycleFallbackContentRoot(project: Project, targetRoot: VirtualFile): Boolean {
+        if (project.isDisposed) return false
+        var created = false
+        ApplicationManager.getApplication().runWriteAction {
+            if (project.isDisposed) return@runWriteAction
+            val moduleManager = ModuleManager.getInstance(project)
+            var moduleName = "$LIFECYCLE_FALLBACK_MODULE_PREFIX${UUID.randomUUID()}"
+            while (moduleManager.findModuleByName(moduleName) != null) {
+                moduleName = "$LIFECYCLE_FALLBACK_MODULE_PREFIX${UUID.randomUUID()}"
+            }
+            val module = moduleManager.newNonPersistentModule(moduleName, EmptyModuleType.EMPTY_MODULE)
+            try {
+                ModuleRootModificationUtil.addContentRoot(module, targetRoot)
+                created = true
+            } catch (error: Exception) {
+                moduleManager.disposeModule(module)
+                throw error
+            }
+        }
+        return created
     }
 
     private fun inspectLifecycleContentRootReadiness(
@@ -2767,6 +2901,7 @@ class InspectionHandler : HttpRequestHandler() {
                             .mapNotNull(::normalizeFileSystemPath)
                             .distinct()
                             .sorted()
+                        val modules = ModuleManager.getInstance(project).modules
                         val sourceRootCount = rootManager.contentSourceRoots
                             .mapNotNull(::localInspectionRootPath)
                             .mapNotNull(::normalizeFileSystemPath)
@@ -2783,9 +2918,17 @@ class InspectionHandler : HttpRequestHandler() {
                                 canonicalTrustPath(Paths.get(contentRoot)).startsWith(targetPath)
                             }.getOrDefault(false)
                         }
+                        val unrelatedContentRoot = contentRoots.any { contentRoot ->
+                            runCatching {
+                                val canonicalContentRoot = canonicalTrustPath(Paths.get(contentRoot))
+                                !targetPath.startsWith(canonicalContentRoot) &&
+                                    !canonicalContentRoot.startsWith(targetPath)
+                            }.getOrDefault(true)
+                        }
                         val reason = when {
                             contentRoots.isEmpty() -> "no_content_roots"
-                            !targetInsideContent && !contentRootInsideTarget -> "content_roots_outside_target"
+                            unrelatedContentRoot || (!targetInsideContent && !contentRootInsideTarget) ->
+                                "content_roots_outside_target"
                             else -> "ready"
                         }
                         LifecycleContentRootReadiness(
@@ -2794,7 +2937,10 @@ class InspectionHandler : HttpRequestHandler() {
                             targetKey = targetKey,
                             contentRootCount = contentRoots.size,
                             sourceRootCount = sourceRootCount,
-                            moduleCount = ModuleManager.getInstance(project).modules.size,
+                            moduleCount = modules.size,
+                            fallbackModuleCount = modules.count { module ->
+                                module.name.startsWith(LIFECYCLE_FALLBACK_MODULE_PREFIX)
+                            },
                             targetInsideContent = targetInsideContent,
                             contentRootInsideTarget = contentRootInsideTarget,
                             contentRoots = contentRoots.take(MAX_SCOPE_FILE_DIAGNOSTICS),
@@ -2815,6 +2961,7 @@ class InspectionHandler : HttpRequestHandler() {
             "content_root_count" to readiness.contentRootCount,
             "source_root_count" to readiness.sourceRootCount,
             "module_count" to readiness.moduleCount,
+            "fallback_module_count" to readiness.fallbackModuleCount,
             "target_inside_content" to readiness.targetInsideContent,
             "content_root_inside_target" to readiness.contentRootInsideTarget,
             "content_roots" to readiness.contentRoots,
@@ -2827,7 +2974,7 @@ class InspectionHandler : HttpRequestHandler() {
             ?.takeIf { candidate -> candidate.project === project }
             ?: return null
         return lifecycleContentRootReadinessPayload(
-            lifecycleContentRootReadinessProvider(project, ownership.targetKey)
+            lifecycleContentRootReadinessForOwnership(project, ownership.targetKey)
         )
     }
 
@@ -2856,7 +3003,12 @@ class InspectionHandler : HttpRequestHandler() {
         target: LifecycleOpenTarget,
         project: Project,
     ): Pair<Map<String, Any?>, HttpResponseStatus> {
-        val readiness = lifecycleContentRootReadinessProvider(project, target.key)
+        val observedReadiness = lifecycleContentRootReadinessProvider(project, target.key)
+        val readiness = if (observedReadiness.ready) {
+            observedReadiness.copy(ready = false, reason = "project_configuration_unstable")
+        } else {
+            observedReadiness
+        }
         val contentRootFailure = readiness.reason in setOf("no_content_roots", "content_roots_outside_target")
         return mapOf(
             "status" to "failed",
@@ -2865,6 +3017,8 @@ class InspectionHandler : HttpRequestHandler() {
             "reason" to if (contentRootFailure) "project_content_roots_missing" else "open_state_unknown",
             "message" to if (contentRootFailure) {
                 "The IDE opened the project but did not establish a content root covering the requested worktree before the guard timeout."
+            } else if (readiness.reason == "project_configuration_unstable") {
+                "The IDE project model became ready but did not remain stable for the required window before the guard timeout."
             } else {
                 "The IDE accepted the lifecycle open request but did not report a ready project before the guard timeout."
             },

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -16,7 +16,9 @@ import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.fileTypes.FileType
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.module.EmptyModuleType
 import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.roots.ModuleRootModificationUtil
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.module.ModuleManager
@@ -3661,9 +3663,10 @@ class InspectionHandlerTest {
         val rootManager = mockk<ProjectRootManager>()
         val moduleManager = mockk<ModuleManager>()
         var contentRoots = emptyArray<VirtualFile>()
+        var modules = emptyArray<com.intellij.openapi.module.Module>()
         every { rootManager.contentRoots } answers { contentRoots }
         every { rootManager.contentSourceRoots } returns emptyArray()
-        every { moduleManager.modules } returns emptyArray()
+        every { moduleManager.modules } answers { modules }
         mockkStatic(ProjectRootManager::class)
         mockkStatic(ModuleManager::class)
         every { ProjectRootManager.getInstance(mockProject) } returns rootManager
@@ -3686,6 +3689,12 @@ class InspectionHandlerTest {
             assertFalse(childReady.targetInsideContent)
             assertTrue(childReady.contentRootInsideTarget)
 
+            val fallbackModule = mockk<com.intellij.openapi.module.Module>()
+            every { fallbackModule.name } returns "__jetbrains_inspection_api_lifecycle_fallback__test"
+            modules = arrayOf(fallbackModule)
+            val fallbackReady = productionHandler.lifecycleContentRootReadinessProvider(mockProject, targetKey)
+            assertEquals(1, fallbackReady.fallbackModuleCount)
+
             val outsideRootPath = Files.createDirectories(tempDir.resolveSibling("outside-module"))
             val outsideRoot = mockk<VirtualFile>()
             every { outsideRoot.path } returns outsideRootPath.toString()
@@ -3694,8 +3703,50 @@ class InspectionHandlerTest {
             val outside = productionHandler.lifecycleContentRootReadinessProvider(mockProject, targetKey)
             assertFalse(outside.ready)
             assertEquals("content_roots_outside_target", outside.reason)
+
+            contentRoots = arrayOf(childRoot, outsideRoot)
+            val mixedRoots = productionHandler.lifecycleContentRootReadinessProvider(mockProject, targetKey)
+            assertFalse(mixedRoots.ready)
+            assertEquals("content_roots_outside_target", mixedRoots.reason)
         } finally {
             unmockkStatic(ProjectRootManager::class)
+            unmockkStatic(ModuleManager::class)
+        }
+    }
+
+    @Test
+    fun `test lifecycle fallback creator adds a non-persistent module content root`() {
+        val moduleManager = mockk<ModuleManager>()
+        val module = mockk<com.intellij.openapi.module.Module>()
+        val targetRoot = mockk<VirtualFile>()
+        val moduleName = slot<String>()
+        every { mockProject.isDisposed } returns false
+        every { mockApplication.runWriteAction(any<Runnable>()) } answers {
+            firstArg<Runnable>().run()
+        }
+        mockkStatic(ModuleManager::class)
+        mockkStatic(ModuleRootModificationUtil::class)
+        every { ModuleManager.getInstance(mockProject) } returns moduleManager
+        every { moduleManager.findModuleByName(any()) } returns null
+        every {
+            moduleManager.newNonPersistentModule(capture(moduleName), EmptyModuleType.EMPTY_MODULE)
+        } returns module
+        every { moduleManager.disposeModule(any()) } just Runs
+        every { ModuleRootModificationUtil.addContentRoot(module, targetRoot) } just Runs
+
+        try {
+            assertTrue(handler.lifecycleFallbackContentRootCreator(mockProject, targetRoot))
+            assertTrue(
+                moduleName.captured.startsWith("__jetbrains_inspection_api_lifecycle_fallback__"),
+                moduleName.captured,
+            )
+            verify(exactly = 1) {
+                moduleManager.newNonPersistentModule(moduleName.captured, EmptyModuleType.EMPTY_MODULE)
+                ModuleRootModificationUtil.addContentRoot(module, targetRoot)
+            }
+            verify(exactly = 0) { moduleManager.disposeModule(any()) }
+        } finally {
+            unmockkStatic(ModuleRootModificationUtil::class)
             unmockkStatic(ModuleManager::class)
         }
     }
@@ -3951,6 +4002,101 @@ class InspectionHandlerTest {
 
         assertTrue(claimBody.contains("\"status\": \"not_owned\""))
         assertFalse(claimBody.contains("\"close_token\""))
+        assertFalse(
+            handler.lifecycleFallbackContentRootInstaller(returnedProject, tempDir.toRealPath().toString()),
+            "A returned project that does not match the before-init ownership instance must not be repaired.",
+        )
+    }
+
+    @Test
+    fun `test lifecycle fallback installer requires a lease-bound open`() {
+        val tempDir = Files.createTempDirectory("inspection-open-fallback-no-lease")
+        val openedProject = mockProject(
+            name = "NoLease",
+            basePath = tempDir.toString(),
+            projectFilePath = tempDir.resolve(".idea/misc.xml").toString(),
+        )
+        var openProjects = emptyArray<Project>()
+        every { mockProjectManager.openProjects } answers { openProjects }
+        every { mockApplication.invokeLater(any()) } answers {
+            firstArg<Runnable>().run()
+        }
+        handler.openProjectPath = { _, beforeInit ->
+            beforeInit(openedProject)
+            openProjects = arrayOf(openedProject)
+            openedProject
+        }
+        val encodedPath = java.net.URLEncoder.encode(tempDir.toString(), "UTF-8")
+        val encodedSession = java.net.URLEncoder.encode(InspectionIdeSession.sessionId, "UTF-8")
+
+        processGetRequest(
+            "/api/inspection/lifecycle/open?worktree_path=$encodedPath&session_id=$encodedSession"
+        )
+
+        assertFalse(
+            handler.lifecycleFallbackContentRootInstaller(openedProject, tempDir.toRealPath().toString()),
+            "Fallback repair requires the same lease used to register helper ownership.",
+        )
+    }
+
+    @Test
+    fun `test lifecycle fallback installer schedules exact owned root without blocking`() {
+        val tempDir = Files.createTempDirectory("inspection-open-fallback-owned")
+        val openedProject = mockProject(
+            name = "OwnedFallback",
+            basePath = tempDir.toString(),
+            projectFilePath = tempDir.resolve(".idea/misc.xml").toString(),
+        )
+        var openProjects = emptyArray<Project>()
+        val scheduled = mutableListOf<Runnable>()
+        val pooled = mutableListOf<Runnable>()
+        every { mockProjectManager.openProjects } answers { openProjects }
+        every { mockApplication.invokeLater(any()) } answers {
+            scheduled += firstArg<Runnable>()
+        }
+        every { mockApplication.executeOnPooledThread(any<Runnable>()) } answers {
+            pooled += firstArg<Runnable>()
+            mockk(relaxed = true)
+        }
+        handler.openProjectPath = { _, beforeInit ->
+            beforeInit(openedProject)
+            openProjects = arrayOf(openedProject)
+            openedProject
+        }
+        handler.lifecycleContentRootReadinessProvider = { _, targetKey ->
+            InspectionHandler.LifecycleContentRootReadiness(
+                ready = false,
+                reason = "no_content_roots",
+                targetKey = targetKey,
+            )
+        }
+        val localFileSystem = mockk<LocalFileSystem>()
+        val targetRoot = mockk<VirtualFile>()
+        val targetKey = tempDir.toRealPath().toString()
+        var createdRoot: VirtualFile? = null
+        mockkStatic(LocalFileSystem::class)
+        every { LocalFileSystem.getInstance() } returns localFileSystem
+        every { localFileSystem.refreshAndFindFileByNioFile(tempDir.toRealPath()) } returns targetRoot
+        handler.lifecycleFallbackContentRootCreator = { project, root ->
+            assertSame(openedProject, project)
+            createdRoot = root
+            true
+        }
+
+        try {
+            processGetRequest(lifecycleOpenUri(tempDir, "owned-fallback-lease"))
+            scheduled.single().run()
+
+            assertEquals(1, pooled.size)
+            assertTrue(handler.lifecycleFallbackContentRootInstaller(openedProject, targetKey))
+            assertEquals(2, scheduled.size, "The installer must enqueue work instead of blocking on the EDT.")
+            assertNull(createdRoot)
+
+            scheduled.last().run()
+            assertSame(targetRoot, createdRoot)
+        } finally {
+            unmockkStatic(LocalFileSystem::class)
+        }
     }
 
     @Test
@@ -4343,6 +4489,107 @@ class InspectionHandlerTest {
     }
 
     @Test
+    fun `test lifecycle open repairs content root lost during project configuration`() {
+        val tempDir = Files.createTempDirectory("inspection-open-root-repair")
+        val openProjects = arrayOfNulls<Project>(1)
+        every { mockProjectManager.openProjects } answers { openProjects.filterNotNull().toTypedArray() }
+        val initializingProject = mockk<Project>()
+        every { initializingProject.isDefault } returns false
+        every { initializingProject.isDisposed } returns false
+        every { initializingProject.isInitialized } returns true
+        every { initializingProject.name } returns "inspection-open-root-repair"
+        every { initializingProject.basePath } returns tempDir.toString()
+        every { initializingProject.projectFilePath } returns tempDir.resolve(".idea/misc.xml").toString()
+        val scheduled = mutableListOf<Runnable>()
+        val guardPolls = mutableListOf<Runnable>()
+        var nowMs = 1_000L
+        var fallbackInstalled = false
+        var fallbackCreateCount = 0
+        every { mockApplication.invokeLater(any()) } answers {
+            scheduled += firstArg<Runnable>()
+        }
+        every { mockApplication.executeOnPooledThread(any<Runnable>()) } answers {
+            guardPolls += firstArg<Runnable>()
+            mockk(relaxed = true)
+        }
+        handler.lifecycleOpenGuardPollMs = 200
+        handler.lifecycleOpenGuardTimeoutMs = 2_000
+        handler.lifecycleOpenRootStabilizationMs = 400
+        handler.lifecycleFallbackRootStabilizationMs = 200
+        handler.lifecycleFallbackFailureThreshold = 2
+        handler.lifecycleOpenGuardNow = { nowMs }
+        handler.lifecycleOpenGuardSleep = { millis ->
+            if (!fallbackInstalled && scheduled.size > 1) {
+                scheduled.last().run()
+            }
+            nowMs += millis
+        }
+        handler.lifecycleProjectSmartProvider = { true }
+        handler.lifecycleContentRootReadinessProvider = { _, targetKey ->
+            when {
+                fallbackInstalled -> InspectionHandler.LifecycleContentRootReadiness(
+                    ready = true,
+                    reason = "ready",
+                    targetKey = targetKey,
+                    contentRootCount = 1,
+                    moduleCount = 1,
+                    fallbackModuleCount = 1,
+                    targetInsideContent = true,
+                    contentRoots = listOf(targetKey),
+                )
+                nowMs < 1_200L -> InspectionHandler.LifecycleContentRootReadiness(
+                    ready = true,
+                    reason = "ready",
+                    targetKey = targetKey,
+                    contentRootCount = 1,
+                    moduleCount = 1,
+                    targetInsideContent = true,
+                    contentRoots = listOf(targetKey),
+                )
+                else -> InspectionHandler.LifecycleContentRootReadiness(
+                    ready = false,
+                    reason = "no_content_roots",
+                    targetKey = targetKey,
+                )
+            }
+        }
+        val localFileSystem = mockk<LocalFileSystem>()
+        val targetRoot = mockk<VirtualFile>()
+        mockkStatic(LocalFileSystem::class)
+        every { LocalFileSystem.getInstance() } returns localFileSystem
+        every { localFileSystem.refreshAndFindFileByNioFile(tempDir.toRealPath()) } returns targetRoot
+        handler.lifecycleFallbackContentRootCreator = { project, root ->
+            assertSame(initializingProject, project)
+            assertSame(targetRoot, root)
+            fallbackCreateCount += 1
+            fallbackInstalled = true
+            true
+        }
+        handler.openProjectPath = { _, beforeInit ->
+            openProjects[0] = initializingProject
+            beforeInit(initializingProject)
+            initializingProject
+        }
+
+        try {
+            val first = processGetRequest(lifecycleOpenUri(tempDir))
+            scheduled.single().run()
+            guardPolls.single().run()
+            val second = processGetRequest(lifecycleOpenUri(tempDir))
+            val secondBody = second.content().toString(Charsets.UTF_8)
+
+            assertEquals(HttpResponseStatus.OK, first.status())
+            assertEquals(HttpResponseStatus.OK, second.status())
+            assertEquals(1, fallbackCreateCount)
+            assertTrue(fallbackInstalled)
+            assertTrue(secondBody.contains("\"status\": \"already_open\""))
+            assertTrue(secondBody.contains("\"fallback_module_count\": 1"))
+        } finally {
+            unmockkStatic(LocalFileSystem::class)
+        }
+    }
+
+    @Test
     fun `test lifecycle open keeps opening guard while project remains open but not initialized`() {
         val tempDir = Files.createTempDirectory("inspection-open-slow-initializing")
         val openProjects = arrayOfNulls<Project>(1)
@@ -4474,6 +4721,76 @@ class InspectionHandlerTest {
         assertTrue(secondBody.contains("\"status\": \"failed\""))
         assertTrue(secondBody.contains("\"reason\": \"open_state_unknown\""))
         assertTrue(secondBody.contains("\"opening_scheduled\": false"))
+    }
+
+    @Test
+    fun `test lifecycle open remains unresolved when readiness misses stabilization deadline`() {
+        val tempDir = Files.createTempDirectory("inspection-open-unstable-ready")
+        val openProjects = arrayOfNulls<Project>(1)
+        every { mockProjectManager.openProjects } answers { openProjects.filterNotNull().toTypedArray() }
+        val openedProject = mockProject(
+            name = "UnstableReady",
+            basePath = tempDir.toString(),
+            projectFilePath = tempDir.resolve(".idea/misc.xml").toString(),
+        )
+        val scheduled = mutableListOf<Runnable>()
+        val guardPolls = mutableListOf<Runnable>()
+        var nowMs = 1_000L
+        every { mockApplication.invokeLater(any()) } answers {
+            scheduled += firstArg<Runnable>()
+        }
+        every { mockApplication.executeOnPooledThread(any<Runnable>()) } answers {
+            guardPolls += firstArg<Runnable>()
+            mockk(relaxed = true)
+        }
+        handler.lifecycleOpenGuardTimeoutMs = 400
+        handler.lifecycleOpenRootStabilizationMs = 1_000
+        handler.lifecycleOpenGuardNow = { nowMs }
+        handler.lifecycleOpenGuardSleep = { millis -> nowMs += millis }
+        handler.lifecycleContentRootReadinessProvider = { _, targetKey ->
+            InspectionHandler.LifecycleContentRootReadiness(
+                ready = true,
+                reason = "ready",
+                targetKey = targetKey,
+                contentRootCount = 1,
+                sourceRootCount = 0,
+                moduleCount = 1,
+                targetInsideContent = true,
+                contentRoots = listOf(targetKey),
+            )
+        }
+        handler.openProjectPath = { _, beforeInit ->
+            openProjects[0] = openedProject
+            beforeInit(openedProject)
+            openedProject
+        }
+        mockInspectionPrerequisites(openedProject)
+
+        processGetRequest(lifecycleOpenUri(tempDir))
+        scheduled.single().run()
+        guardPolls.single().run()
+        val encodedPath = java.net.URLEncoder.encode(tempDir.toString(), "UTF-8")
+        val status = processGetRequest("/api/inspection/status?worktree_path=$encodedPath")
+        val statusBody = status.content().toString(Charsets.UTF_8)
+        val instanceId = projectInstanceId(openedProject)
+        val claim = processGetRequest(
+            "/api/inspection/lifecycle/claim?worktree_path=$encodedPath&project_instance_id=$instanceId&lease_id=test-open-lease"
+        )
+        val claimBody = claim.content().toString(Charsets.UTF_8)
+        val unresolved = processGetRequest(lifecycleOpenUri(tempDir))
+        val unresolvedBody = unresolved.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, status.status())
+        assertTrue(statusBody.contains("\"ready\": false"))
+        assertTrue(statusBody.contains("\"reason\": \"project_configuration_unstable\""))
+        assertEquals(HttpResponseStatus.OK, claim.status())
+        assertTrue(claimBody.contains("\"ready\": false"))
+        assertTrue(claimBody.contains("\"reason\": \"project_configuration_unstable\""))
+        assertEquals(HttpResponseStatus.CONFLICT, unresolved.status())
+        assertTrue(unresolvedBody.contains("\"reason\": \"open_state_unknown\""))
+        assertTrue(unresolvedBody.contains("\"ready\": false"))
+        assertTrue(unresolvedBody.contains("\"reason\": \"project_configuration_unstable\""))
+        assertFalse(unresolvedBody.contains("\"status\": \"already_open\""))
     }
 
     @Test


### PR DESCRIPTION
## Summary

- wait for helper-owned project roots to stabilize before reporting lifecycle readiness
- repair zero-root raw-directory projects with an exact lease-bound, non-persistent fallback module
- keep coalesced, mixed/outside-root, and missed-stabilization cases fail-closed across open, status, and claim
- document the fallback and add regression coverage for ownership, EDT scheduling, root loss, and timeout paths

## Validation

- `./gradlew :test --tests com.shiny.inspectionmcp.InspectionHandlerTest`
- `./scripts/commit-gate.sh --ci`
- multiple read-only agent reviews of lifecycle ownership, root safety, and timeout behavior

No live IDE smoke was run after the user dismissed import-test popups; validation remained headless.

Part of #209.
