### PR TITLE
Release v1.13.21

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion=1.13.20
+pluginVersion=1.13.21
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
 kotlin.stdlib.default.dependency=false
 # Enable Gradle Configuration Cache -> https://docs.gradle.org/current/userguide/configuration_cache.html

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.shiny.inspection.api</id>
     <name>Inspection API</name>
-    <version>1.13.20</version>
+    <version>1.13.21</version>
     <vendor email="info@shinycomputers.com" url="https://github.com/cbusillo/jetbrains-inspection-api">Shiny Computers (Chris Busillo)</vendor>
     <resource-bundle>messages.InspectionApiBundle</resource-bundle>
     


### PR DESCRIPTION
## Summary

- prepare release v1.13.21
- ship the noninteractive lifecycle project-opening fix
- clarify LSP/editor diagnostic coverage in the API verdict contract
- validate plugin metadata and compatibility gates

## Validation

- `./scripts/test-all.sh`
- `./scripts/test-automated.sh` (PyCharm 2026.2.0.1, plugin 1.13.21)
- `./scripts/commit-gate.sh`
- `./scripts/release-compatibility-gate.sh`
- `./scripts/validate-release-version.sh --tag v1.13.21`