### PR TITLE
Harden canary artifact verification trust boundary

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -34,7 +34,8 @@
       "releaseCompatibilityGate": "./scripts/release-compatibility-gate.sh",
       "validateReleaseVersion": "./scripts/validate-release-version.sh --tag vX.Y.Z",
       "validateCanaryReleaseVersion": "./scripts/validate-canary-release-version.sh --tag canary/vX.Y.Z-canary.N --channel canary",
-      "publishCanaryArtifact": "PUBLISH_TOKEN=$CANARY_PUBLISH_TOKEN MARKETPLACE_CHANNEL=canary ./scripts/publish-canary-artifact.sh --archive /path/to/jetbrains-inspection-api-X.Y.Z-canary.N.zip --tag canary/vX.Y.Z-canary.N --channel canary",
+      "verifyCanaryArtifact": "MARKETPLACE_CHANNEL=canary ./scripts/verify-canary-artifact.sh --archive /path/to/jetbrains-inspection-api-X.Y.Z-canary.N.zip --tag canary/vX.Y.Z-canary.N --channel canary",
+      "publishCanaryArtifact": "PUBLISH_TOKEN=$CANARY_PUBLISH_TOKEN MARKETPLACE_CHANNEL=canary ./scripts/publish-canary-artifact.sh --archive /path/to/jetbrains-inspection-api-X.Y.Z-canary.N.zip --tag canary/vX.Y.Z-canary.N --channel canary --expected-sha256 <verified-sha256>",
       "canaryPublishEnvironment": "canary-marketplace",
       "mcpServerJar": "./gradlew :mcp-server-jvm:mcpServerJar"
     },

--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -28,15 +28,17 @@ jobs:
         run: test "$GITHUB_REF" = "refs/heads/$DEFAULT_BRANCH"
 
       - name: Check out trusted publication controls
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
           ref: ${{ github.sha }}
           path: trusted
 
       - name: Check out canary source
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
           ref: ${{ inputs.tag }}
           path: source
 
@@ -65,11 +67,10 @@ jobs:
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           java-version: "21"
           distribution: "temurin"
-          cache: "gradle"
 
       - name: Grant execute permission for Gradle
         working-directory: source
@@ -83,27 +84,8 @@ jobs:
         working-directory: source
         run: ./scripts/release-compatibility-gate.sh
 
-      - name: Verify exact canary internal API manifest
-        shell: bash
-        run: |
-          mapfile -t reports < <(find source/build/reports/pluginVerifier \
-            -path "*/plugins/com.shiny.inspection.api/${{ steps.canary_version.outputs.version }}/internal-api-usages.txt" \
-            -type f -print | sort)
-          if [ "${#reports[@]}" -eq 0 ]; then
-            echo "Plugin Verifier did not produce canary internal API reports."
-            exit 1
-          fi
-          command=(
-            python3 trusted/scripts/verify-internal-api-allowlist.py
-            --manifest source/config/plugin-verifier/canary-internal-api-allowlist.txt
-          )
-          for report in "${reports[@]}"; do
-            command+=(--report "$report")
-          done
-          "${command[@]}"
-
       - name: Upload canary plugin artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: canary-plugin-${{ steps.canary_version.outputs.version }}
           path: source/build/distributions/jetbrains-inspection-api-${{ steps.canary_version.outputs.version }}.zip
@@ -111,7 +93,7 @@ jobs:
           retention-days: 7
 
       - name: Upload test results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: canary-test-results
@@ -121,12 +103,80 @@ jobs:
             source/mcp-server-jvm/build/reports/tests/test/
           retention-days: 7
 
-  publish:
+  verify:
     needs: [build]
+    runs-on: ubuntu-latest
+    outputs:
+      archive_sha256: ${{ steps.archive_digest.outputs.sha256 }}
+    permissions:
+      contents: read
+
+    steps:
+      - name: Verify trusted workflow ref
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: test "$GITHUB_REF" = "refs/heads/$DEFAULT_BRANCH"
+
+      - name: Check out trusted verification controls
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.sha }}
+          path: trusted
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          java-version: "21"
+          distribution: "temurin"
+
+      - name: Download canary plugin artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: canary-plugin-${{ needs.build.outputs.version }}
+          path: artifact
+
+      - name: Revalidate canary tag provenance
+        env:
+          CANARY_TAG: ${{ inputs.tag }}
+          EXPECTED_SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
+        working-directory: trusted
+        run: |
+          git fetch origin "refs/tags/$CANARY_TAG:refs/tags/$CANARY_TAG"
+          test "$(git rev-parse "refs/tags/$CANARY_TAG^{commit}")" = "$EXPECTED_SOURCE_SHA"
+
+      - name: Independently verify canary artifact
+        env:
+          CANARY_TAG: ${{ inputs.tag }}
+          MARKETPLACE_CHANNEL: canary
+        run: |
+          trusted/scripts/verify-canary-artifact.sh \
+            --archive "artifact/jetbrains-inspection-api-${{ needs.build.outputs.version }}.zip" \
+            --tag "$CANARY_TAG" \
+            --channel "$MARKETPLACE_CHANNEL"
+
+      - name: Record verified artifact digest
+        id: archive_digest
+        run: |
+          archive="artifact/jetbrains-inspection-api-${{ needs.build.outputs.version }}.zip"
+          echo "sha256=$(shasum -a 256 "$archive" | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+
+      - name: Upload trusted Plugin Verifier reports
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: always()
+        with:
+          name: canary-plugin-verifier-${{ needs.build.outputs.version }}
+          path: trusted/build/reports/pluginVerifier/
+          if-no-files-found: warn
+          retention-days: 30
+
+  publish:
+    needs: [build, verify]
     runs-on: ubuntu-latest
     environment: canary-marketplace
     permissions:
-      contents: write
+      contents: read
 
     steps:
       - name: Verify trusted workflow ref
@@ -135,14 +185,15 @@ jobs:
         run: test "$GITHUB_REF" = "refs/heads/$DEFAULT_BRANCH"
 
       - name: Check out trusted publication controls
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
           ref: ${{ github.sha }}
           path: trusted
 
       - name: Download canary plugin artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: canary-plugin-${{ needs.build.outputs.version }}
           path: artifact
