### PR TITLE
Fix false-green inspection captures

### DIFF
--- a/src/main/kotlin/com/shiny/inspectionmcp/CopyMcpCommandAction.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/CopyMcpCommandAction.kt
@@ -4,6 +4,8 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.ide.CopyPasteManager
+import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.util.SystemInfo
@@ -13,6 +15,7 @@ import java.nio.file.Path
 import java.nio.file.Paths
 
 private const val MCP_JAR_NAME = "jetbrains-inspection-mcp.jar"
+private const val COPY_MCP_PLUGIN_ID = "com.shiny.inspection.api"
 
 class CopyMcpCommandAction : AnAction() {
     override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.EDT
@@ -105,9 +108,26 @@ private fun buildMcpSetupOptions(): List<McpSetupOption>? {
 }
 
 private fun resolveMcpJarPath(): Path? {
+    PluginManagerCore.getPlugin(PluginId.getId(COPY_MCP_PLUGIN_ID))
+        ?.pluginPath
+        ?.let(::resolveMcpJarPathFromPluginPath)
+        ?.let { return it }
     val codeSource = runCatching {
         CopyMcpCommandAction::class.java.protectionDomain?.codeSource?.location?.toURI()?.let(Paths::get)
     }.getOrNull() ?: return null
+    return resolveMcpJarPathFromCodeSource(codeSource)
+}
+
+internal fun resolveMcpJarPathFromPluginPath(pluginPath: Path): Path? {
+    val pluginRoot = if (Files.isDirectory(pluginPath)) pluginPath else pluginPath.parent ?: return null
+    val candidates = listOf(
+        pluginRoot.resolve("lib").resolve(MCP_JAR_NAME),
+        pluginRoot.resolve(MCP_JAR_NAME),
+    )
+    return candidates.firstOrNull { Files.exists(it) }
+}
+
+internal fun resolveMcpJarPathFromCodeSource(codeSource: Path): Path? {
     val candidates = buildList {
         if (Files.isDirectory(codeSource)) {
             add(codeSource.resolve(MCP_JAR_NAME))

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -4418,8 +4418,10 @@ class InspectionHandler : HttpRequestHandler() {
                             snapshot.reconciliationChangeKind
                         },
                     )
-                } else if (shouldPublishUnchangedSnapshot || projectStateChangedDuringCapture) {
+                } else if (shouldPublishUnchangedSnapshot) {
                     snapshot
+                } else if (projectStateChangedDuringCapture) {
+                    unverifiedChurnSnapshot(snapshot, "inputs_changed")
                 } else {
                     inspectionInputValidationFailureSnapshot(snapshot, "inputs_changed")
                 }
@@ -4447,7 +4449,7 @@ class InspectionHandler : HttpRequestHandler() {
                         isCurrentInspectionRun(key, runId)
                     ) {
                         val fallbackSnapshot = if (projectStateChangedDuringCapture) {
-                            snapshot
+                            unverifiedChurnSnapshot(snapshot, "inputs_changed")
                         } else {
                             inspectionInputValidationFailureSnapshot(snapshot, "inputs_changed")
                         }
@@ -4459,12 +4461,23 @@ class InspectionHandler : HttpRequestHandler() {
             logger.warn("Inspection snapshot validation failed for ${project.name}", error)
             if (!project.isDisposed && isCurrentInspectionRun(key, runId)) {
                 val snapshotToPublish = if (projectStateChangedDuringCapture) {
-                    snapshot
+                    unverifiedChurnSnapshot(snapshot, "validation_failed")
                 } else {
                     inspectionInputValidationFailureSnapshot(snapshot, "validation_failed")
                 }
                 resultsStore.setSnapshot(key, snapshotToPublish)
             }
+        }
+    }
+
+    private fun unverifiedChurnSnapshot(
+        snapshot: InspectionResultsSnapshot,
+        failure: String,
+    ): InspectionResultsSnapshot {
+        return if (snapshot.outcome == InspectionSnapshotOutcome.CLEAN_CONFIRMED) {
+            inspectionInputValidationFailureSnapshot(snapshot, failure)
+        } else {
+            snapshot
         }
     }
 
@@ -4498,7 +4511,8 @@ class InspectionHandler : HttpRequestHandler() {
     }
 
     private fun supportsStableInputValidation(captureScope: InspectionCaptureScope?): Boolean {
-        return isWholeProjectCaptureScope(captureScope) || isChangedFilesCaptureScope(captureScope)
+        val scope = captureScope?.scopeParam?.trim()?.lowercase().orEmpty().ifBlank { "whole_project" }
+        return scope == "whole_project" || scope == "all" || scope == "changed_files" || scope == "current_file"
     }
 
     private fun changedFilesCaptureScopeMatchesCurrent(

--- a/src/test/kotlin/com/shiny/inspectionmcp/CopyMcpCommandActionTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/CopyMcpCommandActionTest.kt
@@ -1,0 +1,36 @@
+package com.shiny.inspectionmcp
+
+import java.nio.file.Files
+import kotlin.io.path.createTempDirectory
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class CopyMcpCommandActionTest {
+    @Test
+    fun `resolves the MCP jar from an installed plugin root`() {
+        val pluginRoot = createTempDirectory("inspection-plugin")
+        val jarPath = Files.createDirectories(pluginRoot.resolve("lib"))
+            .resolve("jetbrains-inspection-mcp.jar")
+        Files.createFile(jarPath)
+
+        assertEquals(jarPath, resolveMcpJarPathFromPluginPath(pluginRoot))
+    }
+
+    @Test
+    fun `resolves the MCP jar from a plugin archive path`() {
+        val pluginRoot = createTempDirectory("inspection-plugin")
+        val archivePath = Files.createDirectories(pluginRoot.resolve("lib"))
+            .resolve("inspection-api.jar")
+        Files.createFile(archivePath)
+        val jarPath = archivePath.parent.resolve("jetbrains-inspection-mcp.jar")
+        Files.createFile(jarPath)
+
+        assertEquals(jarPath, resolveMcpJarPathFromPluginPath(archivePath))
+    }
+
+    @Test
+    fun `returns null when the MCP jar is not installed`() {
+        assertNull(resolveMcpJarPathFromPluginPath(createTempDirectory("inspection-plugin")))
+    }
+}

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -1283,6 +1283,99 @@ class InspectionHandlerTest {
     }
 
     @Test
+    fun `test current file clean snapshot becomes unknown after failed churn validation`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        mockInspectionPrerequisites(mockProject)
+        every { PsiModificationTracker.getInstance(mockProject).modificationCount } returns 10L
+        val key = projectKey(mockProject)
+        InspectionResultsStore.clear(key)
+        val inputFingerprint = projectInputsFingerprint()
+        handler.projectInputsFingerprintProvider = { _, _ -> projectInputsFingerprint(profileName = "ChangedProfile") }
+        mockExtractor(emptyList())
+        setInspectionRunState(
+            key,
+            InspectionRunState(runId = 1L, triggerTimeMs = System.currentTimeMillis(), inProgress = true),
+        )
+        val snapshot = InspectionResultsSnapshot(
+            problems = emptyList(),
+            timestamp = System.currentTimeMillis(),
+            projectState = InspectionProjectStateSnapshot(psiModificationCount = 10L, unsavedProjectDocuments = 1),
+            outcome = InspectionSnapshotOutcome.CLEAN_CONFIRMED,
+            source = "inspection_view",
+            captureScope = InspectionCaptureScope(
+                scopeParam = "current_file",
+                resolvedCurrentFile = "/tmp/TestProject/src/Probe.py",
+            ),
+            runId = 1L,
+        )
+
+        publishInspectionSnapshot(
+            runId = 1L,
+            snapshot = snapshot,
+            captureEndState = InspectionProjectStateSnapshot(psiModificationCount = 10L, unsavedProjectDocuments = 0),
+            projectStateChangedDuringCapture = true,
+            inspectionInputFingerprint = inputFingerprint,
+            projectContentTracker = FakeInspectionProjectContentTracker(),
+        )
+        setInspectionRunState(
+            key,
+            InspectionRunState(runId = 1L, triggerTimeMs = System.currentTimeMillis(), inProgress = false),
+        )
+
+        val publishedSnapshot = requireNotNull(InspectionResultsStore.getSnapshot(key))
+        val status = buildInspectionStatus()
+
+        assertEquals(InspectionSnapshotOutcome.CAPTURE_INCOMPLETE, publishedSnapshot.outcome)
+        assertEquals(CaptureIncompleteReason.INSPECTION_INPUTS_CHANGED, publishedSnapshot.captureIncompleteReason)
+        assertEquals("inputs_changed", publishedSnapshot.captureDiagnostic?.get("final_input_validation"))
+        assertEquals("UNKNOWN", status["inspection_verdict"])
+    }
+
+    @Test
+    fun `test current file clean snapshot validates unchanged project inputs`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        mockInspectionPrerequisites(mockProject)
+        every { PsiModificationTracker.getInstance(mockProject).modificationCount } returns 10L
+        val key = projectKey(mockProject)
+        InspectionResultsStore.clear(key)
+        val inputFingerprint = projectInputsFingerprint()
+        handler.projectInputsFingerprintProvider = { _, _ -> projectInputsFingerprint(profileName = "ChangedProfile") }
+        setInspectionRunState(
+            key,
+            InspectionRunState(runId = 1L, triggerTimeMs = System.currentTimeMillis(), inProgress = true),
+        )
+        val snapshot = InspectionResultsSnapshot(
+            problems = emptyList(),
+            timestamp = System.currentTimeMillis(),
+            projectState = InspectionProjectStateSnapshot(psiModificationCount = 10L, unsavedProjectDocuments = 0),
+            outcome = InspectionSnapshotOutcome.CLEAN_CONFIRMED,
+            source = "inspection_view",
+            captureScope = InspectionCaptureScope(
+                scopeParam = "current_file",
+                resolvedCurrentFile = "/tmp/TestProject/src/Probe.py",
+            ),
+            runId = 1L,
+        )
+
+        publishInspectionSnapshot(
+            runId = 1L,
+            snapshot = snapshot,
+            captureEndState = snapshot.projectState,
+            projectStateChangedDuringCapture = false,
+            inspectionInputFingerprint = inputFingerprint,
+            projectContentTracker = FakeInspectionProjectContentTracker(),
+        )
+
+        val publishedSnapshot = requireNotNull(InspectionResultsStore.getSnapshot(key))
+
+        assertEquals(InspectionSnapshotOutcome.CAPTURE_INCOMPLETE, publishedSnapshot.outcome)
+        assertEquals(CaptureIncompleteReason.INSPECTION_INPUTS_CHANGED, publishedSnapshot.captureIncompleteReason)
+        assertEquals("inputs_changed", publishedSnapshot.captureDiagnostic?.get("final_input_validation"))
+    }
+
+    @Test
     fun `test final publication rejects input drift without psi churn`() {
         every { mockProject.basePath } returns "/tmp/TestProject"
         every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"


### PR DESCRIPTION
## Summary
- Demote unverified clean captures to `capture_incomplete` instead of returning false `GREEN` verdicts.
- Validate `current_file` captures against the project input fingerprint while keeping their captured path pinned.
- Restore plugin-descriptor MCP jar discovery and cover installed root/archive layouts.

## Validation
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test buildPlugin`
- Commit gate passed its root, core, MCP, release-contract, and plugin-build checks.
- JetBrains closeout inspection was inconclusive (`stale_results`) after its built-in retry; it reported no attributable changed-file findings and cleaned up its owned project.

Reported after closed #227; this PR does not reopen that completed deployment issue.