### PR TITLE
Make language readiness match inspection scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,10 +340,14 @@ clients should keep using `/route`, `/trigger`, `/wait`, `/status`, and
   `ownership_proven: true`; preexisting, coalesced, mismatched, and untracked
   projects return `status: "not_owned"` without a close token. Helper-owned
   routes and claims also include `lifecycle_readiness`; automation must wait
-  for `ready: true` before inspection. When Python files are in project scope,
-  readiness also proves a Python SDK is assigned and its SDK refresh and daemon
-  analysis are settled; missing or changing analysis inputs remain fail-closed
-  with bounded `analysis_*`, Python file, and SDK counts. For a helper-owned raw directory whose
+  for `ready: true` before inspection. Lifecycle readiness proves only project,
+  route, module, and content-root structure; its `analysis_reason` is
+  `deferred_to_inspection_scope` once that structure is ready. The inspection
+  preflight then evaluates language support, SDK assignment, and analysis state
+  against the resolved requested scope. Unrelated project Python files therefore
+  do not block targeted Kotlin/Java inspections, while selected Python remains
+  fail-closed with bounded scope, Python file, SDK, start-state, and ownership
+  diagnostics. For a helper-owned raw directory whose
   configurators leave no usable module/content root, the plugin may install a
   non-persistent fallback module rooted at the requested worktree. Repair is
   limited to the exact lease-bound project instance; preexisting, coalesced,

--- a/TESTING.md
+++ b/TESTING.md
@@ -113,11 +113,14 @@ must cover a user project appearing between open acceptance and IDE-thread
 execution, and must prove that such a project receives no close token.
 Helper-owned routes expose `lifecycle_readiness`; readiness requires a content
 root covering the requested worktree after project configuration stabilizes.
-For project scopes containing Python files, readiness also requires a resolved
-Python SDK with no scheduled SDK refresh and no active daemon analysis. Missing
-SDKs report `language_sdk_missing`; SDK refresh, analysis, or unreadable update
-state reports `project_analysis_not_ready`. Neither state may publish decisive
-GREEN or RED findings.
+Lifecycle readiness is structural and must not synthesize a whole-project
+language scope. The inspection preflight evaluates the resolved requested scope:
+non-Python `files` and `changed_files` scopes report `python_not_in_scope`, while
+selected Python requires language support and a resolved Python SDK with no
+scheduled SDK refresh or unsettled analysis. Missing support or SDK assignment
+reports `language_sdk_missing`; SDK refresh, analysis, unreadable update state,
+or unavailable exact-scope resolution reports `project_analysis_not_ready`.
+Neither state may start inspection or publish decisive GREEN or RED findings.
 If configurators remove the initial raw-directory module, the plugin repairs
 the exact lease-bound helper-owned project with a non-persistent fallback module
 and reports `fallback_module_count`; the fallback must not create tracked

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -929,6 +929,12 @@ private fun normalizeFileSystemPath(value: String?): String? {
     }
 }
 
+internal fun inspectionPathWithinDirectory(filePath: String, directoryPath: String): Boolean {
+    return runCatching {
+        Paths.get(filePath).startsWith(Paths.get(directoryPath))
+    }.getOrDefault(false)
+}
+
 private fun looksLikePath(value: String): Boolean {
     return value.contains('/') || value.contains('\\') || value.startsWith("~") || value.startsWith(".")
 }
@@ -3140,26 +3146,9 @@ class InspectionHandler : HttpRequestHandler() {
                                 "content_roots_outside_target"
                             else -> "ready"
                         }
-                        val analysisReadiness = if (contentReason == "ready") {
-                            projectAnalysisReadinessProvider(
-                                project,
-                                InspectionCaptureScope(scopeParam = "whole_project"),
-                            )
-                        } else {
-                            InspectionProjectAnalysisReadiness(
-                                required = false,
-                                ready = true,
-                                reason = "content_not_ready",
-                            )
-                        }
-                        val reason = if (contentReason == "ready" && !analysisReadiness.ready) {
-                            analysisReadiness.reason
-                        } else {
-                            contentReason
-                        }
                         LifecycleContentRootReadiness(
-                            ready = reason == "ready",
-                            reason = reason,
+                            ready = contentReason == "ready",
+                            reason = contentReason,
                             targetKey = targetKey,
                             contentRootCount = contentRoots.size,
                             sourceRootCount = sourceRootCount,
@@ -3170,14 +3159,13 @@ class InspectionHandler : HttpRequestHandler() {
                             targetInsideContent = targetInsideContent,
                             contentRootInsideTarget = contentRootInsideTarget,
                             contentRoots = contentRoots.take(MAX_SCOPE_FILE_DIAGNOSTICS),
-                            analysisRequired = analysisReadiness.required,
-                            analysisReady = analysisReadiness.ready,
-                            analysisReason = analysisReadiness.reason,
-                            pythonFileCount = analysisReadiness.pythonFileCount,
-                            pythonSdkCount = analysisReadiness.pythonSdkCount,
-                            missingSdkFileCount = analysisReadiness.missingSdkFileCount,
-                            updatingSdkCount = analysisReadiness.updatingSdkCount,
-                            daemonRunning = analysisReadiness.daemonRunning,
+                            analysisRequired = false,
+                            analysisReady = true,
+                            analysisReason = if (contentReason == "ready") {
+                                "deferred_to_inspection_scope"
+                            } else {
+                                "content_not_ready"
+                            },
                         )
                     }
                 }
