### PR TITLE
Keep canary source provenance clean

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -78,9 +78,11 @@ jobs:
           java-version: "25"
           distribution: "temurin"
 
-      - name: Grant execute permission for Gradle
+      - name: Prepare Gradle wrapper without source drift
         working-directory: source
-        run: chmod +x gradlew
+        run: |
+          git config core.fileMode false
+          chmod +x gradlew
 
       - name: Run canary commit gate
         working-directory: source

--- a/README.md
+++ b/README.md
@@ -775,7 +775,8 @@ anything. An operator must explicitly dispatch `.github/workflows/canary-release
 from the default branch with the existing tag as input. The workflow builds and
 tests the branch-only source without Marketplace secrets or persisted checkout
 credentials or Gradle build caching. The untrusted 262-only source build uses
-Java 25 and runs tests and plugin
+Java 25, ignores only checkout-local executable-bit differences before invoking
+the Gradle wrapper, and runs tests and plugin
 structure validation but does not make the compatibility or private-API
 decision. That build workspace and all branch-produced verifier reports are
 discarded. A fresh trusted job downloads the resulting zip, independently runs

--- a/TESTING.md
+++ b/TESTING.md
@@ -359,8 +359,10 @@ Canary tags use `canary/vX.Y.Z-canary.N` but do not trigger publication.
 default branch with an existing isolated tag. Its build job treats the source,
 Gradle logic, verifier reports, and workspace as untrusted, persists no checkout
 credentials, uses no Gradle cache, and runs without Marketplace secrets. Same-tag
-dispatches are serialized. The untrusted 262-only source build uses Java 25. A fresh
-verification job checks out only trusted controls, downloads the built zip,
+dispatches are serialized. The untrusted 262-only source build uses Java 25 and
+ignores only checkout-local Gradle-wrapper file-mode differences so embedded
+source provenance remains clean. A fresh verification job checks out only
+trusted controls, downloads the built zip,
 independently runs Plugin Verifier against that artifact on the pinned reviewed
 262 IDE build, and requires every
 artifact-derived report to match the trusted default-branch

--- a/scripts/test-release-contracts.sh
+++ b/scripts/test-release-contracts.sh
@@ -670,6 +670,7 @@ build_steps = [
     "Validate canary source metadata",
     "Verify exact canary tag and branch isolation",
     "Set up JDK 25",
+    "Prepare Gradle wrapper without source drift",
     "Run canary commit gate",
     "Run canary structure gate",
     "Upload canary plugin artifact",
@@ -686,6 +687,10 @@ if 'GRADLE_OPTS: "-Dorg.gradle.caching=false"' not in build or "--no-build-cache
     raise SystemExit("canary build job must disable the Gradle build cache")
 if 'java-version: "25"' not in build:
     raise SystemExit("canary source build must provision Java 25")
+if "git config core.fileMode false" not in build or "chmod +x gradlew" not in build:
+    raise SystemExit("canary build must preserve clean provenance around the Gradle wrapper mode")
+if build.index("git config core.fileMode false") > build.index("chmod +x gradlew"):
+    raise SystemExit("canary build must ignore file-mode drift before making the wrapper executable")
 if build.count("persist-credentials: false") != 2:
     raise SystemExit("canary build checkouts must not persist credentials")
 


### PR DESCRIPTION
## Summary

- keep the immutable canary source checkout clean while making `gradlew` executable on Linux runners
- ignore only checkout-local file-mode differences; content and untracked-file provenance checks remain active
- document and contract-test the clean-provenance preparation step

## Evidence

- `./scripts/test-release-contracts.sh`
- `actionlint .github/workflows/canary-release.yml`
- `shellcheck scripts/test-release-contracts.sh`
- full commit gate passed
- an exact-tag Java 25 build produced `plugin.build.dirty=false` and fingerprint `61e74b59d8adae9f684ff911c8baf6e3a6fe24f1-clean`
- independent trust review found no blockers

## Publication Context

Run `31329839103` was canceled before environment approval after its otherwise-qualified artifact reported dirty provenance caused solely by `chmod +x gradlew`. This PR changes no Stable workflow, token scope, or publication channel.

Refs #274
