### PR TITLE
Avoid internal MCP plugin lookup

### DIFF
--- a/src/main/kotlin/com/shiny/inspectionmcp/CopyMcpCommandAction.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/CopyMcpCommandAction.kt
@@ -4,18 +4,17 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.ide.CopyPasteManager
-import com.intellij.ide.plugins.PluginManagerCore
-import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.util.SystemInfo
 import java.awt.datatransfer.StringSelection
+import java.net.JarURLConnection
+import java.net.URL
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 
 private const val MCP_JAR_NAME = "jetbrains-inspection-mcp.jar"
-private const val COPY_MCP_PLUGIN_ID = "com.shiny.inspection.api"
 
 class CopyMcpCommandAction : AnAction() {
     override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.EDT
@@ -108,14 +107,23 @@ private fun buildMcpSetupOptions(): List<McpSetupOption>? {
 }
 
 private fun resolveMcpJarPath(): Path? {
-    PluginManagerCore.getPlugin(PluginId.getId(COPY_MCP_PLUGIN_ID))
-        ?.pluginPath
-        ?.let(::resolveMcpJarPathFromPluginPath)
-        ?.let { return it }
-    val codeSource = runCatching {
-        CopyMcpCommandAction::class.java.protectionDomain?.codeSource?.location?.toURI()?.let(Paths::get)
-    }.getOrNull() ?: return null
+    val codeSource = CopyMcpCommandAction::class.java.protectionDomain?.codeSource?.location
+        ?.let(::resolveCodeSourcePath)
+        ?: return null
     return resolveMcpJarPathFromCodeSource(codeSource)
+}
+
+internal fun resolveCodeSourcePath(location: URL): Path? {
+    val fileLocation = when (location.protocol.lowercase()) {
+        "file" -> location
+        "jar" -> runCatching {
+            (location.openConnection() as? JarURLConnection)?.jarFileURL
+        }.getOrNull()
+        else -> null
+    } ?: return null
+    return runCatching { Paths.get(fileLocation.toURI()) }.getOrElse {
+        runCatching { Paths.get(fileLocation.path) }.getOrNull()
+    }
 }
 
 internal fun resolveMcpJarPathFromPluginPath(pluginPath: Path): Path? {

--- a/src/test/kotlin/com/shiny/inspectionmcp/CopyMcpCommandActionTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/CopyMcpCommandActionTest.kt
@@ -1,6 +1,8 @@
 package com.shiny.inspectionmcp
 
 import java.nio.file.Files
+import java.net.URI
+import java.net.URL
 import kotlin.io.path.createTempDirectory
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
@@ -32,5 +34,20 @@ class CopyMcpCommandActionTest {
     @Test
     fun `returns null when the MCP jar is not installed`() {
         assertNull(resolveMcpJarPathFromPluginPath(createTempDirectory("inspection-plugin")))
+    }
+
+    @Test
+    fun `resolves file and jar code-source URLs`() {
+        val pluginJar = Files.createFile(createTempDirectory("inspection-plugin").resolve("inspection-api.jar"))
+        val fileUrl = pluginJar.toUri().toURL()
+        val jarUrl = URI.create("jar:${fileUrl}!/").toURL()
+
+        assertEquals(pluginJar, resolveCodeSourcePath(fileUrl))
+        assertEquals(pluginJar, resolveCodeSourcePath(jarUrl))
+    }
+
+    @Test
+    fun `rejects non-file code-source URLs`() {
+        assertNull(resolveCodeSourcePath(URI.create("https://example.com/inspection-api.jar").toURL()))
     }
 }


### PR DESCRIPTION
## Summary

- Resolve the MCP server jar from the plugin action's code-source URL without calling the internal `PluginManagerCore` API.
- Support both `file:` and `jar:` class locations and reject unsupported URL schemes.

## Validation

- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test --tests com.shiny.inspectionmcp.CopyMcpCommandActionTest`
- `./scripts/release-compatibility-gate.sh`
- Commit gate passed its full test, core, MCP, release-contract, and plugin-build checks.

Follow-up to #235: fixes the Plugin Verifier gate before the next patch release.