@@ -159,12 +210,16 @@ jobs:
       - name: Validate trusted canary artifact
         env:
           CANARY_TAG: ${{ inputs.tag }}
+          EXPECTED_ARCHIVE_SHA256: ${{ needs.verify.outputs.archive_sha256 }}
           MARKETPLACE_CHANNEL: canary
         run: |
+          archive="artifact/jetbrains-inspection-api-${{ needs.build.outputs.version }}.zip"
           trusted/scripts/validate-canary-artifact.sh \
-            --archive "artifact/jetbrains-inspection-api-${{ needs.build.outputs.version }}.zip" \
+            --archive "$archive" \
             --tag "$CANARY_TAG" \
             --channel "$MARKETPLACE_CHANNEL"
+          actual_sha256="$(shasum -a 256 "$archive" | awk '{print $1}')"
+          test "$actual_sha256" = "$EXPECTED_ARCHIVE_SHA256"
 
       - name: Verify canary Marketplace token
         env:
@@ -175,27 +230,63 @@ jobs:
             exit 1
           fi
 
-      - name: Create GitHub prerelease
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: ${{ inputs.tag }}
-          name: Canary ${{ inputs.tag }}
-          body: |
-            Branch-only canary for Marketplace review.
-
-            Source commit: ${{ needs.build.outputs.source_sha }}
-            Marketplace channel: canary
-          draft: false
-          prerelease: true
-          files: artifact/jetbrains-inspection-api-${{ needs.build.outputs.version }}.zip
-
       - name: Publish trusted artifact to JetBrains Marketplace canary channel
         env:
           CANARY_TAG: ${{ inputs.tag }}
+          EXPECTED_ARCHIVE_SHA256: ${{ needs.verify.outputs.archive_sha256 }}
           PUBLISH_TOKEN: ${{ secrets.CANARY_PUBLISH_TOKEN }}
           MARKETPLACE_CHANNEL: canary
         run: |
           trusted/scripts/publish-canary-artifact.sh \
             --archive "artifact/jetbrains-inspection-api-${{ needs.build.outputs.version }}.zip" \
             --tag "$CANARY_TAG" \
-            --channel "$MARKETPLACE_CHANNEL"
+            --channel "$MARKETPLACE_CHANNEL" \
+            --expected-sha256 "$EXPECTED_ARCHIVE_SHA256"
+
+  release:
+    needs: [build, verify, publish]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Verify trusted workflow ref
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: test "$GITHUB_REF" = "refs/heads/$DEFAULT_BRANCH"
+
+      - name: Download verified canary plugin artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: canary-plugin-${{ needs.build.outputs.version }}
+          path: artifact
+
+      - name: Revalidate verified artifact digest
+        env:
+          EXPECTED_ARCHIVE_SHA256: ${{ needs.verify.outputs.archive_sha256 }}
+        run: |
+          archive="artifact/jetbrains-inspection-api-${{ needs.build.outputs.version }}.zip"
+          actual_sha256="$(shasum -a 256 "$archive" | awk '{print $1}')"
+          test "$actual_sha256" = "$EXPECTED_ARCHIVE_SHA256"
+
+      - name: Create GitHub prerelease
+        env:
+          CANARY_TAG: ${{ inputs.tag }}
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
+        run: |
+          archive="artifact/jetbrains-inspection-api-${{ needs.build.outputs.version }}.zip"
+          notes_file="$(mktemp)"
+          trap 'rm -f "$notes_file"' EXIT
+          cat > "$notes_file" <<EOF
+          Branch-only canary for Marketplace review.
+
+          Source commit: $SOURCE_SHA
+          Marketplace channel: canary
+          EOF
+          gh release create "$CANARY_TAG" "$archive" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "Canary $CANARY_TAG" \
+            --notes-file "$notes_file" \
+            --prerelease \
+            --verify-tag

--- a/README.md
+++ b/README.md
@@ -769,30 +769,52 @@ channel. A canary branch uses version `X.Y.Z-canary.N` in both version files and
 an isolated `canary/vX.Y.Z-canary.N` tag. Pushing that tag does not publish
 anything. An operator must explicitly dispatch `.github/workflows/canary-release.yml`
 from the default branch with the existing tag as input. The workflow builds and
-verifies the branch-only source without Marketplace secrets, then a separate
-trusted job downloads the resulting zip and publishes only that artifact.
+tests the branch-only source without Marketplace secrets or persisted checkout
+credentials. That build workspace and all branch-produced verifier reports are
+discarded. A fresh trusted job downloads the resulting zip, independently runs
+Plugin Verifier against the artifact, and requires an exact match with the
+reviewed default-branch `canary-internal-api-allowlist.txt` before publication
+can proceed.
 
-The publish job uses the `canary-marketplace` GitHub environment, which must be
+The fresh publish job uses the `canary-marketplace` GitHub environment, which must be
 restricted to the default branch and require reviewer approval, plus the
 environment-only `CANARY_PUBLISH_TOKEN`. Both jobs pin trusted controls to the
