### PR TITLE
Fix post-deployment inspection UNKNOWNs

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,9 @@ clients should keep using `/route`, `/trigger`, `/wait`, `/status`, and
   limited to the exact lease-bound project instance; preexisting, coalesced,
   and outside-root projects remain untouched. The fallback exists only for that
   IDE project instance and does not create tracked `.idea` or `.iml` files. A
+  normal imported module that covers the requested worktree may coexist with
+  unrelated sibling-module content roots. An unrelated root still blocks
+  readiness when target coverage comes only from the lifecycle fallback. A
   project that remains
   `no_content_roots` or `content_roots_outside_target` fails preparation while
   retaining lease-bound close authority for cleanup. Readiness that appears too
@@ -601,6 +604,7 @@ Common completion reasons:
 - `clean`: inspection completed and a clean empty result was confirmed.
 - `no_results`: inspection finished, but no trustworthy result was captured. Treat this as `UNKNOWN`, not clean; rerun inspection or open the Inspection Results view for the exact worktree.
 - `capture_incomplete`: inspection finished, but the plugin could not conclusively capture the IDE results. The response includes `capture_incomplete_reason` when a bucket can be assigned; re-run the inspection or open the Problems/Inspection Results view.
+- `scope_semantic_coverage_missing` or `scope_semantic_coverage_truncated`: inspection finished and the semantic-coverage gap is terminal `UNKNOWN` evidence, not an active inspection timeout. Fetch `/problems` for the scoped diagnostics; the external helper may explicitly accept only generic text coverage with `--allow-text-only-coverage`.
 - `stale_results`: cached results exist, but project files changed after the last inspection. Trigger again before trusting findings. Wait responses expose cached counts as `cached_total_problems`, not `total_problems`.
 - `no_recent_inspection`: no inspection run is known for the selected project. Trigger one first.
 - `no_project`: no matching project was open during the wait period. This is not reported as `timed_out`; open a project or pass the exact project name.

--- a/TESTING.md
+++ b/TESTING.md
@@ -105,6 +105,10 @@ preparation must fail with
 inspection trigger. A project model that becomes ready but misses the required
 stabilization window must remain unresolved as `project_configuration_unstable`
 rather than becoming ready on the next lifecycle poll.
+Imported multi-module projects may retain unrelated sibling content roots when
+a normal non-fallback module covers the requested worktree. Regression coverage
+must also prove that fallback-only target coverage plus an unrelated root stays
+blocked as `content_roots_outside_target`.
 
 The helper treats `capture_incomplete`, stale results, timeouts, indexing,
 session drift, route ambiguity, wrong-worktree routes, and cleanup failures as
@@ -132,6 +136,10 @@ option can accept generic text coverage. Recognized dependency lockfiles count
 as metadata only when the plugin reports both `is_excluded=true` and the
 `excluded_dependency_lockfile` role; basename-only or wildcard lockfile
 exemptions are not allowed.
+Once a settled clean snapshot has only a semantic-coverage gap, `/wait` must
+complete with that semantic reason instead of consuming the full timeout. This
+keeps default behavior fail-closed while allowing the helper's explicit
+text-only override to make a decisive result.
 Input changes during final publication return retryable
 `inspection_inputs_changed` instead of unattributed `unknown`. MCP trigger flows
 pin the accepted inspection run through wait/problems and reuse the trigger's

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -2902,6 +2902,18 @@ class InspectionHandler : HttpRequestHandler() {
                             .distinct()
                             .sorted()
                         val modules = ModuleManager.getInstance(project).modules
+                        val nonFallbackContentRoots = modules
+                            .asSequence()
+                            .filterNot { module -> module.name.startsWith(LIFECYCLE_FALLBACK_MODULE_PREFIX) }
+                            .flatMap { module ->
+                                runCatching {
+                                    ModuleRootManager.getInstance(module).contentRoots.asSequence()
+                                }.getOrElse { emptySequence() }
+                            }
+                            .mapNotNull(::localInspectionRootPath)
+                            .mapNotNull(::normalizeFileSystemPath)
+                            .distinct()
+                            .toList()
                         val sourceRootCount = rootManager.contentSourceRoots
                             .mapNotNull(::localInspectionRootPath)
                             .mapNotNull(::normalizeFileSystemPath)
@@ -2925,8 +2937,16 @@ class InspectionHandler : HttpRequestHandler() {
                                     !canonicalContentRoot.startsWith(targetPath)
                             }.getOrDefault(true)
                         }
