### PR TITLE
Use Java 25 for canary source builds

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -72,10 +72,10 @@ jobs:
           ../trusted/scripts/verify-canary-branch-isolation.sh "$DEFAULT_BRANCH"
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
-          java-version: "21"
+          java-version: "25"
           distribution: "temurin"
 
       - name: Grant execute permission for Gradle

--- a/README.md
+++ b/README.md
@@ -774,7 +774,8 @@ an isolated `canary/vX.Y.Z-canary.N` tag. Pushing that tag does not publish
 anything. An operator must explicitly dispatch `.github/workflows/canary-release.yml`
 from the default branch with the existing tag as input. The workflow builds and
 tests the branch-only source without Marketplace secrets or persisted checkout
-credentials or Gradle build caching. The untrusted build runs tests and plugin
+credentials or Gradle build caching. The untrusted 262-only source build uses
+Java 25 and runs tests and plugin
 structure validation but does not make the compatibility or private-API
 decision. That build workspace and all branch-produced verifier reports are
 discarded. A fresh trusted job downloads the resulting zip, independently runs

--- a/TESTING.md
+++ b/TESTING.md
@@ -8,10 +8,12 @@ This project has three test surfaces:
 
 ## Prerequisites
 
-- Java 21 (required for Gradle builds)
+- Java 21 for Stable Gradle builds and trusted canary artifact verification.
+- Java 25 for the 262-only canary source build.
 
 If `/usr/libexec/java_home -v 21` fails on macOS, set `JAVA_HOME_21` to your
-JDK 21 path before running the scripts.
+JDK 21 path before running the scripts. Set `JAVA_HOME_25` when Java 25 is not
+discoverable for a canary source build.
 
 In the Every Code sandbox, Gradle may need escalated permissions. If you see
 "Operation not permitted" from NativeServices, re-run the command with
@@ -357,7 +359,7 @@ Canary tags use `canary/vX.Y.Z-canary.N` but do not trigger publication.
 default branch with an existing isolated tag. Its build job treats the source,
 Gradle logic, verifier reports, and workspace as untrusted, persists no checkout
 credentials, uses no Gradle cache, and runs without Marketplace secrets. Same-tag
-dispatches are serialized. A fresh
+dispatches are serialized. The untrusted 262-only source build uses Java 25. A fresh
 verification job checks out only trusted controls, downloads the built zip,
 independently runs Plugin Verifier against that artifact on the pinned reviewed
 262 IDE build, and requires every

--- a/scripts/test-release-contracts.sh
+++ b/scripts/test-release-contracts.sh
@@ -669,6 +669,7 @@ build_steps = [
     "Verify trusted workflow ref",
     "Validate canary source metadata",
     "Verify exact canary tag and branch isolation",
+    "Set up JDK 25",
     "Run canary commit gate",
     "Run canary structure gate",
     "Upload canary plugin artifact",
@@ -683,6 +684,8 @@ if "release-compatibility-gate.sh" in build or " verifyPlugin\n" in build:
     raise SystemExit("canary build job must not run branch-controlled compatibility verification")
 if 'GRADLE_OPTS: "-Dorg.gradle.caching=false"' not in build or "--no-build-cache verifyPluginStructure" not in build:
     raise SystemExit("canary build job must disable the Gradle build cache")
+if 'java-version: "25"' not in build:
+    raise SystemExit("canary source build must provision Java 25")
 if build.count("persist-credentials: false") != 2:
     raise SystemExit("canary build checkouts must not persist credentials")
 
@@ -705,6 +708,8 @@ if "persist-credentials: false" not in verify:
     raise SystemExit("trusted verification checkout must not persist credentials")
 if "trusted/scripts/verify-canary-artifact.sh" not in verify:
     raise SystemExit("trusted verification job must independently inspect the downloaded artifact")
+if "Set up JDK 21" not in verify or 'java-version: "21"' not in verify:
+    raise SystemExit("trusted artifact verification must preserve Java 21")
 if "archive_sha256:" not in verify:
     raise SystemExit("trusted verification job must bind publication to the verified artifact digest")
 if "test \"$(git rev-parse \"refs/tags/$CANARY_TAG^{commit}\")\" = \"$EXPECTED_SOURCE_SHA\"" not in verify:


### PR DESCRIPTION
## Summary

- provision Java 25 for the untrusted 262-only canary source build
- preserve Java 21 for fresh trusted artifact verification
- add release-contract assertions for the Java split and update release/testing docs

## Failure Evidence

Canary Release run 31328943871 was dispatched from trusted `main` commit
`c18b1c4c452ffcdc37fff8e63244da49eb0994df` for immutable tag
`canary/v1.14.0-canary.1`. The build failed before artifact upload because the
preserved canary commit gate requires Java 25 and the workflow had provisioned
only Java 21. Verify, publish, and prerelease jobs were skipped; Marketplace and
Stable were untouched.

## Trust Boundary

- Java 25 is limited to the unprivileged source build job
- trusted artifact verification remains on Java 21
- no secret, permissions, tag, digest, channel, environment, Stable workflow, or publication behavior changes
- the existing canary tag remains unchanged and will be reused after this PR lands

## Validation

- `./scripts/test-release-contracts.sh`
- `actionlint .github/workflows/canary-release.yml`
- preserved canary source `./scripts/commit-gate.sh --ci` with Java 25
- commit hook: full `./scripts/commit-gate.sh --ci`
- independent GPT-5.6 trust-boundary review found no code-level or Stable-publication blocker

Refs #274