-workflow dispatch commit; the publish job revalidates the tag SHA and archive
-before creating a GitHub prerelease or uploading. It requires the explicit
-`canary` channel and validates the embedded plugin ID/version. For a
-manual recovery or diagnostic upload, run the trusted default-branch script
-against an already-built canary zip:
+workflow dispatch commit; the trusted verification job records the independently
+verified archive digest, and the publish job revalidates the tag SHA, archive,
+and digest immediately before upload. It requires the
+explicit `canary` channel and validates the embedded plugin ID/version. A
+separate final job with GitHub contents write permission creates the prerelease
+only after Marketplace publication succeeds; the token-bearing Marketplace job
+has read-only repository permission. For a manual recovery or diagnostic
+upload, verify the already-built canary zip with
+trusted default-branch controls before running the publisher. Run both commands
+from a separate, clean checkout pinned to the reviewed default-branch dispatch
+commit, never from the canary source worktree:
 
 ```bash
+cd /path/to/clean/trusted-default-branch-checkout
+
+MARKETPLACE_CHANNEL=canary \
+  ./scripts/verify-canary-artifact.sh \
+    --archive /path/to/jetbrains-inspection-api-1.14.0-canary.1.zip \
+    --tag canary/v1.14.0-canary.1 \
+    --channel canary
+
+verified_sha256="$(shasum -a 256 /path/to/jetbrains-inspection-api-1.14.0-canary.1.zip | awk '{print $1}')"
 PUBLISH_TOKEN="$CANARY_PUBLISH_TOKEN" MARKETPLACE_CHANNEL=canary \
   ./scripts/publish-canary-artifact.sh \
     --archive /path/to/jetbrains-inspection-api-1.14.0-canary.1.zip \
     --tag canary/v1.14.0-canary.1 \
-    --channel canary
+    --channel canary \
+    --expected-sha256 "$verified_sha256"
 ```
 
 The artifact publisher fails before network upload when the tag, zip name,
-embedded plugin ID/version, token, or channel is wrong. Canary product code and
-its exact `canary-internal-api-allowlist.txt` changes stay on the experimental
-branch; they are not hidden behind a Stable runtime flag. Recovery is to stop
+embedded plugin ID/version, token, or channel is wrong. Canary product code stays
+on the experimental branch and is not hidden behind a Stable runtime flag. Its
+intended private API findings must be reviewed into the trusted default-branch
+canary manifest before dispatch; the branch cannot supply the publication
+decision, verifier, manifest, or reports. Recovery is to stop
 dispatching the canary workflow, withdraw the canary-channel Marketplace update
 if one exists, delete any orphaned GitHub prerelease from a failed upload, and
 delete the experimental branch after preserving verifier evidence. Stable

--- a/TESTING.md
+++ b/TESTING.md
@@ -346,20 +346,31 @@ class-name pattern to make a report pass.
 
 Canary tags use `canary/vX.Y.Z-canary.N` but do not trigger publication.
 `.github/workflows/canary-release.yml` must be dispatched explicitly from the
-default branch with an existing isolated tag. Its build job checks out trusted
-controls separately from branch-only source, runs without Marketplace secrets,
-and requires exact findings from
-`config/plugin-verifier/canary-internal-api-allowlist.txt`. The publish job uses
-the default-branch-only, reviewer-approved `canary-marketplace` environment,
-pins trusted controls to the dispatch SHA, revalidates the tag SHA and verified
-zip, and uploads through the
+default branch with an existing isolated tag. Its build job treats the source,
+Gradle logic, verifier reports, and workspace as untrusted, persists no checkout
+credentials, uses no Gradle cache, and runs without Marketplace secrets. A fresh
+verification job checks out only trusted controls, downloads the built zip,
+independently runs Plugin Verifier against that artifact, and requires every
+artifact-derived report to match the trusted default-branch
+`config/plugin-verifier/canary-internal-api-allowlist.txt`. The verification job
+records the artifact digest and uploads its reports. Only then may the fresh
+publish job enter the default-branch-only, reviewer-approved
+`canary-marketplace` environment. It revalidates the tag SHA, archive identity,
+and verified digest, then uploads through the
 trusted `scripts/publish-canary-artifact.sh` with the environment-only
-`CANARY_PUBLISH_TOKEN` and explicit `canary` channel. The release contract tests
+`CANARY_PUBLISH_TOKEN`, explicit `canary` channel, and required verified SHA-256.
+That environment job has read-only repository permission. A separate write-only
+GitHub release job creates the prerelease only after Marketplace upload succeeds
+and rechecks the verified digest without receiving the Marketplace token. The release contract tests
 cover malformed versions, Stable/canary workflow separation, branch isolation,
