### PR TITLE
Fix noninteractive lifecycle project opening

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -95,8 +95,10 @@ to the separate-window mode. If auto-open stalls, treat it as a blocker: check
 for an unsupported IDE config layout, settings sync overwriting the config, or a
 missing inspection plugin. The
 plugin-side lifecycle open endpoint schedules project opening asynchronously and
-uses the worktree directory name as the frame project name, runs project
-configurators, and refreshes the VFS so cloned worktrees
+prepares a directory-based project store before using the noninteractive public
+project-open path. This avoids the IDE's Open/Attach/New Window prompt while
+using the worktree directory name as the frame project name, running project
+configurators, and refreshing the VFS so cloned worktrees
 with identical checked-in `.idea` metadata can coexist in IntelliJ IDEA,
 PyCharm, and WebStorm. Current builds advertise the `lease_bound_v1` ownership
 protocol: the helper persists a lease before open, passes that `lease_id`, and

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -138,6 +138,12 @@ internal fun normalizeOptionalFilter(raw: String?): String? {
     return trimmed
 }
 
+internal fun prepareLifecycleProjectStore(openPath: Path): Path {
+    val projectStore = openPath.resolve(Project.DIRECTORY_STORE_FOLDER)
+    Files.createDirectories(projectStore)
+    return projectStore
+}
+
 internal enum class InspectionSnapshotOutcome(val apiValue: String) {
     PROBLEMS_FOUND("problems_found"),
     CLEAN_CONFIRMED("clean_confirmed"),
@@ -1509,7 +1515,8 @@ class InspectionHandler : HttpRequestHandler() {
     }
     internal var openProjectPath: (Path, (Project) -> Unit) -> Project? = { path, onOpened ->
         val openPath = canonicalTrustPath(path)
-        ProjectUtil.openOrImport(openPath.toString(), null, true)?.also(onOpened)
+        prepareLifecycleProjectStore(openPath)
+        ProjectUtil.openProject(openPath.toString(), null, true)?.also(onOpened)
     }
 
     private val resultsStore = InspectionResultsStore

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -85,7 +85,7 @@ class InspectionHandlerTest {
     private lateinit var mockApplication: Application
 
     @Test
-    fun `inspection handler opens projects without private OpenProjectTask APIs`() {
+    fun `inspection handler opens projects without private or interactive project APIs`() {
         val resourceName = InspectionHandler::class.java.name.replace('.', '/') + ".class"
         val classResource = requireNotNull(InspectionHandler::class.java.classLoader.getResource(resourceName))
         val classPath = when (classResource.protocol) {
@@ -122,8 +122,12 @@ class InspectionHandlerTest {
             "Lifecycle project opening must not use JetBrains private OpenProjectTask APIs.",
         )
         assertTrue(
+            disassembly.contains("com/intellij/ide/impl/ProjectUtil.openProject"),
+            "Lifecycle project opening must use the public noninteractive ProjectUtil open path.",
+        )
+        assertFalse(
             disassembly.contains("com/intellij/ide/impl/ProjectUtil.openOrImport"),
-            "Lifecycle project opening must use the public ProjectUtil open path.",
+            "Lifecycle project opening must not use the interactive open-or-import processor path.",
         )
         assertFalse(
             disassembly.contains("runProcessWithProgressSynchronously"),
@@ -133,6 +137,28 @@ class InspectionHandlerTest {
             disassembly.contains("com/intellij/openapi/progress/util/ProgressWindow"),
             "JetBrains global inspections require a non-modal ProgressWindow indicator.",
         )
+    }
+
+    @Test
+    fun `lifecycle project store prepares a fresh directory for direct opening`() {
+        val projectRoot = Files.createTempDirectory("inspection-project-store")
+
+        val projectStore = prepareLifecycleProjectStore(projectRoot)
+
+        assertEquals(projectRoot.resolve(Project.DIRECTORY_STORE_FOLDER), projectStore)
+        assertTrue(Files.isDirectory(projectStore))
+    }
+
+    @Test
+    fun `lifecycle project store preserves existing metadata`() {
+        val projectRoot = Files.createTempDirectory("inspection-existing-project-store")
+        val projectStore = projectRoot.resolve(Project.DIRECTORY_STORE_FOLDER)
+        Files.createDirectories(projectStore)
+        val metadata = projectStore.resolve("misc.xml")
+        Files.writeString(metadata, "<project />")
+
+        assertEquals(projectStore, prepareLifecycleProjectStore(projectRoot))
+        assertEquals("<project />", Files.readString(metadata))
     }
     
     @BeforeEach


### PR DESCRIPTION
## Why

The public project-open replacement introduced for Marketplace compatibility used `ProjectUtil.openOrImport`, which can enter the IDE's interactive Open/Attach/New Window flow. In unattended helper workflows, that modal dialog blocks the EDT and causes repeated `project_open_blocked` timeouts.

## What Changed

- Prepare a directory-based project store for fresh worktrees.
- Open the project through the public direct `ProjectUtil.openProject` path with a forced new frame.
- Add bytecode guards preventing both private `OpenProjectTask` usage and interactive `openOrImport` usage.
- Add project-store regression coverage and update lifecycle testing documentation.

## Validation

- Focused `InspectionHandlerTest` passed.
- `./scripts/commit-gate.sh --ci` passed.
- `verifyPluginStructure` passed.
- Plugin Verifier passed against builds 251, 252, 253, 261, and 262 with no new unapproved internal APIs.
- Isolated live IDE smoke opened and claimed a fresh worktree without `.idea` in about six seconds, with `ownership_proven=true`, lifecycle readiness `ready`, and no Open/Attach dialog.

## Related

Refs #232

Pre-existing constant-parameter IDE warnings discovered during validation are tracked separately in #248.