+                        val nonFallbackTargetCoverage = nonFallbackContentRoots.any { contentRoot ->
+                            runCatching {
+                                val canonicalContentRoot = canonicalTrustPath(Paths.get(contentRoot))
+                                targetPath.startsWith(canonicalContentRoot) ||
+                                    canonicalContentRoot.startsWith(targetPath)
+                            }.getOrDefault(false)
+                        }
                         val reason = when {
                             contentRoots.isEmpty() -> "no_content_roots"
+                            nonFallbackTargetCoverage -> "ready"
                             unrelatedContentRoot || (!targetInsideContent && !contentRootInsideTarget) ->
                                 "content_roots_outside_target"
                             else -> "ready"
@@ -4161,6 +4181,7 @@ class InspectionHandler : HttpRequestHandler() {
                 !inspectionInProgress &&
                 snapshotScopeHasProof &&
                 snapshot?.outcome == InspectionSnapshotOutcome.CLEAN_CONFIRMED &&
+                scopeFileSemanticEvidenceComplete(snapshot.captureDiagnostic) &&
                 !scopeFileSemanticCoverageMissing(snapshot.captureDiagnostic) &&
                 !staleness.stale
             )
@@ -4615,6 +4636,12 @@ class InspectionHandler : HttpRequestHandler() {
             val resultsSource = status["results_source"] as? String
             val resultsTimestampMs = (status["results_timestamp_ms"] as? Number)?.toLong()
             val snapshotOutcome = status["snapshot_outcome"] as? String
+            val inspectionVerdict = status["inspection_verdict"] as? String
+            val inspectionVerdictReason = status["inspection_verdict_reason"] as? String
+            val terminalSemanticCoverageReason = inspectionVerdictReason?.takeIf { reason ->
+                reason == SCOPE_SEMANTIC_COVERAGE_MISSING_REASON ||
+                    reason == "scope_semantic_coverage_truncated"
+            }
             val timeSinceTrigger = (status["time_since_last_trigger_ms"] as? Number)?.toLong()
             val resultsMayBeStale = status["results_may_be_stale"] as? Boolean ?: false
             val minStableMs = 5000L
@@ -4625,7 +4652,25 @@ class InspectionHandler : HttpRequestHandler() {
                 return formatWaitResponse(status, start, timeoutMs, pollMs, true, "stale_results", requestAttribution)
             }
 
-            if (cleanInspection && !isScanning && !inProgress) {
+            if (
+                hasResults &&
+                !isScanning &&
+                !inProgress &&
+                inspectionVerdict == "UNKNOWN" &&
+                terminalSemanticCoverageReason != null
+            ) {
+                return formatWaitResponse(
+                    status,
+                    start,
+                    timeoutMs,
+                    pollMs,
+                    true,
+                    terminalSemanticCoverageReason,
+                    requestAttribution,
+                )
+            }
+
+            if (cleanInspection && inspectionVerdict == "GREEN" && !isScanning && !inProgress) {
                 if (cleanStableSince == null && resultsTimestampMs == null) {
                     cleanStableSince = now
                 }

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -19,6 +19,7 @@ import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.module.EmptyModuleType
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.roots.ModuleRootModificationUtil
+import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.module.ModuleManager
@@ -2489,6 +2490,89 @@ class InspectionHandlerTest {
     }
 
     @Test
+    fun `test wait endpoint completes for settled semantic coverage gaps`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        runPooledTasksInline()
+        mockInspectionPrerequisites(mockProject)
+        val key = projectKey(mockProject)
+        setInspectionRunState(
+            key,
+            InspectionRunState(
+                runId = 10L,
+                triggerTimeMs = System.currentTimeMillis(),
+                inProgress = false,
+                captureScope = InspectionCaptureScope(scopeParam = "whole_project"),
+            ),
+        )
+        InspectionResultsStore.setSnapshot(
+            key,
+            InspectionResultsSnapshot(
+                problems = emptyList(),
+                timestamp = System.currentTimeMillis(),
+                projectState = InspectionProjectStateSnapshot(psiModificationCount = 11L, unsavedProjectDocuments = 0),
+                outcome = InspectionSnapshotOutcome.CLEAN_CONFIRMED,
+                source = "inspection_view",
+                captureDiagnostic = semanticCoverageGapDiagnostic(),
+                runId = 10L,
+            ),
+        )
+
+        val response = processGetRequest(
+            "/api/inspection/wait?timeout_ms=1000&poll_ms=200&inspection_run_id=10"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"wait_completed\": true"), body)
+        assertTrue(body.contains("\"timed_out\": false"), body)
+        assertTrue(body.contains("\"completion_reason\": \"scope_semantic_coverage_missing\""), body)
+        assertTrue(body.contains("\"inspection_verdict\": \"UNKNOWN\""), body)
+    }
+
+    @Test
+    fun `test wait endpoint keeps delayed truncated semantic coverage unknown`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        runPooledTasksInline()
+        mockInspectionPrerequisites(mockProject)
+        val key = projectKey(mockProject)
+        setInspectionRunState(
+            key,
+            InspectionRunState(
+                runId = 11L,
+                triggerTimeMs = System.currentTimeMillis() - 20_000L,
+                inProgress = false,
+                captureScope = InspectionCaptureScope(scopeParam = "whole_project"),
+            ),
+        )
+        InspectionResultsStore.setSnapshot(
+            key,
+            InspectionResultsSnapshot(
+                problems = emptyList(),
+                timestamp = System.currentTimeMillis() - 10_000L,
+                projectState = InspectionProjectStateSnapshot(psiModificationCount = 11L, unsavedProjectDocuments = 0),
+                outcome = InspectionSnapshotOutcome.CLEAN_CONFIRMED,
+                source = "inspection_view",
+                captureDiagnostic = semanticCoverageTruncatedDiagnostic(),
+                runId = 11L,
+            ),
+        )
+
+        val response = processGetRequest(
+            "/api/inspection/wait?timeout_ms=1000&poll_ms=200&inspection_run_id=11"
+        )
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"wait_completed\": true"), body)
+        assertTrue(body.contains("\"timed_out\": false"), body)
+        assertTrue(body.contains("\"completion_reason\": \"scope_semantic_coverage_truncated\""), body)
+        assertTrue(body.contains("\"inspection_verdict\": \"UNKNOWN\""), body)
+        assertFalse(body.contains("\"completion_reason\": \"clean\""), body)
+    }
+
+    @Test
     fun `test clean problems response includes decisive attribution`() {
         every { mockProject.basePath } returns "/tmp/TestProject"
         every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
@@ -3664,13 +3748,18 @@ class InspectionHandlerTest {
         val moduleManager = mockk<ModuleManager>()
         var contentRoots = emptyArray<VirtualFile>()
         var modules = emptyArray<com.intellij.openapi.module.Module>()
+        val moduleRootManagers = mutableMapOf<com.intellij.openapi.module.Module, ModuleRootManager>()
         every { rootManager.contentRoots } answers { contentRoots }
         every { rootManager.contentSourceRoots } returns emptyArray()
         every { moduleManager.modules } answers { modules }
         mockkStatic(ProjectRootManager::class)
         mockkStatic(ModuleManager::class)
+        mockkStatic(ModuleRootManager::class)
         every { ProjectRootManager.getInstance(mockProject) } returns rootManager
         every { ModuleManager.getInstance(mockProject) } returns moduleManager
+        every { ModuleRootManager.getInstance(any()) } answers {
+            moduleRootManagers.getValue(firstArg())
+        }
         val productionHandler = InspectionHandler()
         val targetKey = tempDir.toRealPath().toString()
 
@@ -3690,9 +3779,13 @@ class InspectionHandlerTest {
             assertTrue(childReady.contentRootInsideTarget)
 
             val fallbackModule = mockk<com.intellij.openapi.module.Module>()
+            val fallbackRootManager = mockk<ModuleRootManager>()
             every { fallbackModule.name } returns "__jetbrains_inspection_api_lifecycle_fallback__test"
+            every { fallbackRootManager.contentRoots } returns arrayOf(childRoot)
+            moduleRootManagers[fallbackModule] = fallbackRootManager
             modules = arrayOf(fallbackModule)
             val fallbackReady = productionHandler.lifecycleContentRootReadinessProvider(mockProject, targetKey)
+            assertTrue(fallbackReady.ready, fallbackReady.toString())
             assertEquals(1, fallbackReady.fallbackModuleCount)
 
             val outsideRootPath = Files.createDirectories(tempDir.resolveSibling("outside-module"))
@@ -3700,17 +3793,35 @@ class InspectionHandlerTest {
             every { outsideRoot.path } returns outsideRootPath.toString()
             every { outsideRoot.isInLocalFileSystem } returns true
             contentRoots = arrayOf(outsideRoot)
+            modules = emptyArray()
             val outside = productionHandler.lifecycleContentRootReadinessProvider(mockProject, targetKey)
             assertFalse(outside.ready)
             assertEquals("content_roots_outside_target", outside.reason)
 
+            val targetModule = mockk<com.intellij.openapi.module.Module>()
+            val targetModuleRootManager = mockk<ModuleRootManager>()
+            every { targetModule.name } returns "target-module"
+            every { targetModuleRootManager.contentRoots } returns arrayOf(childRoot)
+            moduleRootManagers[targetModule] = targetModuleRootManager
+            val siblingModule = mockk<com.intellij.openapi.module.Module>()
+            val siblingModuleRootManager = mockk<ModuleRootManager>()
+            every { siblingModule.name } returns "sibling-module"
+            every { siblingModuleRootManager.contentRoots } returns arrayOf(outsideRoot)
+            moduleRootManagers[siblingModule] = siblingModuleRootManager
             contentRoots = arrayOf(childRoot, outsideRoot)
+            modules = arrayOf(targetModule, siblingModule)
             val mixedRoots = productionHandler.lifecycleContentRootReadinessProvider(mockProject, targetKey)
-            assertFalse(mixedRoots.ready)
-            assertEquals("content_roots_outside_target", mixedRoots.reason)
+            assertTrue(mixedRoots.ready, mixedRoots.toString())
+            assertEquals("ready", mixedRoots.reason)
+
+            modules = arrayOf(fallbackModule, siblingModule)
+            val fallbackWithSibling = productionHandler.lifecycleContentRootReadinessProvider(mockProject, targetKey)
+            assertFalse(fallbackWithSibling.ready)
+            assertEquals("content_roots_outside_target", fallbackWithSibling.reason)
         } finally {
             unmockkStatic(ProjectRootManager::class)
             unmockkStatic(ModuleManager::class)
+            unmockkStatic(ModuleRootManager::class)
         }
     }
 
@@ -6131,6 +6242,15 @@ class InspectionHandlerTest {
             "metadata_file_count" to 0,
             "metadata_files" to emptyList<Map<String, Any?>>(),
         ),
+        "scope_file_diagnostics" to emptyList<Map<String, Any?>>(),
+    )
+
+    private fun semanticCoverageTruncatedDiagnostic(): Map<String, Any?> = mapOf(
+        "scope_file_resolved_count" to 1,
+        "scope_file_diagnostic_count" to 0,
+        "scope_file_diagnostics_truncated" to true,
+        "scope_file_diagnostics_complete" to false,
+        "scope_file_semantic_evidence_complete" to false,
         "scope_file_diagnostics" to emptyList<Map<String, Any?>>(),
     )
 


### PR DESCRIPTION
## Summary
- allow legitimate imported multi-module projects when a non-fallback module covers the requested worktree
- keep fallback-only coverage fail-closed when unrelated roots remain
- complete settled semantic-coverage UNKNOWN waits immediately instead of timing out, while preventing incomplete semantic proof from reporting clean
- document and regression-test the lifecycle and wait contracts

## Validation
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./scripts/commit-gate.sh --ci`
- focused lifecycle, semantic-missing, and semantic-truncated wait tests

Refs #209