### PR TITLE
Revalidate canary tag before GitHub prerelease

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -255,6 +255,14 @@ jobs:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: test "$GITHUB_REF" = "refs/heads/$DEFAULT_BRANCH"
 
+      - name: Check out trusted publication controls
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.sha }}
+          path: trusted
+
       - name: Download verified canary plugin artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -268,6 +276,15 @@ jobs:
           archive="artifact/jetbrains-inspection-api-${{ needs.build.outputs.version }}.zip"
           actual_sha256="$(shasum -a 256 "$archive" | awk '{print $1}')"
           test "$actual_sha256" = "$EXPECTED_ARCHIVE_SHA256"
+
+      - name: Revalidate canary tag provenance
+        env:
+          CANARY_TAG: ${{ inputs.tag }}
+          EXPECTED_SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
+        working-directory: trusted
+        run: |
+          git fetch origin "refs/tags/$CANARY_TAG:refs/tags/$CANARY_TAG"
+          test "$(git rev-parse "refs/tags/$CANARY_TAG^{commit}")" = "$EXPECTED_SOURCE_SHA"
 
       - name: Create GitHub prerelease
         env:

--- a/scripts/test-release-contracts.sh
+++ b/scripts/test-release-contracts.sh
@@ -679,8 +679,10 @@ if publish.index("EXPECTED_ARCHIVE_SHA256") > publish.index("Verify canary Marke
 
 release_steps = [
     "Verify trusted workflow ref",
+    "Check out trusted publication controls",
     "Download verified canary plugin artifact",
     "Revalidate verified artifact digest",
+    "Revalidate canary tag provenance",
     "Create GitHub prerelease",
 ]
 if [release.index(step) for step in release_steps] != sorted(release.index(step) for step in release_steps):
@@ -689,8 +691,14 @@ if "needs: [build, verify, publish]" not in release:
     raise SystemExit("GitHub prerelease creation must follow successful Marketplace publication")
 if "contents: write" not in release or "CANARY_PUBLISH_TOKEN" in release:
     raise SystemExit("GitHub release authority must remain isolated from Marketplace authority")
+if "path: source" in release or "working-directory: source" in release:
+    raise SystemExit("GitHub release job must not check out branch-controlled source")
+if "persist-credentials: false" not in release:
+    raise SystemExit("GitHub release trusted checkout must not persist credentials")
 if 'test "$actual_sha256" = "$EXPECTED_ARCHIVE_SHA256"' not in release:
     raise SystemExit("GitHub prerelease must use the independently verified artifact")
+if "test \"$(git rev-parse \"refs/tags/$CANARY_TAG^{commit}\")\" = \"$EXPECTED_SOURCE_SHA\"" not in release:
+    raise SystemExit("GitHub prerelease must enforce the verified source tag digest")
 PY
 
   assert_contains scripts/test-all.sh 'Plugin JaCoCo verification (0% minimum; report-only signal)'


### PR DESCRIPTION
## Summary

- add the trusted checkout to the final canary GitHub release job
- revalidate the canary tag still resolves to the source SHA verified by the build and publication jobs
- extend release contracts so the final job cannot regress to branch source, persisted credentials, or a moved tag

Refs #272

## Why

The final fresh job previously rechecked only the artifact digest. A canary tag could move after Marketplace publication but before `gh release create --verify-tag`, allowing the GitHub prerelease to attach the verified artifact to a different tag commit. The final job now uses SHA-pinned trusted controls and repeats the exact tag provenance check before creating the prerelease.

## Validation

- `./scripts/test-release-contracts.sh`
- `actionlint .github/workflows/canary-release.yml`
- `shellcheck --severity=warning scripts/test-release-contracts.sh`
- commit hook: full `./scripts/commit-gate.sh --ci` passed