@@ -5565,10 +5553,19 @@ class InspectionHandler : HttpRequestHandler() {
                 }
             }
             val analysisReadiness = projectAnalysisReadinessProvider(project, effectiveCaptureScope)
+            val analysisReadinessDiagnostic = projectAnalysisReadinessDiagnostic(
+                requestedScope = captureScope,
+                resolvedScope = effectiveCaptureScope,
+                readiness = analysisReadiness,
+                inspectionStarted = false,
+            )
             if (analysisReadiness.required && !analysisReadiness.ready) {
                 projectContentTracker?.close()
                 projectContentTracker = null
-                val incompleteReason = if (analysisReadiness.reason == "python_sdk_missing") {
+                val incompleteReason = if (
+                    analysisReadiness.reason == "python_sdk_missing" ||
+                    analysisReadiness.reason == "python_support_unavailable"
+                ) {
                     CaptureIncompleteReason.LANGUAGE_SDK_MISSING
                 } else {
                     CaptureIncompleteReason.PROJECT_ANALYSIS_NOT_READY
@@ -5583,7 +5580,7 @@ class InspectionHandler : HttpRequestHandler() {
                         source = "project_analysis_readiness",
                         note = "The selected files' language SDK or analysis state is not ready for a trustworthy inspection.",
                         captureScope = effectiveCaptureScope,
-                        captureDiagnostic = mapOf(
+                        captureDiagnostic = analysisReadinessDiagnostic + mapOf(
                             "analysis_required" to analysisReadiness.required,
                             "analysis_ready" to analysisReadiness.ready,
                             "analysis_reason" to analysisReadiness.reason,
@@ -5615,7 +5612,7 @@ class InspectionHandler : HttpRequestHandler() {
                             source = "project_analysis_readiness",
                             note = "Project analysis inputs could not be fingerprinted before inspection.",
                             captureScope = effectiveCaptureScope,
-                            captureDiagnostic = mapOf(
+                            captureDiagnostic = analysisReadinessDiagnostic + mapOf(
                                 "analysis_required" to true,
                                 "analysis_ready" to true,
                                 "analysis_reason" to analysisReadiness.reason,
@@ -5642,6 +5639,7 @@ class InspectionHandler : HttpRequestHandler() {
                         source = "empty_changed_files",
                         note = "No changed files matched the requested inspection scope.",
                         captureScope = effectiveCaptureScope,
+                        captureDiagnostic = analysisReadinessDiagnostic,
                         runId = runId,
                         triggerTimeMs = inspectionRunStatesByProject[key]?.triggerTimeMs,
                     ),
@@ -5671,7 +5669,9 @@ class InspectionHandler : HttpRequestHandler() {
                 files = captureScope.files,
                 resolvedCurrentFile = captureScope.resolvedCurrentFile,
                 resolvedChangedFiles = changedFilesScopeFiles,
-            ) + mapOf(
+            ) + analysisReadinessDiagnostic.mapValues { (key, value) ->
+                if (key == "inspection_started") true else value
+            } + mapOf(
                 "dumb_after_sync" to dumbAfterSync,
                 "dispatch_thread_before_inspection" to ApplicationManager.getApplication().isDispatchThread,
             )
@@ -6769,21 +6769,28 @@ class InspectionHandler : HttpRequestHandler() {
         }
         return runCatching {
             ApplicationManager.getApplication().runReadAction<InspectionProjectAnalysisReadiness, Exception> {
-                val pythonFileType = FileTypeManager.getInstance().getFileTypeByExtension("py")
-                if (!pythonFileType.name.contains("python", ignoreCase = true)) {
+                val pythonFiles = resolvePythonScopeFiles(project, captureScope)
+                if (pythonFiles == null) {
                     return@runReadAction InspectionProjectAnalysisReadiness(
-                        required = false,
-                        ready = true,
-                        reason = "python_support_unavailable",
+                        required = true,
+                        ready = false,
+                        reason = "scope_resolution_unavailable",
                     )
                 }
-
-                val pythonFiles = resolvePythonScopeFiles(project, captureScope)
                 if (pythonFiles.isEmpty()) {
                     return@runReadAction InspectionProjectAnalysisReadiness(
                         required = false,
                         ready = true,
                         reason = "python_not_in_scope",
+                    )
+                }
+                val pythonFileType = FileTypeManager.getInstance().getFileTypeByExtension("py")
+                if (!pythonFileType.name.contains("python", ignoreCase = true)) {
+                    return@runReadAction InspectionProjectAnalysisReadiness(
+                        required = true,
+                        ready = false,
+                        reason = "python_support_unavailable",
+                        pythonFileCount = pythonFiles.size,
                     )
                 }
 
@@ -6830,27 +6837,78 @@ class InspectionHandler : HttpRequestHandler() {
     private fun resolvePythonScopeFiles(
         project: Project,
         captureScope: InspectionCaptureScope?,
-    ): List<VirtualFile> {
-        val resolvedFiles = captureScope?.resolvedFiles
-        if (resolvedFiles != null) {
-            return resolvedFiles.mapNotNull { path ->
-                LocalFileSystem.getInstance().findFileByPath(path)
-            }.filter(::isPythonFile)
-        }
-
+    ): List<VirtualFile>? {
         val scopeKind = captureScope?.scopeParam?.trim()?.lowercase().orEmpty().ifBlank { "whole_project" }
+        if (scopeKind in setOf("files", "changed_files", "current_file")) {
+            val resolvedFiles = captureScope?.resolvedFiles ?: return null
+            if (scopeKind != "changed_files" && resolvedFiles.isEmpty()) return null
+            val localFileSystem = LocalFileSystem.getInstance()
+            val scopeFiles = resolvedFiles.map { path ->
+                val file = localFileSystem.findFileByPath(path) ?: return null
+                if (!file.isValid || file.isDirectory) return null
+                file
+            }
+            return scopeFiles.distinctBy { file -> normalizeFileSystemPath(file.path) ?: file.path }
+                .filter(::isPythonFile)
+        }
         val resolvedDirectory = captureScope?.resolvedDirectory?.let(::normalizeFileSystemPath)
+        if (scopeKind == "directory") {
+            val directory = resolvedDirectory?.let { path ->
+                LocalFileSystem.getInstance().findFileByPath(path)
+            } ?: return null
+            if (!directory.isValid || !directory.isDirectory) return null
+        }
         return FilenameIndex.getAllFilesByExt(project, "py", GlobalSearchScope.projectScope(project))
             .asSequence()
             .filter { file ->
                 scopeKind != "directory" ||
                     resolvedDirectory == null ||
                     normalizeFileSystemPath(file.path)?.let { path ->
-                        path == resolvedDirectory || path.startsWith("$resolvedDirectory/")
+                        inspectionPathWithinDirectory(path, resolvedDirectory)
                     } == true
             }
             .distinctBy { file -> normalizeFileSystemPath(file.path) ?: file.path }
             .toList()
+    }
+
+    private fun projectAnalysisReadinessDiagnostic(
+        requestedScope: InspectionCaptureScope,
+        resolvedScope: InspectionCaptureScope,
+        readiness: InspectionProjectAnalysisReadiness,
+        inspectionStarted: Boolean,
+    ): Map<String, Any?> {
+        val requestedScopeKind = requestedScope.scopeParam?.trim()?.lowercase().orEmpty().ifBlank { "whole_project" }
+        val resolvedScopeKind = resolvedScope.scopeParam?.trim()?.lowercase().orEmpty().ifBlank { "whole_project" }
+        val languageSupportState = when (readiness.reason) {
+            "python_support_unavailable" -> "unavailable"
+            "python_not_in_scope", "scope_resolution_unavailable" -> "not_evaluated"
+            else -> "available"
+        }
+        val sdkAssignmentState = when {
+            !readiness.required -> "not_required"
+            readiness.missingSdkFileCount > 0 || readiness.reason == "python_sdk_missing" -> "missing"
+            readiness.pythonSdkCount > 0 -> "assigned"
+            else -> "unknown"
+        }
+        val outcomeOwnership = when (readiness.reason) {
+            "python_sdk_missing", "python_support_unavailable" -> "configuration"
+            "python_sdk_updating", "project_disposed" -> "environment"
+            "python_sdk_update_state_unavailable", "analysis_readiness_unavailable", "scope_resolution_unavailable" -> "tool"
+            else -> "none"
+        }
+        return mapOf(
+            "readiness_stage" to "inspection_preflight",
+            "requested_scope" to requestedScopeKind,
+            "resolved_scope" to resolvedScopeKind,
+            "resolved_scope_file_count" to resolvedScope.resolvedFiles?.size,
+            "resolved_scope_directory" to resolvedScope.resolvedDirectory,
+            "selected_python_file_count" to readiness.pythonFileCount,
+            "language_support_state" to languageSupportState,
+            "sdk_assignment_state" to sdkAssignmentState,
+            "analysis_state" to readiness.reason,
+            "inspection_started" to inspectionStarted,
+            "outcome_ownership" to outcomeOwnership,
+        ).filterValues { it != null }
     }
 
     private fun isPythonFile(file: VirtualFile): Boolean {
@@ -7410,16 +7468,16 @@ class InspectionHandler : HttpRequestHandler() {
     ): InspectionCaptureScope {
         val scopeKind = captureScope.scopeParam?.trim()?.lowercase().orEmpty().ifBlank { "whole_project" }
         val resolvedFiles = when (scopeKind) {
-            "files" -> resolveRequestedFiles(project, captureScope.files.orEmpty()).map { it.path }
+            "files" -> captureScope.resolvedFiles
+                ?: resolveRequestedFiles(project, captureScope.files.orEmpty()).map { it.path }
             "changed_files" -> (resolvedChangedFiles ?: resolveChangedFilesScopeFiles(
                 project = project,
                 includeUnversioned = captureScope.includeUnversioned,
                 changedFilesMode = captureScope.changedFilesMode,
                 maxFiles = captureScope.maxFiles,
             )).map { it.path }
-            "current_file" -> listOfNotNull(captureScope.resolvedCurrentFile).filter { path ->
-                runCatching { LocalFileSystem.getInstance().findFileByPath(path)?.isValid == true }.getOrDefault(false)
-            }
+            "current_file" -> captureScope.resolvedFiles
+                ?: listOfNotNull(captureScope.resolvedCurrentFile)
             else -> null
         }?.mapNotNull(::normalizeFileSystemPath)?.distinct()
 

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -5446,10 +5446,33 @@ class InspectionHandler : HttpRequestHandler() {
             }
 
             val changedFilesScopeFiles = if (captureScope.scopeParam?.lowercase()?.trim() == "changed_files") {
-                captureScope.resolvedFiles.orEmpty().map { path ->
-                    LocalFileSystem.getInstance().findFileByPath(path)
-                        ?: throw IllegalStateException("Validated changed file '$path' is no longer available.")
+                val missingPaths = mutableListOf<String>()
+                val resolvedFiles = captureScope.resolvedFiles.orEmpty().mapNotNull { path ->
+                    LocalFileSystem.getInstance().findFileByPath(path) ?: run {
+                        missingPaths += path
+                        null
+                    }
                 }
+                if (missingPaths.isNotEmpty()) {
+                    publishProjectAnalysisReadinessFailure(
+                        key = key,
+                        runId = runId,
+                        projectState = inspectionInputState,
+                        requestedScope = captureScope,
+                        resolvedScope = captureScope,
+                        readiness = InspectionProjectAnalysisReadiness(
+                            required = true,
+                            ready = false,
+                            reason = "scope_resolution_unavailable",
+                        ),
+                        additionalDiagnostic = mapOf(
+                            "scope_resolution_missing_file_count" to missingPaths.size,
+                            "scope_resolution_missing_files" to missingPaths.take(MAX_SCOPE_FILE_DIAGNOSTICS),
+                        ),
+                    )
+                    return
+                }
+                resolvedFiles
             } else {
                 null
             }
@@ -5562,40 +5585,13 @@ class InspectionHandler : HttpRequestHandler() {
             if (analysisReadiness.required && !analysisReadiness.ready) {
                 projectContentTracker?.close()
                 projectContentTracker = null
-                val incompleteReason = if (
-                    analysisReadiness.reason == "python_sdk_missing" ||
-                    analysisReadiness.reason == "python_support_unavailable"
-                ) {
-                    CaptureIncompleteReason.LANGUAGE_SDK_MISSING
-                } else {
-                    CaptureIncompleteReason.PROJECT_ANALYSIS_NOT_READY
-                }
-                resultsStore.setSnapshot(
-                    key,
-                    InspectionResultsSnapshot(
-                        problems = emptyList(),
-                        timestamp = System.currentTimeMillis(),
-                        projectState = inspectionInputState,
-                        outcome = InspectionSnapshotOutcome.CAPTURE_INCOMPLETE,
-                        source = "project_analysis_readiness",
-                        note = "The selected files' language SDK or analysis state is not ready for a trustworthy inspection.",
-                        captureScope = effectiveCaptureScope,
-                        captureDiagnostic = analysisReadinessDiagnostic + mapOf(
-                            "analysis_required" to analysisReadiness.required,
-                            "analysis_ready" to analysisReadiness.ready,
-                            "analysis_reason" to analysisReadiness.reason,
-                            "python_file_count" to analysisReadiness.pythonFileCount,
-                            "python_sdk_count" to analysisReadiness.pythonSdkCount,
-                            "missing_sdk_file_count" to analysisReadiness.missingSdkFileCount,
-                            "updating_sdk_count" to analysisReadiness.updatingSdkCount,
-                            "daemon_running" to analysisReadiness.daemonRunning,
-                            "sdk_update_state_unavailable" to analysisReadiness.sdkUpdateStateUnavailable,
-                            "exit_reason" to incompleteReason.apiValue,
-                        ),
-                        captureIncompleteReason = incompleteReason,
-                        runId = runId,
-                        triggerTimeMs = inspectionRunStatesByProject[key]?.triggerTimeMs,
-                    ),
+                publishProjectAnalysisReadinessFailure(
+                    key = key,
+                    runId = runId,
+                    projectState = inspectionInputState,
+                    requestedScope = captureScope,
+                    resolvedScope = effectiveCaptureScope,
+                    readiness = analysisReadiness,
                 )
                 return
             }
@@ -6909,6 +6905,58 @@ class InspectionHandler : HttpRequestHandler() {
             "inspection_started" to inspectionStarted,
             "outcome_ownership" to outcomeOwnership,
         ).filterValues { it != null }
+    }
+
+    private fun publishProjectAnalysisReadinessFailure(
+        key: String,
+        runId: Long,
+        projectState: InspectionProjectStateSnapshot,
+        requestedScope: InspectionCaptureScope,
+        resolvedScope: InspectionCaptureScope,
+        readiness: InspectionProjectAnalysisReadiness,
+        additionalDiagnostic: Map<String, Any?> = emptyMap(),
+    ) {
+        val incompleteReason = if (
+            readiness.reason == "python_sdk_missing" ||
+            readiness.reason == "python_support_unavailable"
+        ) {
+            CaptureIncompleteReason.LANGUAGE_SDK_MISSING
+        } else {
+            CaptureIncompleteReason.PROJECT_ANALYSIS_NOT_READY
+        }
+        val diagnostic = projectAnalysisReadinessDiagnostic(
+            requestedScope = requestedScope,
+            resolvedScope = resolvedScope,
+            readiness = readiness,
+            inspectionStarted = false,
+        ) + mapOf(
+            "analysis_required" to readiness.required,
+            "analysis_ready" to readiness.ready,
+            "analysis_reason" to readiness.reason,
+            "python_file_count" to readiness.pythonFileCount,
+            "python_sdk_count" to readiness.pythonSdkCount,
+            "missing_sdk_file_count" to readiness.missingSdkFileCount,
+            "updating_sdk_count" to readiness.updatingSdkCount,
+            "daemon_running" to readiness.daemonRunning,
+            "sdk_update_state_unavailable" to readiness.sdkUpdateStateUnavailable,
+            "exit_reason" to incompleteReason.apiValue,
+        ) + additionalDiagnostic
+        resultsStore.setSnapshot(
+            key,
+            InspectionResultsSnapshot(
+                problems = emptyList(),
+                timestamp = System.currentTimeMillis(),
+                projectState = projectState,
+                outcome = InspectionSnapshotOutcome.CAPTURE_INCOMPLETE,
+                source = "project_analysis_readiness",
+                note = "The selected files' language SDK, scope, or analysis state is not ready for a trustworthy inspection.",
+                captureScope = resolvedScope,
+                captureDiagnostic = diagnostic,
+                captureIncompleteReason = incompleteReason,
+                runId = runId,
+                triggerTimeMs = inspectionRunStatesByProject[key]?.triggerTimeMs,
+            ),
+        )
     }
 
     private fun isPythonFile(file: VirtualFile): Boolean {

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -14,6 +14,7 @@ import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.fileTypes.FileType
+import com.intellij.openapi.fileTypes.FileTypeManager
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.module.EmptyModuleType
@@ -46,6 +47,8 @@ import com.intellij.psi.PsiDirectory
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
+import com.intellij.psi.search.FilenameIndex
+import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.util.PsiModificationTracker
 import com.intellij.ui.content.Content
 import com.intellij.ui.content.ContentManager
@@ -169,6 +172,16 @@ class InspectionHandlerTest {
 
         assertNull(prepareLifecycleProjectStoreIfDirectory(projectFilePath))
         assertFalse(Files.exists(projectRoot.resolve(Project.DIRECTORY_STORE_FOLDER)))
+    }
+
+    @Test
+    fun `directory scope ancestry uses native path components`() {
+        val directory = Files.createTempDirectory("inspection-directory-scope")
+        val child = directory.resolve("nested").resolve("selected.py")
+        val sibling = directory.resolveSibling("inspection-directory-scope-sibling").resolve("selected.py")
+
+        assertTrue(inspectionPathWithinDirectory(child.toString(), directory.toString()))
+        assertFalse(inspectionPathWithinDirectory(sibling.toString(), directory.toString()))
     }
     
     @BeforeEach
@@ -387,7 +400,257 @@ class InspectionHandlerTest {
         assertEquals(0, status["total_problems"])
         assertTrue(statusBody.contains("\"classification\": \"configuration_blocked\""), statusBody)
         assertTrue(statusBody.contains("\"code\": \"language_sdk_missing\""), statusBody)
+        @Suppress("UNCHECKED_CAST")
+        val diagnostic = status["capture_diagnostic"] as Map<String, Any?>
+        assertEquals("inspection_preflight", diagnostic["readiness_stage"])
+        assertEquals("whole_project", diagnostic["requested_scope"])
+        assertEquals("whole_project", diagnostic["resolved_scope"])
+        assertEquals(2, diagnostic["selected_python_file_count"])
+        assertEquals("available", diagnostic["language_support_state"])
+        assertEquals("missing", diagnostic["sdk_assignment_state"])
+        assertEquals("python_sdk_missing", diagnostic["analysis_state"])
+        assertEquals(false, diagnostic["inspection_started"])
+        assertEquals("configuration", diagnostic["outcome_ownership"])
         verify(exactly = 0) { mockInspectionManager.createNewGlobalContext() }
+    }
+
+    @Test
+    fun `test refreshing Python analysis remains fail closed before inspection`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        every { mockApplication.isDispatchThread } returns true
+        every { mockVirtualFileManager.syncRefresh() } returns 0L
+        every { mockProfileManager.profiles } returns listOf(mockProfile)
+        every { mockApplication.executeOnPooledThread(any<Runnable>()) } answers {
+            firstArg<Runnable>().run()
+            mockk(relaxed = true)
+        }
+        mockInspectionPrerequisites(mockProject)
+
+        val inputFingerprint = projectInputsFingerprint(profileName = "TestProfile")
+        handler.projectInputsFingerprintProvider = { _, _ -> inputFingerprint }
+        handler.projectContentTrackerFactory = { _, _ -> FakeInspectionProjectContentTracker() }
+        handler.projectAnalysisReadinessProvider = { _, _ ->
+            InspectionProjectAnalysisReadiness(
+                required = true,
+                ready = false,
+                reason = "python_sdk_updating",
+                pythonFileCount = 1,
+                pythonSdkCount = 1,
+                updatingSdkCount = 1,
+            )
+        }
+
+        val response = processTriggerRequest("/api/inspection/trigger?scope=whole_project")
+        val status = buildInspectionStatus()
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertEquals("capture_incomplete", status["snapshot_outcome"])
+        assertEquals("project_analysis_not_ready", status["capture_incomplete_reason"])
+        assertEquals("project_analysis_readiness", status["results_source"])
+        @Suppress("UNCHECKED_CAST")
+        val diagnostic = status["capture_diagnostic"] as Map<String, Any?>
+        assertEquals("inspection_preflight", diagnostic["readiness_stage"])
+        assertEquals("python_sdk_updating", diagnostic["analysis_state"])
+        assertEquals(false, diagnostic["inspection_started"])
+        assertEquals("environment", diagnostic["outcome_ownership"])
+        verify(exactly = 0) { mockInspectionManager.createNewGlobalContext() }
+    }
+
+    @Test
+    fun `test unresolved targeted analysis scope fails closed without widening`() {
+        val productionHandler = InspectionHandler()
+
+        val readiness = productionHandler.projectAnalysisReadinessProvider(
+            mockProject,
+            InspectionCaptureScope(
+                scopeParam = "files",
+                files = listOf("src/main/kotlin/App.kt"),
+            ),
+        )
+
+        assertTrue(readiness.required)
+        assertFalse(readiness.ready)
+        assertEquals("scope_resolution_unavailable", readiness.reason)
+        assertEquals(0, readiness.pythonFileCount)
+    }
+
+    @Test
+    fun `test resolved non-python files and changed files do not require a Python SDK`() {
+        val productionHandler = InspectionHandler()
+        val localFileSystem = mockk<LocalFileSystem>(relaxed = true)
+        val kotlinFile = mockk<VirtualFile>(relaxed = true)
+        val kotlinPath = "/tmp/TestProject/src/App.kt"
+        every { kotlinFile.path } returns kotlinPath
+        every { kotlinFile.name } returns "App.kt"
+        every { kotlinFile.isValid } returns true
+        every { kotlinFile.isDirectory } returns false
+        every { kotlinFile.isInLocalFileSystem } returns true
+        every { kotlinFile.extension } returns "kt"
+        mockkStatic(LocalFileSystem::class)
+        every { LocalFileSystem.getInstance() } returns localFileSystem
+        every { localFileSystem.findFileByPath(kotlinPath) } returns kotlinFile
+
+        try {
+            listOf("files", "changed_files").forEach { scopeKind ->
+                val readiness = productionHandler.projectAnalysisReadinessProvider(
+                    mockProject,
+                    InspectionCaptureScope(
+                        scopeParam = scopeKind,
+                        files = listOf(kotlinPath).takeIf { scopeKind == "files" },
+                        resolvedFiles = listOf(kotlinPath),
+                    ),
+                )
+
+                assertFalse(readiness.required, scopeKind)
+                assertTrue(readiness.ready, scopeKind)
+                assertEquals("python_not_in_scope", readiness.reason, scopeKind)
+                assertEquals(0, readiness.pythonFileCount, scopeKind)
+            }
+        } finally {
+            unmockkStatic(LocalFileSystem::class)
+        }
+    }
+
+    @Test
+    fun `test selected Python file without SDK fails closed`() {
+        val productionHandler = InspectionHandler()
+        val localFileSystem = mockk<LocalFileSystem>(relaxed = true)
+        val pythonFile = mockk<VirtualFile>(relaxed = true)
+        val pythonFileType = mockk<FileType>(relaxed = true)
+        val fileTypeManager = mockk<FileTypeManager>(relaxed = true)
+        val rootManager = mockk<ProjectRootManager>(relaxed = true)
+        val pythonPath = "/tmp/TestProject/scripts/check.py"
+        every { pythonFile.path } returns pythonPath
+        every { pythonFile.name } returns "check.py"
+        every { pythonFile.isValid } returns true
+        every { pythonFile.isDirectory } returns false
+        every { pythonFile.isInLocalFileSystem } returns true
+        every { pythonFile.extension } returns "py"
+        every { pythonFileType.name } returns "Plain Text"
+        every { rootManager.projectSdk } returns null
+        mockkStatic(LocalFileSystem::class)
+        mockkStatic(FileTypeManager::class)
+        mockkStatic(ProjectRootManager::class)
+        mockkStatic(ModuleUtilCore::class)
+        every { LocalFileSystem.getInstance() } returns localFileSystem
+        every { localFileSystem.findFileByPath(pythonPath) } returns pythonFile
+        every { FileTypeManager.getInstance() } returns fileTypeManager
+        every { fileTypeManager.getFileTypeByExtension("py") } returns pythonFileType
+        every { ProjectRootManager.getInstance(mockProject) } returns rootManager
+        every { ModuleUtilCore.findModuleForFile(pythonFile, mockProject) } returns null
+
+        try {
+            val unsupportedReadiness = productionHandler.projectAnalysisReadinessProvider(
+                mockProject,
+                InspectionCaptureScope(
+                    scopeParam = "files",
+                    files = listOf(pythonPath),
+                    resolvedFiles = listOf(pythonPath),
+                ),
+            )
+            assertTrue(unsupportedReadiness.required)
+            assertFalse(unsupportedReadiness.ready)
+            assertEquals("python_support_unavailable", unsupportedReadiness.reason)
+            assertEquals(1, unsupportedReadiness.pythonFileCount)
+
+            every { pythonFileType.name } returns "Python"
+            val readiness = productionHandler.projectAnalysisReadinessProvider(
+                mockProject,
+                InspectionCaptureScope(
+                    scopeParam = "files",
+                    files = listOf(pythonPath),
+                    resolvedFiles = listOf(pythonPath),
+                ),
+            )
+
+            assertTrue(readiness.required)
+            assertFalse(readiness.ready)
+            assertEquals("python_sdk_missing", readiness.reason)
+            assertEquals(1, readiness.pythonFileCount)
+            assertEquals(1, readiness.missingSdkFileCount)
+        } finally {
+            unmockkStatic(ModuleUtilCore::class)
+            unmockkStatic(ProjectRootManager::class)
+            unmockkStatic(FileTypeManager::class)
+            unmockkStatic(LocalFileSystem::class)
+        }
+    }
+
+    @Test
+    fun `test directory and whole project preserve Python readiness boundaries`() {
+        val productionHandler = InspectionHandler()
+        val localFileSystem = mockk<LocalFileSystem>(relaxed = true)
+        val directory = mockk<VirtualFile>(relaxed = true)
+        val selectedPythonFile = mockk<VirtualFile>(relaxed = true)
+        val unrelatedPythonFile = mockk<VirtualFile>(relaxed = true)
+        val pythonFileType = mockk<FileType>(relaxed = true)
+        val fileTypeManager = mockk<FileTypeManager>(relaxed = true)
+        val rootManager = mockk<ProjectRootManager>(relaxed = true)
+        val searchScope = mockk<GlobalSearchScope>(relaxed = true)
+        val directoryPath = "/tmp/TestProject/scripts"
+        val selectedPath = "$directoryPath/selected.py"
+        val unrelatedPath = "/tmp/TestProject/fixtures/unrelated.py"
+        every { directory.path } returns directoryPath
+        every { directory.isValid } returns true
+        every { directory.isDirectory } returns true
+        every { selectedPythonFile.path } returns selectedPath
+        every { selectedPythonFile.name } returns "selected.py"
+        every { selectedPythonFile.isValid } returns true
+        every { selectedPythonFile.isDirectory } returns false
+        every { selectedPythonFile.extension } returns "py"
+        every { unrelatedPythonFile.path } returns unrelatedPath
+        every { unrelatedPythonFile.name } returns "unrelated.py"
+        every { unrelatedPythonFile.isValid } returns true
+        every { unrelatedPythonFile.isDirectory } returns false
+        every { unrelatedPythonFile.extension } returns "py"
+        every { pythonFileType.name } returns "Python"
+        every { rootManager.projectSdk } returns null
+        mockkStatic(LocalFileSystem::class)
+        mockkStatic(FileTypeManager::class)
+        mockkStatic(ProjectRootManager::class)
+        mockkStatic(ModuleUtilCore::class)
+        mockkStatic(FilenameIndex::class)
+        mockkStatic(GlobalSearchScope::class)
+        every { LocalFileSystem.getInstance() } returns localFileSystem
+        every { localFileSystem.findFileByPath(directoryPath) } returns directory
+        every { FileTypeManager.getInstance() } returns fileTypeManager
+        every { fileTypeManager.getFileTypeByExtension("py") } returns pythonFileType
+        every { ProjectRootManager.getInstance(mockProject) } returns rootManager
+        every { ModuleUtilCore.findModuleForFile(any(), mockProject) } returns null
+        every { GlobalSearchScope.projectScope(mockProject) } returns searchScope
+        every {
+            FilenameIndex.getAllFilesByExt(mockProject, "py", searchScope)
+        } returns listOf(selectedPythonFile, unrelatedPythonFile)
+
+        try {
+            val directoryReadiness = productionHandler.projectAnalysisReadinessProvider(
+                mockProject,
+                InspectionCaptureScope(
+                    scopeParam = "directory",
+                    directoryParam = directoryPath,
+                    resolvedDirectory = directoryPath,
+                ),
+            )
+            val wholeProjectReadiness = productionHandler.projectAnalysisReadinessProvider(
+                mockProject,
+                InspectionCaptureScope(scopeParam = "whole_project"),
+            )
+
+            assertEquals("python_sdk_missing", directoryReadiness.reason)
+            assertEquals(1, directoryReadiness.pythonFileCount)
+            assertEquals(1, directoryReadiness.missingSdkFileCount)
+            assertEquals("python_sdk_missing", wholeProjectReadiness.reason)
+            assertEquals(2, wholeProjectReadiness.pythonFileCount)
+            assertEquals(2, wholeProjectReadiness.missingSdkFileCount)
+        } finally {
+            unmockkStatic(GlobalSearchScope::class)
+            unmockkStatic(FilenameIndex::class)
+            unmockkStatic(ModuleUtilCore::class)
+            unmockkStatic(ProjectRootManager::class)
+            unmockkStatic(FileTypeManager::class)
+            unmockkStatic(LocalFileSystem::class)
+        }
     }
 
     @Test
@@ -3957,12 +4220,10 @@ class InspectionHandlerTest {
             moduleRootManagers.getValue(firstArg())
         }
         val productionHandler = InspectionHandler()
+        var analysisReadinessCalls = 0
         productionHandler.projectAnalysisReadinessProvider = { _, _ ->
-            InspectionProjectAnalysisReadiness(
-                required = false,
-                ready = true,
-                reason = "python_not_in_scope",
-            )
+            analysisReadinessCalls += 1
+            error("Lifecycle structural readiness must not evaluate whole-project language readiness.")
         }
         val targetKey = tempDir.toRealPath().toString()
 
@@ -3980,6 +4241,9 @@ class InspectionHandlerTest {
             assertTrue(childReady.ready, childReady.toString())
             assertFalse(childReady.targetInsideContent)
             assertTrue(childReady.contentRootInsideTarget)
+            assertFalse(childReady.analysisRequired)
+            assertTrue(childReady.analysisReady)
+            assertEquals("deferred_to_inspection_scope", childReady.analysisReason)
 
             val fallbackModule = mockk<com.intellij.openapi.module.Module>()
             val fallbackRootManager = mockk<ModuleRootManager>()
@@ -4021,6 +4285,7 @@ class InspectionHandlerTest {
             val fallbackWithSibling = productionHandler.lifecycleContentRootReadinessProvider(mockProject, targetKey)
             assertFalse(fallbackWithSibling.ready)
             assertEquals("content_roots_outside_target", fallbackWithSibling.reason)
+            assertEquals(0, analysisReadinessCalls)
         } finally {
             unmockkStatic(ProjectRootManager::class)
             unmockkStatic(ModuleManager::class)

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -176,9 +176,10 @@ class InspectionHandlerTest {
 
     @Test
     fun `directory scope ancestry uses native path components`() {
-        val directory = Files.createTempDirectory("inspection-directory-scope")
+        val root = Files.createTempDirectory("inspection-directory-scope")
+        val directory = root.resolve("app")
         val child = directory.resolve("nested").resolve("selected.py")
-        val sibling = directory.resolveSibling("inspection-directory-scope-sibling").resolve("selected.py")
+        val sibling = root.resolve("application").resolve("selected.py")
 
         assertTrue(inspectionPathWithinDirectory(child.toString(), directory.toString()))
         assertFalse(inspectionPathWithinDirectory(sibling.toString(), directory.toString()))
@@ -356,6 +357,76 @@ class InspectionHandlerTest {
         assertEquals(false, status["capture_incomplete"])
         assertEquals(false, status["results_may_be_stale"])
         assertEquals(0, status["total_problems"])
+    }
+
+    @Test
+    fun `test changed file disappearing before preflight fails closed with scope evidence`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+        every { mockApplication.isDispatchThread } returns true
+        every { mockVirtualFileManager.syncRefresh() } returns 0L
+        every { mockProfileManager.profiles } returns listOf(mockProfile)
+        val queuedTasks = mutableListOf<Runnable>()
+        every { mockApplication.executeOnPooledThread(any<Runnable>()) } answers {
+            queuedTasks += firstArg<Runnable>()
+            mockk(relaxed = true)
+        }
+        mockInspectionPrerequisites(mockProject)
+        val changedPath = "/tmp/TestProject/src/Disappeared.kt"
+        mockChangedFiles(listOf(changedPath))
+        val localFileSystem = mockk<LocalFileSystem>()
+        mockkStatic(LocalFileSystem::class)
+        every { LocalFileSystem.getInstance() } returns localFileSystem
+        every { localFileSystem.findFileByPath(changedPath) } returns null
+        var analysisReadinessCalls = 0
+        handler.projectAnalysisReadinessProvider = { _, _ ->
+            analysisReadinessCalls += 1
+            error("Unavailable changed-file evidence must fail before language analysis.")
+        }
+
+        try {
+            val uri = "/api/inspection/trigger?scope=changed_files&include_unversioned=false"
+            val urlDecoder = QueryStringDecoder(uri)
+            val request = mockk<FullHttpRequest>()
+            val context = mockk<ChannelHandlerContext>()
+            val responseSlot = slot<Any>()
+            every { request.uri() } returns uri
+            every { context.writeAndFlush(capture(responseSlot)) } returns mockk(relaxed = true)
+
+            assertTrue(handler.process(urlDecoder, request, context))
+            assertEquals(1, queuedTasks.size)
+            queuedTasks.removeAt(0).run()
+
+            val response = responseSlot.captured as FullHttpResponse
+            assertEquals(HttpResponseStatus.OK, response.status())
+            assertEquals(1, queuedTasks.size)
+
+            queuedTasks.removeAt(0).run()
+
+            val status = buildInspectionStatus()
+            val statusResponse = processGetRequest("/api/inspection/status")
+            val statusBody = statusResponse.content().toString(Charsets.UTF_8)
+            assertEquals("capture_incomplete", status["snapshot_outcome"])
+            assertEquals("project_analysis_not_ready", status["capture_incomplete_reason"])
+            assertEquals("project_analysis_readiness", status["results_source"])
+            @Suppress("UNCHECKED_CAST")
+            val diagnostic = status["capture_diagnostic"] as Map<String, Any?>
+            assertEquals("inspection_preflight", diagnostic["readiness_stage"])
+            assertEquals("changed_files", diagnostic["requested_scope"])
+            assertEquals("changed_files", diagnostic["resolved_scope"])
+            assertEquals(1, diagnostic["resolved_scope_file_count"])
+            assertEquals("scope_resolution_unavailable", diagnostic["analysis_state"])
+            assertEquals(false, diagnostic["inspection_started"])
+            assertEquals("tool", diagnostic["outcome_ownership"])
+            assertEquals(1, diagnostic["scope_resolution_missing_file_count"])
+            assertEquals(listOf(changedPath), diagnostic["scope_resolution_missing_files"])
+            assertTrue(statusBody.contains("\"code\": \"project_analysis_not_ready\""), statusBody)
+            assertEquals(0, analysisReadinessCalls)
+            assertEquals(false, inspectionRunState(projectKey(mockProject))?.inProgress)
+            verify(exactly = 0) { mockInspectionManager.createNewGlobalContext() }
+        } finally {
+            unmockkStatic(LocalFileSystem::class)
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- keep lifecycle readiness structural and defer language SDK/analysis checks to the resolved inspection scope
- fail closed when targeted scope evidence is unavailable instead of widening to whole-project Python files
- expose structured preflight scope, language, SDK, analysis, start-state, and ownership evidence
- preserve Python SDK/update fail-closed behavior and native path-safe directory boundaries

## Validation
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./scripts/commit-gate.sh --ci`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew verifyPluginStructure`
- `git diff --check`
- focused lifecycle, files, changed_files, directory, whole_project, missing SDK, unavailable language support, and refreshing analysis tests

## Live inspection boundary
- `inspect-closeout --scope changed_files` routed to IntelliJ IDEA 2026.2.0.1 but returned `UNKNOWN/language_sdk_missing` from installed plugin `1.14.0@544d3ac...`, which predates this branch and reproduces the lifecycle widening defect fixed here
- helper cleanup completed with `status=closed`; no development plugin was installed because the handoff prohibits install/publish actions

## Review
- Gemini review completed without findings
- Claude Opus review was unavailable because the local Anthropic monthly spend limit was reached
- independent GPT review found one Windows directory-separator issue; fixed with `Path.startsWith` ancestry and a native-path regression test

Fixes #280
Refs #279
Refs #281