### PR TITLE
Keep idea metadata lifecycle opens rooted

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -96,9 +96,11 @@ for an unsupported IDE config layout, settings sync overwriting the config, or a
 missing inspection plugin. The
 plugin-side lifecycle open endpoint schedules project opening asynchronously and
 prepares a directory-based project store before using the noninteractive public
-project-open path for directory inputs. Explicit `.ipr` inputs preserve the
-requested file-based project path and use its containing directory for trust,
-routing, readiness, and lifecycle ownership. This avoids the IDE's Open/Attach/New Window prompt while
+project-open path for directory inputs. Explicit `.ipr` inputs outside `.idea`
+preserve the requested file-based project path and use its containing directory
+for trust, routing, readiness, and lifecycle ownership. Files under `.idea`
+always open the containing project root regardless of filename extension. This
+avoids the IDE's Open/Attach/New Window prompt while
 using the worktree directory name as the frame project name, running project
 configurators, and refreshing the VFS so cloned worktrees
 with identical checked-in `.idea` metadata can coexist in IntelliJ IDEA,

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -3149,31 +3149,26 @@ class InspectionHandler : HttpRequestHandler() {
     }
 
     private fun resolveLifecycleOpenTarget(path: Path): LifecycleOpenTarget {
-        val projectRoot = lifecycleOpenProjectRoot(path)
+        val metadataProjectRoot = projectRootFromIdeaMetadataPath(path)
+        val explicitProjectFile = metadataProjectRoot == null &&
+            Files.isRegularFile(path) &&
+            path.fileName.toString().endsWith(".ipr")
+        val projectRoot = when {
+            metadataProjectRoot != null -> metadataProjectRoot
+            Files.isDirectory(path) -> path
+            explicitProjectFile -> path.parent
+            else -> null
+        }
             ?: throw BadRequestException(
                 "worktree_path",
                 "Parameter 'worktree_path' must point to an existing directory, .ipr project file, or file inside .idea.",
             )
-        val openPath = if (Files.isRegularFile(path) && path.fileName.toString().endsWith(".ipr")) {
-            path
-        } else {
-            projectRoot
-        }
         return LifecycleOpenTarget(
             path = path,
-            openPath = openPath,
+            openPath = if (explicitProjectFile) path else projectRoot,
             projectRoot = projectRoot,
             key = canonicalLifecycleOpenKey(projectRoot),
         )
-    }
-
-    private fun lifecycleOpenProjectRoot(path: Path): Path? {
-        projectRootFromIdeaMetadataPath(path)?.let { return it }
-        if (Files.isDirectory(path)) return path
-        if (!Files.isRegularFile(path)) return null
-        val fileName = path.fileName?.toString() ?: return null
-        if (fileName.endsWith(".ipr")) return path.parent
-        return null
     }
 
     private fun canonicalLifecycleOpenKey(path: Path): String {

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -4476,6 +4476,52 @@ class InspectionHandlerTest {
     }
 
     @Test
+    fun `test lifecycle open treats ipr-named idea metadata as project root`() {
+        val tempDir = Files.createTempDirectory("inspection-open-idea-ipr-file")
+        val metadataPath = tempDir.resolve(".idea/project.ipr")
+        Files.createDirectories(metadataPath.parent)
+        Files.writeString(metadataPath, "<project />")
+        val openedProject = mockProject(
+            name = "OpenedIdeaIprMetadata",
+            basePath = tempDir.toString(),
+            projectFilePath = tempDir.resolve(".idea/misc.xml").toString(),
+        )
+        every { mockProjectManager.openProjects } returns emptyArray()
+        every { mockApplication.invokeLater(any()) } answers {
+            firstArg<Runnable>().run()
+        }
+        var trustedPath: Path? = null
+        var openedPath: Path? = null
+        handler.trustProjectPath = { path: Path -> trustedPath = path }
+        handler.openProjectPath = { path: Path, beforeInit ->
+            openedPath = path
+            beforeInit(openedProject)
+            openedProject
+        }
+
+        val response = processGetRequest(lifecycleOpenUri(metadataPath))
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertEquals(tempDir.toAbsolutePath().normalize(), trustedPath)
+        assertEquals(tempDir.toAbsolutePath().normalize(), openedPath)
+    }
+
+    @Test
+    fun `test lifecycle open rejects regular non-project file outside idea`() {
+        val tempDir = Files.createTempDirectory("inspection-open-non-project-file")
+        val regularFile = tempDir.resolve("notes.txt")
+        Files.writeString(regularFile, "not a project")
+        every { mockProjectManager.openProjects } returns emptyArray()
+
+        val response = processGetRequest(lifecycleOpenUri(regularFile))
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.BAD_REQUEST, response.status())
+        assertTrue(body.contains("\"parameter\": \"worktree_path\""))
+        assertTrue(body.contains(".ipr project file, or file inside .idea"))
+    }
+
+    @Test
     fun `test lifecycle open resolves idea directory to project root`() {
         val tempDir = Files.createTempDirectory("inspection-open-idea-dir")
         val ideaDir = tempDir.resolve(".idea")


### PR DESCRIPTION
## Summary

- classify `.idea` metadata before explicit top-level `.ipr` files in one unified lifecycle-open decision
- keep top-level `.ipr` inputs opening the requested project file
- keep every file under `.idea`, including `.idea/*.ipr`, opening the containing project root
- add positive coverage for all accepted input classes plus the invalid regular-file rejection path

## Validation

- focused directory, top-level `.ipr`, `.idea` metadata, `.idea/*.ipr`, and rejection tests
- `./scripts/commit-gate.sh --ci`
- `./scripts/release-compatibility-gate.sh` across IU 251–262
- live PyCharm 2026.2 smoke: `.idea/project.ipr` opened the directory and reported `.idea/misc.xml`
- IntelliJ changed-files inspection: only the six pre-existing `SameParameterValue` findings tracked by #248
- independent Opus review: approved with no blockers

Closes #252