### PR TITLE
Preserve file-based lifecycle project opens

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -96,7 +96,9 @@ for an unsupported IDE config layout, settings sync overwriting the config, or a
 missing inspection plugin. The
 plugin-side lifecycle open endpoint schedules project opening asynchronously and
 prepares a directory-based project store before using the noninteractive public
-project-open path. This avoids the IDE's Open/Attach/New Window prompt while
+project-open path for directory inputs. Explicit `.ipr` inputs preserve the
+requested file-based project path and use its containing directory for trust,
+routing, readiness, and lifecycle ownership. This avoids the IDE's Open/Attach/New Window prompt while
 using the worktree directory name as the frame project name, running project
 configurators, and refreshing the VFS so cloned worktrees
 with identical checked-in `.idea` metadata can coexist in IntelliJ IDEA,

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -144,6 +144,13 @@ internal fun prepareLifecycleProjectStore(openPath: Path): Path {
     return projectStore
 }
 
+internal fun prepareLifecycleProjectStoreIfDirectory(openPath: Path): Path? {
+    if (!Files.isDirectory(openPath)) {
+        return null
+    }
+    return prepareLifecycleProjectStore(openPath)
+}
+
 internal enum class InspectionSnapshotOutcome(val apiValue: String) {
     PROBLEMS_FOUND("problems_found"),
     CLEAN_CONFIRMED("clean_confirmed"),
@@ -1515,7 +1522,7 @@ class InspectionHandler : HttpRequestHandler() {
     }
     internal var openProjectPath: (Path, (Project) -> Unit) -> Project? = { path, onOpened ->
         val openPath = canonicalTrustPath(path)
-        prepareLifecycleProjectStore(openPath)
+        prepareLifecycleProjectStoreIfDirectory(openPath)
         ProjectUtil.openProject(openPath.toString(), null, true)?.also(onOpened)
     }
 
@@ -2662,7 +2669,12 @@ class InspectionHandler : HttpRequestHandler() {
                     if (isUnresolvedLifecycleOpenActive(project)) {
                         val projectRoot = Paths.get(entry.key)
                         return lifecycleOpenStateUnknown(
-                            LifecycleOpenTarget(path, projectRoot, projectRoot, entry.key),
+                            LifecycleOpenTarget(
+                                path = path,
+                                openPath = projectRoot,
+                                projectRoot = projectRoot,
+                                key = entry.key,
+                            ),
                             project,
                         )
                     }
@@ -2732,8 +2744,8 @@ class InspectionHandler : HttpRequestHandler() {
                     LifecycleOpenRouteVisibility.hide(target.key)
                     routeHidden = true
                     val openedProjectCandidate = AtomicReference<Project?>()
-                    trustProjectPath(target.openPath)
-                    refreshProjectRoot(target.openPath.toString())
+                    trustProjectPath(target.projectRoot)
+                    refreshProjectRoot(target.projectRoot.toString())
                     opened = openProjectPath(target.openPath) { project ->
                         openedProjectCandidate.compareAndSet(null, project)
                     }
@@ -2750,7 +2762,7 @@ class InspectionHandler : HttpRequestHandler() {
                     LifecycleOpenRouteVisibility.reveal(target.key)
                     routeHidden = false
                     if (opened != null) {
-                        refreshProjectRoot(target.openPath.toString())
+                        refreshProjectRoot(target.projectRoot.toString())
                         keepOpeningGuard = true
                         releaseLifecycleOpenGuardWhenUsable(target.key, opened, request)
                     }
@@ -3142,9 +3154,14 @@ class InspectionHandler : HttpRequestHandler() {
                 "worktree_path",
                 "Parameter 'worktree_path' must point to an existing directory, .ipr project file, or file inside .idea.",
             )
+        val openPath = if (Files.isRegularFile(path) && path.fileName.toString().endsWith(".ipr")) {
+            path
+        } else {
+            projectRoot
+        }
         return LifecycleOpenTarget(
             path = path,
-            openPath = projectRoot,
+            openPath = openPath,
             projectRoot = projectRoot,
             key = canonicalLifecycleOpenKey(projectRoot),
         )

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -160,6 +160,16 @@ class InspectionHandlerTest {
         assertEquals(projectStore, prepareLifecycleProjectStore(projectRoot))
         assertEquals("<project />", Files.readString(metadata))
     }
+
+    @Test
+    fun `lifecycle project store skips explicit ipr project file`() {
+        val projectRoot = Files.createTempDirectory("inspection-ipr-project-store")
+        val projectFilePath = projectRoot.resolve("project.ipr")
+        Files.writeString(projectFilePath, "<project />")
+
+        assertNull(prepareLifecycleProjectStoreIfDirectory(projectFilePath))
+        assertFalse(Files.exists(projectRoot.resolve(Project.DIRECTORY_STORE_FOLDER)))
+    }
     
     @BeforeEach
     fun setup() {
@@ -4052,7 +4062,9 @@ class InspectionHandlerTest {
         every { mockApplication.invokeLater(any()) } answers {
             firstArg<Runnable>().run()
         }
+        var trustedPath: Path? = null
         var openedPath: Path? = null
+        handler.trustProjectPath = { path: Path -> trustedPath = path }
         handler.openProjectPath = { path: Path, beforeInit ->
             openedPath = path
             beforeInit(openedProject)
@@ -4413,7 +4425,9 @@ class InspectionHandlerTest {
         every { mockApplication.invokeLater(any()) } answers {
             firstArg<Runnable>().run()
         }
+        var trustedPath: Path? = null
         var openedPath: Path? = null
+        handler.trustProjectPath = { path: Path -> trustedPath = path }
         handler.openProjectPath = { path: Path, beforeInit ->
             openedPath = path
             beforeInit(openedProject)
@@ -4426,7 +4440,8 @@ class InspectionHandlerTest {
         assertEquals(HttpResponseStatus.OK, response.status())
         assertTrue(body.contains("\"status\": \"opening\""))
         assertTrue(body.contains("\"opening_scheduled\": true"))
-        assertEquals(tempDir.toAbsolutePath().normalize(), openedPath)
+        assertEquals(tempDir.toAbsolutePath().normalize(), trustedPath)
+        assertEquals(projectFilePath.toAbsolutePath().normalize(), openedPath)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- preserve an explicit `.ipr` path as the JetBrains project-open target
- keep trust, route identity, readiness, and lifecycle ownership rooted at the containing directory
- bootstrap `.idea` only for directory open paths
- document and test the file-based project contract

## Validation

- focused `.ipr` lifecycle tests
- `./scripts/commit-gate.sh --ci`
- `./scripts/release-compatibility-gate.sh` across IU 251–262
- live PyCharm 2026.2 smoke: `project_file_path` remained `project.ipr`, route base remained the containing directory, and `.idea` remained absent
- IntelliJ changed-files inspection: only the six pre-existing `SameParameterValue` findings tracked in #248
- independent Opus review: approved with no blockers

Closes #252