-artifact identity, absent or wrong channels, and unexpected internal APIs.
-The canary manifest is branch-owned, reviewable evidence: #273 may change its
-exact entries for intended private usages, but must not change the Stable
-manifest or replace exact matching with a broader rule.
+artifact identity, absent or wrong channels, unexpected internal APIs, and an
+adversarial attempt to replace trusted verifier controls and reports.
+The canary manifest is trusted, reviewable evidence. An intended canary finding
+must first update that default-branch manifest through review; the experimental
+branch must not modify the Stable manifest or replace exact matching with a
+broader rule. Manual verification and recovery publication must run from a
+separate, clean checkout pinned to the reviewed default-branch dispatch commit,
+never from the canary source worktree.
 
 `./scripts/test-all.sh` reports the configured JaCoCo contracts accurately:
 plugin coverage is a 0% minimum report-only signal because IntelliJ classloader

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -182,6 +182,10 @@ tasks {
 
     withType<VerifyPluginTask> {
         val verifierPluginVersion = project.property("pluginVersion").toString()
+        val externalVerificationArchive = providers.gradleProperty("pluginVerificationArchive")
+        if (externalVerificationArchive.isPresent) {
+            archiveFile.set(layout.file(externalVerificationArchive.map { file(it) }))
+        }
         val allowlistName = if (
             Regex("^[0-9]+\\.[0-9]+\\.[0-9]+-canary\\.[1-9][0-9]*$").matches(verifierPluginVersion)
         ) {

--- a/config/plugin-verifier/canary-internal-api-allowlist.txt
+++ b/config/plugin-verifier/canary-internal-api-allowlist.txt
@@ -1,5 +1,5 @@
-# Exact canonical Plugin Verifier findings approved for Stable.
-# Keep entries sorted; every configured IDE report must match this list.
+# Exact canonical Plugin Verifier findings approved for canary publication.
+# Keep this trusted default-branch manifest sorted; every fresh artifact-derived report must match it.
 Internal class com.intellij.codeInspection.ex.GlobalInspectionContextImpl is referenced in com.shiny.inspectionmcp.InspectionHandler.extractProblemsFromContext$default(InspectionHandler, GlobalInspectionContextImpl, Project, Set, Function0, int, Object) : InspectionModelExtraction
 Internal class com.intellij.codeInspection.ex.GlobalInspectionContextImpl is referenced in com.shiny.inspectionmcp.InspectionHandler.extractProblemsFromContext(GlobalInspectionContextImpl, Project, Set, Function0) : InspectionModelExtraction
 Internal class com.intellij.codeInspection.ex.GlobalInspectionContextImpl is referenced in com.shiny.inspectionmcp.InspectionHandler.extractProblemsFromContextSafe$default(InspectionHandler, GlobalInspectionContextImpl, Project, Set, List, Function0, int, Object) : InspectionModelExtraction

--- a/scripts/publish-canary-artifact.sh
+++ b/scripts/publish-canary-artifact.sh
@@ -6,6 +6,7 @@ ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 ARCHIVE=""
 TAG="${GITHUB_REF_NAME:-}"
 CHANNEL="${MARKETPLACE_CHANNEL:-}"
+EXPECTED_SHA256=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -21,6 +22,10 @@ while [ $# -gt 0 ]; do
       shift
       CHANNEL="${1:-}"
       ;;
+    --expected-sha256)
+      shift
+      EXPECTED_SHA256="${1:-}"
+      ;;
     *)
       echo "ERROR: Unknown argument: $1" >&2
       exit 1
@@ -33,6 +38,16 @@ done
   --archive "$ARCHIVE" \
   --tag "$TAG" \
   --channel "$CHANNEL"
+
+if ! [[ "$EXPECTED_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+  echo "ERROR: --expected-sha256 must be the lowercase SHA-256 of the verified canary artifact." >&2
+  exit 1
+fi
+ACTUAL_SHA256=$(shasum -a 256 "$ARCHIVE" | awk '{print $1}')
+if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
+  echo "ERROR: Canary artifact SHA-256 does not match the independently verified artifact." >&2
+  exit 1
+fi
 
 if [ -z "${PUBLISH_TOKEN:-}" ]; then
   echo "ERROR: CANARY_PUBLISH_TOKEN is not available as PUBLISH_TOKEN." >&2

--- a/scripts/test-release-contracts.sh
+++ b/scripts/test-release-contracts.sh
@@ -99,13 +99,14 @@ test_canary_version_validator() {
 }
 
 test_canary_artifact_publication() {
-  local temp_dir fake_bin curl_log archive bad_archive bad_version_archive missing_jar_archive
+  local temp_dir fake_bin curl_log archive archive_sha256 bad_archive bad_version_archive bad_compatibility_archive missing_jar_archive
   temp_dir=$(mktemp -d)
   fake_bin="$temp_dir/bin"
   curl_log="$temp_dir/curl.log"
   archive="$temp_dir/jetbrains-inspection-api-1.2.3-canary.1.zip"
   bad_archive="$temp_dir/bad/jetbrains-inspection-api-1.2.3-canary.1.zip"
   bad_version_archive="$temp_dir/bad-version/jetbrains-inspection-api-1.2.3-canary.1.zip"
+  bad_compatibility_archive="$temp_dir/bad-compatibility/jetbrains-inspection-api-1.2.3-canary.1.zip"
   missing_jar_archive="$temp_dir/missing-jar/jetbrains-inspection-api-1.2.3-canary.1.zip"
   trap 'rm -rf "$temp_dir"' RETURN
   mkdir -p "$temp_dir/scripts" "$fake_bin"
@@ -114,17 +115,34 @@ test_canary_artifact_publication() {
     scripts/validate-canary-artifact.sh \
     scripts/validate-marketplace-publication.sh \
     "$temp_dir/scripts/"
-  mkdir -p "$(dirname "$bad_archive")" "$(dirname "$bad_version_archive")" "$(dirname "$missing_jar_archive")"
-  python3 - "$archive" "$bad_archive" "$bad_version_archive" "$missing_jar_archive" <<'PY'
+  mkdir -p \
+    "$(dirname "$bad_archive")" \
+    "$(dirname "$bad_version_archive")" \
+    "$(dirname "$bad_compatibility_archive")" \
+    "$(dirname "$missing_jar_archive")"
+  python3 - \
+    "$archive" \
+    "$bad_archive" \
+    "$bad_version_archive" \
+    "$bad_compatibility_archive" \
+    "$missing_jar_archive" <<'PY'
 from io import BytesIO
 from pathlib import Path
 import sys
 import zipfile
 
-def write_archive(path: Path, plugin_id: str, version: str) -> None:
+def write_archive(
+    path: Path,
+    plugin_id: str,
+    version: str,
+    since_build: str = "251",
+    until_build: str = "262.*",
+) -> None:
     plugin_xml = (
         f"<idea-plugin><id>{plugin_id}</id>"
-        f"<version>{version}</version></idea-plugin>"
+        f"<version>{version}</version>"
+        f'<idea-version since-build="{since_build}" until-build="{until_build}"/>'
+        "</idea-plugin>"
     )
     plugin_jar = BytesIO()
     with zipfile.ZipFile(plugin_jar, "w") as jar:
@@ -138,9 +156,16 @@ def write_archive(path: Path, plugin_id: str, version: str) -> None:
 write_archive(Path(sys.argv[1]), "com.shiny.inspection.api", "1.2.3-canary.1")
 write_archive(Path(sys.argv[2]), "different.plugin.id", "1.2.3-canary.1")
 write_archive(Path(sys.argv[3]), "com.shiny.inspection.api", "1.2.3-canary.2")
-with zipfile.ZipFile(Path(sys.argv[4]), "w") as plugin_zip:
+write_archive(
+    Path(sys.argv[4]),
+    "com.shiny.inspection.api",
+    "1.2.3-canary.1",
+    until_build="271.*",
+)
+with zipfile.ZipFile(Path(sys.argv[5]), "w") as plugin_zip:
     plugin_zip.writestr("unexpected.txt", "missing plugin jar")
 PY
+  archive_sha256=$(shasum -a 256 "$archive" | awk '{print $1}')
   cat > "$fake_bin/curl" <<'CURL'
 #!/usr/bin/env bash
 printf '%s\n' "$@" > "$CURL_LOG"
@@ -172,17 +197,27 @@ CURL
   fi
   [ ! -e "$curl_log" ] || fail "canary artifact publisher invoked curl for a mismatched version"
 
+  if (cd "$temp_dir" && PATH="$fake_bin:$PATH" CURL_LOG="$curl_log" PUBLISH_TOKEN=test MARKETPLACE_CHANNEL=canary ./scripts/publish-canary-artifact.sh --archive "$bad_compatibility_archive" --tag canary/v1.2.3-canary.1 >/dev/null 2>&1); then
+    fail "canary artifact publisher accepted an untrusted compatibility range"
+  fi
+  [ ! -e "$curl_log" ] || fail "canary artifact publisher invoked curl for an untrusted compatibility range"
+
   if (cd "$temp_dir" && PATH="$fake_bin:$PATH" CURL_LOG="$curl_log" PUBLISH_TOKEN=test MARKETPLACE_CHANNEL=canary ./scripts/publish-canary-artifact.sh --archive "$missing_jar_archive" --tag canary/v1.2.3-canary.1 >/dev/null 2>&1); then
     fail "canary artifact publisher accepted an archive without the plugin jar"
   fi
   [ ! -e "$curl_log" ] || fail "canary artifact publisher invoked curl for a missing plugin jar"
 
-  if (cd "$temp_dir" && PATH="$fake_bin:$PATH" CURL_LOG="$curl_log" PUBLISH_TOKEN='' MARKETPLACE_CHANNEL=canary ./scripts/publish-canary-artifact.sh --archive "$archive" --tag canary/v1.2.3-canary.1 >/dev/null 2>&1); then
+  if (cd "$temp_dir" && PATH="$fake_bin:$PATH" CURL_LOG="$curl_log" PUBLISH_TOKEN='' MARKETPLACE_CHANNEL=canary ./scripts/publish-canary-artifact.sh --archive "$archive" --tag canary/v1.2.3-canary.1 --expected-sha256 "$archive_sha256" >/dev/null 2>&1); then
     fail "canary artifact publisher accepted an absent token"
   fi
   [ ! -e "$curl_log" ] || fail "canary artifact publisher invoked curl without a token"
 
-  (cd "$temp_dir" && PATH="$fake_bin:$PATH" CURL_LOG="$curl_log" PUBLISH_TOKEN=test MARKETPLACE_CHANNEL=canary ./scripts/publish-canary-artifact.sh --archive "$archive" --tag canary/v1.2.3-canary.1 >/dev/null)
+  if (cd "$temp_dir" && PATH="$fake_bin:$PATH" CURL_LOG="$curl_log" PUBLISH_TOKEN=test MARKETPLACE_CHANNEL=canary ./scripts/publish-canary-artifact.sh --archive "$archive" --tag canary/v1.2.3-canary.1 --expected-sha256 "$(printf '0%.0s' {1..64})" >/dev/null 2>&1); then
+    fail "canary artifact publisher accepted an unverified artifact digest"
+  fi
+  [ ! -e "$curl_log" ] || fail "canary artifact publisher invoked curl for an unverified artifact digest"
+
+  (cd "$temp_dir" && PATH="$fake_bin:$PATH" CURL_LOG="$curl_log" PUBLISH_TOKEN=test MARKETPLACE_CHANNEL=canary ./scripts/publish-canary-artifact.sh --archive "$archive" --tag canary/v1.2.3-canary.1 --expected-sha256 "$archive_sha256" >/dev/null)
   assert_contains "$curl_log" "xmlId=com.shiny.inspection.api"
   assert_contains "$curl_log" "file=@$archive"
   assert_contains "$curl_log" "channel=canary"
@@ -313,6 +348,94 @@ MANIFEST
   trap - RETURN
 }
 
+test_canary_verification_trust_boundary() {
+  local temp_dir trusted source archive gradle_log
+  temp_dir=$(mktemp -d)
+  trusted="$temp_dir/trusted"
+  source="$temp_dir/source"
+  archive="$temp_dir/jetbrains-inspection-api-1.2.3-canary.1.zip"
+  gradle_log="$temp_dir/gradle.log"
+  trap 'rm -rf "$temp_dir"' RETURN
+
+  mkdir -p \
+    "$trusted/scripts" \
+    "$trusted/config/plugin-verifier" \
+    "$source/trusted/scripts" \
+    "$source/build/reports/pluginVerifier/tampered" \
+    "$source/config/plugin-verifier"
+  cp \
+    scripts/validate-canary-artifact.sh \
+    scripts/validate-marketplace-publication.sh \
+    scripts/verify-canary-artifact.sh \
+    "$trusted/scripts/"
+  cp config/plugin-verifier/canary-internal-api-allowlist.txt \
+    "$trusted/config/plugin-verifier/"
+
+  cat > "$trusted/gradlew" <<'GRADLE'
+#!/usr/bin/env bash
+set -euo pipefail
+test "$PWD" = "$TRUSTED_ROOT"
+test -f config/plugin-verifier/canary-internal-api-allowlist.txt
+printf '%s\n' "$@" > "$GRADLE_LOG"
+GRADLE
+  chmod +x "$trusted/gradlew"
+
+  cat > "$source/trusted/scripts/verify-canary-artifact.sh" <<'MALICIOUS'
+#!/usr/bin/env bash
+touch "${TAMPER_MARKER:?}"
+exit 0
+MALICIOUS
+  chmod +x "$source/trusted/scripts/verify-canary-artifact.sh"
+  printf 'fabricated report\n' > \
+    "$source/build/reports/pluginVerifier/tampered/internal-api-usages.txt"
+  printf 'fabricated manifest\n' > \
+    "$source/config/plugin-verifier/canary-internal-api-allowlist.txt"
+
+  python3 - "$archive" <<'PY'
+from io import BytesIO
+from pathlib import Path
+import sys
+import zipfile
+
+archive = Path(sys.argv[1])
+plugin_jar = BytesIO()
+with zipfile.ZipFile(plugin_jar, "w") as jar:
+    jar.writestr(
+        "META-INF/plugin.xml",
+        "<idea-plugin><id>com.shiny.inspection.api</id>"
+        "<version>1.2.3-canary.1</version>"
+        '<idea-version since-build="251" until-build="262.*"/>'
+        "</idea-plugin>",
+    )
+with zipfile.ZipFile(archive, "w") as plugin_zip:
+    plugin_zip.writestr(
+        "jetbrains-inspection-api/lib/jetbrains-inspection-api-1.2.3-canary.1.jar",
+        plugin_jar.getvalue(),
+    )
+PY
+
+  (
+    export GRADLE_LOG="$gradle_log"
+    export TAMPER_MARKER="$temp_dir/tampered"
+    export TRUSTED_ROOT="$trusted"
+    cd "$source"
+    "$trusted/scripts/verify-canary-artifact.sh" \
+      --archive "$archive" \
+      --tag canary/v1.2.3-canary.1 \
+      --channel canary >/dev/null
+  )
+
+  [ ! -e "$temp_dir/tampered" ] || \
+    fail "canary verification executed branch-controlled trusted controls"
+  assert_contains "$gradle_log" "--no-build-cache"
+  assert_contains "$gradle_log" "verifyPlugin"
+  assert_contains "$gradle_log" "-PpluginVersion=1.2.3-canary.1"
+  assert_contains "$gradle_log" "-PpluginVerificationArchive=$archive"
+
+  rm -rf "$temp_dir"
+  trap - RETURN
+}
+
 write_gate_stub() {
   local path="$1"
   cat > "$path" <<'STUB'
@@ -408,6 +531,8 @@ test_static_contracts() {
   assert_contains scripts/release-compatibility-gate.sh 'buildPlugin verifyPluginStructure verifyPlugin'
   assert_contains build.gradle.kts 'stable-internal-api-allowlist.txt'
   assert_contains build.gradle.kts 'canary-internal-api-allowlist.txt'
+  assert_contains build.gradle.kts 'providers.gradleProperty("pluginVerificationArchive")'
+  assert_contains build.gradle.kts 'archiveFile.set(layout.file(externalVerificationArchive.map { file(it) }))'
   assert_contains build.gradle.kts 'scripts/validate-marketplace-publication.sh'
   assert_contains scripts/validate-marketplace-publication.sh 'Canary plugin versions require -PmarketplaceChannel=canary.'
   assert_contains scripts/validate-marketplace-publication.sh 'Stable plugin versions must use the default Marketplace channel.'
@@ -417,13 +542,21 @@ test_static_contracts() {
     --manifest config/plugin-verifier/stable-internal-api-allowlist.txt >/dev/null
   ./scripts/verify-internal-api-allowlist.py \
     --manifest config/plugin-verifier/canary-internal-api-allowlist.txt >/dev/null
-  cmp -s \
-    config/plugin-verifier/stable-internal-api-allowlist.txt \
-    config/plugin-verifier/canary-internal-api-allowlist.txt || \
-    fail "canary allowlist diverged before branch-only canary implementation"
 
   python3 - <<'PY'
 from pathlib import Path
+import re
+
+build = Path("build.gradle.kts").read_text(encoding="utf-8")
+validator = Path("scripts/validate-canary-artifact.sh").read_text(encoding="utf-8")
+build_since = re.search(r'sinceBuild = "([^"]+)"', build)
+build_until = re.search(r'untilBuild = "([^"]+)"', build)
+validator_since = re.search(r'EXPECTED_SINCE_BUILD="([^"]+)"', validator)
+validator_until = re.search(r'EXPECTED_UNTIL_BUILD="([^"]+)"', validator)
+if not all((build_since, build_until, validator_since, validator_until)):
+    raise SystemExit("trusted compatibility policy could not be resolved")
+if build_since.group(1) != validator_since.group(1) or build_until.group(1) != validator_until.group(1):
+    raise SystemExit("trusted artifact and Gradle compatibility policies diverged")
 
 workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
 validate = workflow.index("Validate release version")
@@ -447,10 +580,15 @@ PY
   assert_contains .github/workflows/canary-release.yml 'MARKETPLACE_CHANNEL: canary'
   assert_contains .github/workflows/canary-release.yml 'CANARY_PUBLISH_TOKEN'
   assert_contains .github/workflows/canary-release.yml 'environment: canary-marketplace'
-  assert_contains .github/workflows/canary-release.yml 'prerelease: true'
+  assert_contains .github/workflows/canary-release.yml '--prerelease'
   assert_contains .github/workflows/canary-release.yml 'trusted/scripts/publish-canary-artifact.sh'
   assert_contains .github/workflows/canary-release.yml 'trusted/scripts/validate-canary-artifact.sh'
-  assert_contains .github/workflows/canary-release.yml 'source/config/plugin-verifier/canary-internal-api-allowlist.txt'
+  assert_contains .github/workflows/canary-release.yml 'trusted/scripts/verify-canary-artifact.sh'
+  assert_not_contains .github/workflows/canary-release.yml 'source/config/plugin-verifier/canary-internal-api-allowlist.txt'
+  assert_not_contains .github/workflows/canary-release.yml 'cache: "gradle"'
+  assert_contains .github/workflows/canary-release.yml 'if: always()'
+  assert_not_contains .github/workflows/canary-release.yml 'softprops/action-gh-release'
+  assert_contains scripts/publish-canary-artifact.sh '--expected-sha256'
   assert_not_contains .github/workflows/canary-release.yml 'generate-release-notes.sh'
   assert_not_contains .github/workflows/canary-release.yml '--tag "${{ inputs.tag }}"'
   assert_contains .github/workflows/canary-release.yml 'CANARY_TAG: ${{ inputs.tag }}'
@@ -460,10 +598,18 @@ PY
 
   python3 - <<'PY'
 from pathlib import Path
+import re
 
 workflow = Path(".github/workflows/canary-release.yml").read_text(encoding="utf-8")
-build = workflow.split("\n  build:\n", 1)[1].split("\n  publish:\n", 1)[0]
-publish = workflow.split("\n  publish:\n", 1)[1]
+build = workflow.split("\n  build:\n", 1)[1].split("\n  verify:\n", 1)[0]
+verify = workflow.split("\n  verify:\n", 1)[1].split("\n  publish:\n", 1)[0]
+publish = workflow.split("\n  publish:\n", 1)[1].split("\n  release:\n", 1)[0]
+release = workflow.split("\n  release:\n", 1)[1]
+
+for line in workflow.splitlines():
+    stripped = line.strip()
+    if stripped.startswith("uses:") and not re.search(r"@[0-9a-f]{40}(?:\s+#\s+v\d+)?$", stripped):
+        raise SystemExit(f"canary workflow action is not pinned to a full commit SHA: {stripped}")
 
 build_steps = [
     "Verify trusted workflow ref",
@@ -471,13 +617,38 @@ build_steps = [
     "Verify exact canary tag and branch isolation",
     "Run canary commit gate",
     "Run canary release compatibility gate",
-    "Verify exact canary internal API manifest",
     "Upload canary plugin artifact",
 ]
 if [build.index(step) for step in build_steps] != sorted(build.index(step) for step in build_steps):
     raise SystemExit("canary build workflow gate ordering is unsafe")
 if "CANARY_PUBLISH_TOKEN" in build:
     raise SystemExit("canary build job must not receive Marketplace secrets")
+if "verify-internal-api-allowlist.py" in build or "internal-api-usages.txt" in build:
+    raise SystemExit("canary build job must not make the trusted verification decision")
+if build.count("persist-credentials: false") != 2:
+    raise SystemExit("canary build checkouts must not persist credentials")
+
+verify_steps = [
+    "Verify trusted workflow ref",
+    "Check out trusted verification controls",
+    "Download canary plugin artifact",
+    "Revalidate canary tag provenance",
+    "Independently verify canary artifact",
+    "Record verified artifact digest",
+    "Upload trusted Plugin Verifier reports",
+]
+if [verify.index(step) for step in verify_steps] != sorted(verify.index(step) for step in verify_steps):
+    raise SystemExit("canary verification workflow gate ordering is unsafe")
+if "path: source" in verify or "working-directory: source" in verify:
+    raise SystemExit("trusted verification job must not check out branch-controlled source")
+if "CANARY_PUBLISH_TOKEN" in verify or "environment:" in verify:
+    raise SystemExit("trusted verification job must not receive publication authority")
+if "trusted/scripts/verify-canary-artifact.sh" not in verify:
+    raise SystemExit("trusted verification job must independently inspect the downloaded artifact")
+if "archive_sha256:" not in verify:
+    raise SystemExit("trusted verification job must bind publication to the verified artifact digest")
+if "test \"$(git rev-parse \"refs/tags/$CANARY_TAG^{commit}\")\" = \"$EXPECTED_SOURCE_SHA\"" not in verify:
+    raise SystemExit("trusted verification must enforce the source tag digest")
 
 publish_steps = [
     "Verify trusted workflow ref",
@@ -485,13 +656,41 @@ publish_steps = [
     "Revalidate canary tag provenance",
     "Validate trusted canary artifact",
     "Verify canary Marketplace token",
-    "Create GitHub prerelease",
     "Publish trusted artifact to JetBrains Marketplace canary channel",
 ]
 if [publish.index(step) for step in publish_steps] != sorted(publish.index(step) for step in publish_steps):
     raise SystemExit("canary publish workflow gate ordering is unsafe")
 if "path: source" in publish or "working-directory: source" in publish:
     raise SystemExit("canary publish job must not check out or execute branch-controlled source")
+if "contents: read" not in publish or "contents: write" in publish:
+    raise SystemExit("Marketplace publication must not receive GitHub contents write authority")
+if "needs: [build, verify]" not in publish:
+    raise SystemExit("canary publication must depend on trusted artifact verification")
+if "EXPECTED_ARCHIVE_SHA256: ${{ needs.verify.outputs.archive_sha256 }}" not in publish:
+    raise SystemExit("canary publication must require the trusted verification digest")
+if 'test "$actual_sha256" = "$EXPECTED_ARCHIVE_SHA256"' not in publish:
+    raise SystemExit("canary publication must compare the downloaded artifact to the trusted digest")
+if '--expected-sha256 "$EXPECTED_ARCHIVE_SHA256"' not in publish:
+    raise SystemExit("Marketplace upload must recheck the independently verified artifact digest")
+if "test \"$(git rev-parse \"refs/tags/$CANARY_TAG^{commit}\")\" = \"$EXPECTED_SOURCE_SHA\"" not in publish:
+    raise SystemExit("canary publication must enforce the source tag digest")
+if publish.index("EXPECTED_ARCHIVE_SHA256") > publish.index("Verify canary Marketplace token"):
+    raise SystemExit("verified artifact identity must be checked before publication authority")
+
+release_steps = [
+    "Verify trusted workflow ref",
+    "Download verified canary plugin artifact",
+    "Revalidate verified artifact digest",
+    "Create GitHub prerelease",
+]
+if [release.index(step) for step in release_steps] != sorted(release.index(step) for step in release_steps):
+    raise SystemExit("canary GitHub release workflow ordering is unsafe")
+if "needs: [build, verify, publish]" not in release:
+    raise SystemExit("GitHub prerelease creation must follow successful Marketplace publication")
+if "contents: write" not in release or "CANARY_PUBLISH_TOKEN" in release:
+    raise SystemExit("GitHub release authority must remain isolated from Marketplace authority")
+if 'test "$actual_sha256" = "$EXPECTED_ARCHIVE_SHA256"' not in release:
+    raise SystemExit("GitHub prerelease must use the independently verified artifact")
 PY
 
   assert_contains scripts/test-all.sh 'Plugin JaCoCo verification (0% minimum; report-only signal)'
@@ -505,6 +704,7 @@ test_canary_artifact_publication
 test_marketplace_publication_policy
 test_canary_branch_isolation
 test_internal_api_allowlist
+test_canary_verification_trust_boundary
 test_release_script_flow
 test_static_contracts
 

--- a/scripts/validate-canary-artifact.sh
+++ b/scripts/validate-canary-artifact.sh
@@ -39,6 +39,8 @@ if ! [[ "$TAG" =~ ^canary/v([0-9]+\.[0-9]+\.[0-9]+)-canary\.([1-9][0-9]*)$ ]]; t
 fi
 
 VERSION="${BASH_REMATCH[1]}-canary.${BASH_REMATCH[2]}"
+EXPECTED_SINCE_BUILD="251"
+EXPECTED_UNTIL_BUILD="262.*"
 "$ROOT/scripts/validate-marketplace-publication.sh" \
   --version "$VERSION" \
   --channel "$CHANNEL"
@@ -71,13 +73,19 @@ if ! unzip -p "$TEMP_DIR/plugin.jar" META-INF/plugin.xml > "$TEMP_DIR/plugin.xml
   exit 1
 fi
 
-python3 - "$TEMP_DIR/plugin.xml" "$VERSION" <<'PY'
+python3 - \
+  "$TEMP_DIR/plugin.xml" \
+  "$VERSION" \
+  "$EXPECTED_SINCE_BUILD" \
+  "$EXPECTED_UNTIL_BUILD" <<'PY'
 from pathlib import Path
 import sys
 import xml.etree.ElementTree as ET
 
 plugin_xml_path = Path(sys.argv[1])
 expected_version = sys.argv[2]
+expected_since_build = sys.argv[3]
+expected_until_build = sys.argv[4]
 
 try:
     plugin_root = ET.parse(plugin_xml_path).getroot()
@@ -85,11 +93,22 @@ except ET.ParseError as error:
     raise SystemExit(f"ERROR: Canary archive plugin.xml is not valid XML: {error}") from error
 plugin_id = (plugin_root.findtext("id") or "").strip()
 plugin_version = (plugin_root.findtext("version") or "").strip()
+idea_version = plugin_root.find("idea-version")
 if plugin_id != "com.shiny.inspection.api":
     raise SystemExit("ERROR: Canary archive does not preserve plugin ID com.shiny.inspection.api.")
 if plugin_version != expected_version:
     actual = plugin_version or "<missing>"
     raise SystemExit(
         f"ERROR: Canary archive version {actual} does not match tag version {expected_version}."
+    )
+if idea_version is None:
+    raise SystemExit("ERROR: Canary archive does not declare an idea-version compatibility range.")
+since_build = (idea_version.get("since-build") or "").strip()
+until_build = (idea_version.get("until-build") or "").strip()
+if since_build != expected_since_build or until_build != expected_until_build:
+    raise SystemExit(
+        "ERROR: Canary archive compatibility range "
+        f"{since_build or '<missing>'}..{until_build or '<missing>'} does not match "
+        f"trusted range {expected_since_build}..{expected_until_build}."
     )
 PY

--- a/scripts/verify-canary-artifact.sh
+++ b/scripts/verify-canary-artifact.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+ARCHIVE=""
+TAG="${GITHUB_REF_NAME:-}"
+CHANNEL="${MARKETPLACE_CHANNEL:-}"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --archive)
+      shift
+      ARCHIVE="${1:-}"
+      ;;
+    --tag)
+      shift
+      TAG="${1:-}"
+      ;;
+    --channel)
+      shift
+      CHANNEL="${1:-}"
+      ;;
+    *)
+      echo "ERROR: Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+"$ROOT/scripts/validate-canary-artifact.sh" \
+  --archive "$ARCHIVE" \
+  --tag "$TAG" \
+  --channel "$CHANNEL"
+
+ARCHIVE=$(cd "$(dirname "$ARCHIVE")" && pwd)/$(basename "$ARCHIVE")
+VERSION="${TAG#canary/v}"
+
+cd "$ROOT"
+rm -rf build/reports/pluginVerifier
+./gradlew \
+  --no-build-cache \
+  --no-daemon \
+  verifyPlugin \
+  "-PpluginVersion=$VERSION" \
+  "-PpluginVerificationArchive=$ARCHIVE"


### PR DESCRIPTION
## Summary

- move authoritative canary verification into a fresh, non-secret trusted job that downloads and independently verifies the built zip
- bind Marketplace and GitHub prerelease publication to the exact artifact-derived SHA-256 and trusted canary manifest
- remove persisted checkout credentials and the canary Gradle cache, pin all canary workflow actions to full commit SHAs, and isolate GitHub write authority from the Marketplace environment job
- add adversarial contracts for verifier/report/manifest replacement, digest substitution, compatibility-range drift, and job ordering

Refs #272

## Trust Boundary

The canary source checkout, branch Gradle logic, branch scripts, branch verifier reports, and build workspace are treated as untrusted after source execution. The fresh `verify` job checks out only controls pinned to the dispatch SHA, reruns JetBrains Plugin Verifier against the downloaded zip, compares five artifact-derived reports to the trusted exact canary manifest, and emits the verified artifact digest. The environment-bearing Marketplace job has read-only repository permission and requires that digest again inside the uploader. A later isolated job receives GitHub contents write permission to create the prerelease only after Marketplace publication succeeds.

## Validation

- `./scripts/test-release-contracts.sh`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./scripts/test-all.sh`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./scripts/commit-gate.sh --ci`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./scripts/release-compatibility-gate.sh`
- `actionlint .github/workflows/ci.yml .github/workflows/release.yml .github/workflows/canary-release.yml`
- `shellcheck --severity=warning scripts/*.sh`
- fresh external artifact proof: `1.14.0-canary.1`, 5 Plugin Verifier reports, 60 exact findings per report, SHA-256 `104be4b4a8ec93381673603aa616f1177c94e4db7a3d333e6f7ca2d09872b2f6`
- Opus final review: merge-ready, no security or present-day breakage findings
- Gemini/antigravity returned no output; GPT-5.6 substitute review findings were resolved, including action SHA pinning and write-token isolation
- JetBrains changed-files inspection: `UNKNOWN` (`language_sdk_missing`), cleanup closed, no retry recommended by the helper

## Guardrails Preserved

- Stable workflow, plugin ID, version/tag validation, and default Marketplace channel are unchanged
- `canary-marketplace` remains main-only/reviewer-approved and no token was added
- no canary or Stable Marketplace artifact was uploaded, replaced, or resubmitted
