### PR TITLE
Rebuild canary artifact from clean source

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -34,8 +34,8 @@
       "releaseCompatibilityGate": "./scripts/release-compatibility-gate.sh",
       "validateReleaseVersion": "./scripts/validate-release-version.sh --tag vX.Y.Z",
       "validateCanaryReleaseVersion": "./scripts/validate-canary-release-version.sh --tag canary/vX.Y.Z-canary.N --channel canary",
-      "verifyCanaryArtifact": "MARKETPLACE_CHANNEL=canary ./scripts/verify-canary-artifact.sh --archive /path/to/jetbrains-inspection-api-X.Y.Z-canary.N.zip --tag canary/vX.Y.Z-canary.N --channel canary",
-      "publishCanaryArtifact": "PUBLISH_TOKEN=$CANARY_PUBLISH_TOKEN MARKETPLACE_CHANNEL=canary ./scripts/publish-canary-artifact.sh --archive /path/to/jetbrains-inspection-api-X.Y.Z-canary.N.zip --tag canary/vX.Y.Z-canary.N --channel canary --expected-sha256 <verified-sha256>",
+      "verifyCanaryArtifact": "MARKETPLACE_CHANNEL=canary ./scripts/verify-canary-artifact.sh --archive /path/to/jetbrains-inspection-api-X.Y.Z-canary.N.zip --tag canary/vX.Y.Z-canary.N --channel canary --source-sha <40-character-source-sha>",
+      "publishCanaryArtifact": "PUBLISH_TOKEN=$CANARY_PUBLISH_TOKEN MARKETPLACE_CHANNEL=canary ./scripts/publish-canary-artifact.sh --archive /path/to/jetbrains-inspection-api-X.Y.Z-canary.N.zip --tag canary/vX.Y.Z-canary.N --channel canary --expected-sha256 <verified-sha256> --source-sha <40-character-source-sha>",
       "canaryPublishEnvironment": "canary-marketplace",
       "mcpServerJar": "./gradlew :mcp-server-jvm:mcpServerJar"
     },

--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -78,19 +78,21 @@ jobs:
           java-version: "25"
           distribution: "temurin"
 
-      - name: Prepare Gradle wrapper without source drift
-        working-directory: source
-        run: |
-          git config core.fileMode false
-          chmod +x gradlew
-
       - name: Run canary commit gate
         working-directory: source
         run: ./scripts/commit-gate.sh --ci
 
-      - name: Run canary structure gate
+      - name: Restore exact source for artifact build
         working-directory: source
-        run: ./gradlew --no-build-cache verifyPluginStructure
+        run: |
+          git reset --hard HEAD
+          git clean -ffdx
+          test -x gradlew
+          test -z "$(git status --porcelain --untracked-files=all)"
+
+      - name: Build clean canary artifact
+        working-directory: source
+        run: ./gradlew --no-build-cache buildPlugin verifyPluginStructure
 
       - name: Upload canary plugin artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -157,12 +159,14 @@ jobs:
       - name: Independently verify canary artifact
         env:
           CANARY_TAG: ${{ inputs.tag }}
+          EXPECTED_SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
           MARKETPLACE_CHANNEL: canary
         run: |
           trusted/scripts/verify-canary-artifact.sh \
             --archive "artifact/jetbrains-inspection-api-${{ needs.build.outputs.version }}.zip" \
             --tag "$CANARY_TAG" \
-            --channel "$MARKETPLACE_CHANNEL"
+            --channel "$MARKETPLACE_CHANNEL" \
+            --source-sha "$EXPECTED_SOURCE_SHA"
 
       - name: Record verified artifact digest
         id: archive_digest
@@ -219,13 +223,15 @@ jobs:
         env:
           CANARY_TAG: ${{ inputs.tag }}
           EXPECTED_ARCHIVE_SHA256: ${{ needs.verify.outputs.archive_sha256 }}
+          EXPECTED_SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
           MARKETPLACE_CHANNEL: canary
         run: |
           archive="artifact/jetbrains-inspection-api-${{ needs.build.outputs.version }}.zip"
           trusted/scripts/validate-canary-artifact.sh \
             --archive "$archive" \
             --tag "$CANARY_TAG" \
-            --channel "$MARKETPLACE_CHANNEL"
+            --channel "$MARKETPLACE_CHANNEL" \
+            --source-sha "$EXPECTED_SOURCE_SHA"
           actual_sha256="$(shasum -a 256 "$archive" | awk '{print $1}')"
           test "$actual_sha256" = "$EXPECTED_ARCHIVE_SHA256"
 
@@ -242,6 +248,7 @@ jobs:
         env:
           CANARY_TAG: ${{ inputs.tag }}
           EXPECTED_ARCHIVE_SHA256: ${{ needs.verify.outputs.archive_sha256 }}
+          EXPECTED_SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
           PUBLISH_TOKEN: ${{ secrets.CANARY_PUBLISH_TOKEN }}
           MARKETPLACE_CHANNEL: canary
         run: |
@@ -249,7 +256,8 @@ jobs:
             --archive "artifact/jetbrains-inspection-api-${{ needs.build.outputs.version }}.zip" \
             --tag "$CANARY_TAG" \
             --channel "$MARKETPLACE_CHANNEL" \
-            --expected-sha256 "$EXPECTED_ARCHIVE_SHA256"
+            --expected-sha256 "$EXPECTED_ARCHIVE_SHA256" \
+            --source-sha "$EXPECTED_SOURCE_SHA"
 
   release:
     needs: [build, verify, publish]

--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -82,26 +82,6 @@ jobs:
         working-directory: source
         run: ./scripts/commit-gate.sh --ci
 
-      - name: Restore exact source for artifact build
-        working-directory: source
-        run: |
-          git reset --hard HEAD
-          git clean -ffdx
-          test -x gradlew
-          test -z "$(git status --porcelain --untracked-files=all)"
-
-      - name: Build clean canary artifact
-        working-directory: source
-        run: ./gradlew --no-build-cache buildPlugin verifyPluginStructure
-
-      - name: Upload canary plugin artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: canary-plugin-${{ steps.canary_version.outputs.version }}
-          path: source/build/distributions/jetbrains-inspection-api-${{ steps.canary_version.outputs.version }}.zip
-          if-no-files-found: error
-          retention-days: 7
-
       - name: Upload test results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
@@ -113,8 +93,60 @@ jobs:
             source/mcp-server-jvm/build/reports/tests/test/
           retention-days: 7
 
-  verify:
+  package:
     needs: [build]
+    runs-on: ubuntu-latest
+    env:
+      GRADLE_OPTS: "-Dorg.gradle.caching=false"
+    permissions:
+      contents: read
+
+    steps:
+      - name: Verify trusted workflow ref
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: test "$GITHUB_REF" = "refs/heads/$DEFAULT_BRANCH"
+
+      - name: Check out exact canary source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ needs.build.outputs.source_sha }}
+          path: source
+
+      - name: Revalidate exact canary source
+        env:
+          CANARY_TAG: ${{ inputs.tag }}
+          EXPECTED_SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
+        working-directory: source
+        run: |
+          git fetch origin "refs/tags/$CANARY_TAG:refs/tags/$CANARY_TAG"
+          test "$(git rev-parse HEAD)" = "$EXPECTED_SOURCE_SHA"
+          test "$(git rev-parse "refs/tags/$CANARY_TAG^{commit}")" = "$EXPECTED_SOURCE_SHA"
+          test -x gradlew
+          test -z "$(git status --porcelain --untracked-files=all)"
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          java-version: "25"
+          distribution: "temurin"
+
+      - name: Build clean canary artifact
+        working-directory: source
+        run: ./gradlew --no-build-cache buildPlugin verifyPluginStructure
+
+      - name: Upload canary plugin artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: canary-plugin-${{ needs.build.outputs.version }}
+          path: source/build/distributions/jetbrains-inspection-api-${{ needs.build.outputs.version }}.zip
+          if-no-files-found: error
+          retention-days: 7
+
+  verify:
+    needs: [build, package]
     runs-on: ubuntu-latest
     outputs:
       archive_sha256: ${{ steps.archive_digest.outputs.sha256 }}
@@ -184,7 +216,7 @@ jobs:
           retention-days: 30
 
   publish:
-    needs: [build, verify]
+    needs: [build, package, verify]
     runs-on: ubuntu-latest
     environment: canary-marketplace
     permissions:
@@ -260,7 +292,7 @@ jobs:
             --source-sha "$EXPECTED_SOURCE_SHA"
 
   release:
-    needs: [build, verify, publish]
+    needs: [build, package, verify, publish]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/README.md
+++ b/README.md
@@ -776,14 +776,15 @@ from the default branch with the existing tag as input. The workflow builds and
 tests the branch-only source without Marketplace secrets or persisted checkout
 credentials or Gradle build caching. The untrusted 262-only source build uses
 Java 25 and runs tests but does not make the compatibility or private-API
-decision. After the tests, the workflow resets the checkout to the immutable
-tag, deletes every generated or untracked file, and rebuilds the distributable
-and structure report without a Gradle build cache. That test workspace and all
-branch-produced verifier reports are discarded. A fresh trusted job downloads
-the resulting zip, requires the embedded source commit, clean-state marker, and
-fingerprint to match the tagged commit exactly, independently runs Plugin
-Verifier against the artifact, and requires an exact match with the reviewed
-default-branch `canary-internal-api-allowlist.txt` before publication can proceed.
+decision. That runner is discarded. A separate fresh packaging runner checks
+out the captured immutable source commit directly, re-resolves the tag to the
+same SHA, proves the checkout is clean, and rebuilds the distributable and
+structure report without a Gradle build cache. A fresh trusted verification job
+downloads the resulting zip, requires the embedded source commit, clean-state
+marker, and fingerprint to match the tagged commit exactly, independently runs
+Plugin Verifier against the artifact, and requires an exact match with the
+reviewed default-branch `canary-internal-api-allowlist.txt` before publication
+can proceed.
 
 The fresh publish job uses the `canary-marketplace` GitHub environment, which must be
 restricted to the default branch and require reviewer approval, plus the

--- a/README.md
+++ b/README.md
@@ -775,14 +775,15 @@ anything. An operator must explicitly dispatch `.github/workflows/canary-release
 from the default branch with the existing tag as input. The workflow builds and
 tests the branch-only source without Marketplace secrets or persisted checkout
 credentials or Gradle build caching. The untrusted 262-only source build uses
-Java 25, ignores only checkout-local executable-bit differences before invoking
-the Gradle wrapper, and runs tests and plugin
-structure validation but does not make the compatibility or private-API
-decision. That build workspace and all branch-produced verifier reports are
-discarded. A fresh trusted job downloads the resulting zip, independently runs
-Plugin Verifier against the artifact, and requires an exact match with the
-reviewed default-branch `canary-internal-api-allowlist.txt` before publication
-can proceed.
+Java 25 and runs tests but does not make the compatibility or private-API
+decision. After the tests, the workflow resets the checkout to the immutable
+tag, deletes every generated or untracked file, and rebuilds the distributable
+and structure report without a Gradle build cache. That test workspace and all
+branch-produced verifier reports are discarded. A fresh trusted job downloads
+the resulting zip, requires the embedded source commit, clean-state marker, and
+fingerprint to match the tagged commit exactly, independently runs Plugin
+Verifier against the artifact, and requires an exact match with the reviewed
+default-branch `canary-internal-api-allowlist.txt` before publication can proceed.
 
 The fresh publish job uses the `canary-marketplace` GitHub environment, which must be
 restricted to the default branch and require reviewer approval, plus the
@@ -814,7 +815,8 @@ MARKETPLACE_CHANNEL=canary \
   ./scripts/verify-canary-artifact.sh \
     --archive /path/to/jetbrains-inspection-api-1.14.0-canary.1.zip \
     --tag canary/v1.14.0-canary.1 \
-    --channel canary
+    --channel canary \
+    --source-sha 61e74b59d8adae9f684ff911c8baf6e3a6fe24f1
 
 verified_sha256="$(shasum -a 256 /path/to/jetbrains-inspection-api-1.14.0-canary.1.zip | awk '{print $1}')"
 PUBLISH_TOKEN="$CANARY_PUBLISH_TOKEN" MARKETPLACE_CHANNEL=canary \
@@ -822,11 +824,13 @@ PUBLISH_TOKEN="$CANARY_PUBLISH_TOKEN" MARKETPLACE_CHANNEL=canary \
     --archive /path/to/jetbrains-inspection-api-1.14.0-canary.1.zip \
     --tag canary/v1.14.0-canary.1 \
     --channel canary \
-    --expected-sha256 "$verified_sha256"
+    --expected-sha256 "$verified_sha256" \
+    --source-sha 61e74b59d8adae9f684ff911c8baf6e3a6fe24f1
 ```
 
 The artifact publisher fails before network upload when the tag, zip name,
-embedded plugin ID/version, token, or channel is wrong. Canary product code stays
+embedded plugin ID/version, source commit, clean-state fingerprint, token, or
+channel is wrong. Canary product code stays
 on the experimental branch, is compatible only with the 262 platform line, and
 is not hidden behind a Stable runtime flag. Its
 intended private API findings must be reviewed into the trusted default-branch

--- a/TESTING.md
+++ b/TESTING.md
@@ -360,9 +360,10 @@ default branch with an existing isolated tag. Its build job treats the source,
 Gradle logic, verifier reports, and workspace as untrusted, persists no checkout
 credentials, uses no Gradle cache, and runs without Marketplace secrets. Same-tag
 dispatches are serialized. The untrusted 262-only source build uses Java 25 and
-ignores only checkout-local Gradle-wrapper file-mode differences so embedded
-source provenance remains clean. A fresh verification job checks out only
-trusted controls, downloads the built zip,
+resets and cleans the exact tagged checkout after tests before rebuilding the
+artifact and structure report from scratch. A fresh verification job checks out
+only trusted controls, downloads the built zip, requires the embedded commit,
+clean-state marker, and fingerprint to match the tagged source exactly,
 independently runs Plugin Verifier against that artifact on the pinned reviewed
 262 IDE build, and requires every
 artifact-derived report to match the trusted default-branch
@@ -373,8 +374,9 @@ publish job enter the default-branch-only, reviewer-approved
 `canary-marketplace` environment. It revalidates the tag SHA, archive identity,
 and verified digest, then uploads through the
 trusted `scripts/publish-canary-artifact.sh` with the environment-only
-`CANARY_PUBLISH_TOKEN`, explicit `canary` channel, and required verified SHA-256.
-Artifact validation requires the canary's narrow `262..262.*` compatibility range.
+`CANARY_PUBLISH_TOKEN`, explicit `canary` channel, required source SHA, and
+verified SHA-256. Artifact validation requires the canary's narrow
+`262..262.*` compatibility range and clean tagged-source provenance.
 That environment job has read-only repository permission. A separate write-only
 GitHub release job creates the prerelease only after Marketplace upload succeeds
 and rechecks the verified digest without receiving the Marketplace token. The release contract tests

--- a/TESTING.md
+++ b/TESTING.md
@@ -360,9 +360,11 @@ default branch with an existing isolated tag. Its build job treats the source,
 Gradle logic, verifier reports, and workspace as untrusted, persists no checkout
 credentials, uses no Gradle cache, and runs without Marketplace secrets. Same-tag
 dispatches are serialized. The untrusted 262-only source build uses Java 25 and
-resets and cleans the exact tagged checkout after tests before rebuilding the
-artifact and structure report from scratch. A fresh verification job checks out
-only trusted controls, downloads the built zip, requires the embedded commit,
+is discarded after tests. A separate fresh packaging runner checks out the
+captured source SHA, re-resolves the immutable tag, proves the checkout is clean,
+and rebuilds the artifact and structure report from scratch. A fresh
+verification job checks out only trusted controls, downloads the built zip,
+requires the embedded commit,
 clean-state marker, and fingerprint to match the tagged source exactly,
 independently runs Plugin Verifier against that artifact on the pinned reviewed
 262 IDE build, and requires every

--- a/scripts/publish-canary-artifact.sh
+++ b/scripts/publish-canary-artifact.sh
@@ -7,6 +7,7 @@ ARCHIVE=""
 TAG="${GITHUB_REF_NAME:-}"
 CHANNEL="${MARKETPLACE_CHANNEL:-}"
 EXPECTED_SHA256=""
+SOURCE_SHA="${CANARY_SOURCE_SHA:-}"
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -26,6 +27,10 @@ while [ $# -gt 0 ]; do
       shift
       EXPECTED_SHA256="${1:-}"
       ;;
+    --source-sha)
+      shift
+      SOURCE_SHA="${1:-}"
+      ;;
     *)
       echo "ERROR: Unknown argument: $1" >&2
       exit 1
@@ -37,7 +42,8 @@ done
 "$ROOT/scripts/validate-canary-artifact.sh" \
   --archive "$ARCHIVE" \
   --tag "$TAG" \
-  --channel "$CHANNEL"
+  --channel "$CHANNEL" \
+  --source-sha "$SOURCE_SHA"
 
 if ! [[ "$EXPECTED_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
   echo "ERROR: --expected-sha256 must be the lowercase SHA-256 of the verified canary artifact." >&2

--- a/scripts/test-release-contracts.sh
+++ b/scripts/test-release-contracts.sh
@@ -723,7 +723,8 @@ from pathlib import Path
 import re
 
 workflow = Path(".github/workflows/canary-release.yml").read_text(encoding="utf-8")
-build = workflow.split("\n  build:\n", 1)[1].split("\n  verify:\n", 1)[0]
+build = workflow.split("\n  build:\n", 1)[1].split("\n  package:\n", 1)[0]
+package = workflow.split("\n  package:\n", 1)[1].split("\n  verify:\n", 1)[0]
 verify = workflow.split("\n  verify:\n", 1)[1].split("\n  publish:\n", 1)[0]
 publish = workflow.split("\n  publish:\n", 1)[1].split("\n  release:\n", 1)[0]
 release = workflow.split("\n  release:\n", 1)[1]
@@ -739,9 +740,6 @@ build_steps = [
     "Verify exact canary tag and branch isolation",
     "Set up JDK 25",
     "Run canary commit gate",
-    "Restore exact source for artifact build",
-    "Build clean canary artifact",
-    "Upload canary plugin artifact",
 ]
 if [build.index(step) for step in build_steps] != sorted(build.index(step) for step in build_steps):
     raise SystemExit("canary build workflow gate ordering is unsafe")
@@ -751,15 +749,43 @@ if "verify-internal-api-allowlist.py" in build or "internal-api-usages.txt" in b
     raise SystemExit("canary build job must not make the trusted verification decision")
 if "release-compatibility-gate.sh" in build or " verifyPlugin\n" in build:
     raise SystemExit("canary build job must not run branch-controlled compatibility verification")
-if 'GRADLE_OPTS: "-Dorg.gradle.caching=false"' not in build or "--no-build-cache buildPlugin verifyPluginStructure" not in build:
+if 'GRADLE_OPTS: "-Dorg.gradle.caching=false"' not in build:
     raise SystemExit("canary build job must disable the Gradle build cache")
 if 'java-version: "25"' not in build:
     raise SystemExit("canary source build must provision Java 25")
-for clean_command in ["git reset --hard HEAD", "git clean -ffdx", "test -x gradlew", "git status --porcelain --untracked-files=all"]:
-    if clean_command not in build:
-        raise SystemExit(f"canary build must restore exact source before artifact creation: {clean_command}")
 if build.count("persist-credentials: false") != 2:
     raise SystemExit("canary build checkouts must not persist credentials")
+
+package_steps = [
+    "Verify trusted workflow ref",
+    "Check out exact canary source",
+    "Revalidate exact canary source",
+    "Set up JDK 25",
+    "Build clean canary artifact",
+    "Upload canary plugin artifact",
+]
+if [package.index(step) for step in package_steps] != sorted(package.index(step) for step in package_steps):
+    raise SystemExit("canary packaging workflow gate ordering is unsafe")
+if "needs: [build]" not in package:
+    raise SystemExit("canary packaging must follow the untrusted test gate on a fresh runner")
+if "CANARY_PUBLISH_TOKEN" in package or "environment:" in package:
+    raise SystemExit("canary packaging must not receive publication authority")
+if "persist-credentials: false" not in package:
+    raise SystemExit("canary packaging checkout must not persist credentials")
+if 'ref: ${{ needs.build.outputs.source_sha }}' not in package:
+    raise SystemExit("canary packaging checkout must pin the captured source commit")
+for exact_source_check in [
+    'test "$(git rev-parse HEAD)" = "$EXPECTED_SOURCE_SHA"',
+    'test "$(git rev-parse "refs/tags/$CANARY_TAG^{commit}")" = "$EXPECTED_SOURCE_SHA"',
+    "test -x gradlew",
+    "git status --porcelain --untracked-files=all",
+]:
+    if exact_source_check not in package:
+        raise SystemExit(f"canary packaging must prove exact clean source: {exact_source_check}")
+if 'GRADLE_OPTS: "-Dorg.gradle.caching=false"' not in package or "--no-build-cache buildPlugin verifyPluginStructure" not in package:
+    raise SystemExit("canary packaging must rebuild without the Gradle build cache")
+if 'java-version: "25"' not in package:
+    raise SystemExit("canary packaging must provision Java 25")
 
 verify_steps = [
     "Verify trusted workflow ref",
@@ -786,6 +812,8 @@ if "Set up JDK 21" not in verify or 'java-version: "21"' not in verify:
     raise SystemExit("trusted artifact verification must preserve Java 21")
 if "archive_sha256:" not in verify:
     raise SystemExit("trusted verification job must bind publication to the verified artifact digest")
+if "needs: [build, package]" not in verify:
+    raise SystemExit("trusted verification must consume only the fresh packaging artifact")
 if "test \"$(git rev-parse \"refs/tags/$CANARY_TAG^{commit}\")\" = \"$EXPECTED_SOURCE_SHA\"" not in verify:
     raise SystemExit("trusted verification must enforce the source tag digest")
 
@@ -805,7 +833,7 @@ if "contents: read" not in publish or "contents: write" in publish:
     raise SystemExit("Marketplace publication must not receive GitHub contents write authority")
 if "persist-credentials: false" not in publish:
     raise SystemExit("Marketplace publication checkout must not persist credentials")
-if "needs: [build, verify]" not in publish:
+if "needs: [build, package, verify]" not in publish:
     raise SystemExit("canary publication must depend on trusted artifact verification")
 if "EXPECTED_ARCHIVE_SHA256: ${{ needs.verify.outputs.archive_sha256 }}" not in publish:
     raise SystemExit("canary publication must require the trusted verification digest")
@@ -830,7 +858,7 @@ release_steps = [
 ]
 if [release.index(step) for step in release_steps] != sorted(release.index(step) for step in release_steps):
     raise SystemExit("canary GitHub release workflow ordering is unsafe")
-if "needs: [build, verify, publish]" not in release:
+if "needs: [build, package, verify, publish]" not in release:
     raise SystemExit("GitHub prerelease creation must follow successful Marketplace publication")
 if "contents: write" not in release or "CANARY_PUBLISH_TOKEN" in release:
     raise SystemExit("GitHub release authority must remain isolated from Marketplace authority")

--- a/scripts/test-release-contracts.sh
+++ b/scripts/test-release-contracts.sh
@@ -99,7 +99,7 @@ test_canary_version_validator() {
 }
 
 test_canary_artifact_publication() {
-  local temp_dir fake_bin curl_log archive archive_sha256 bad_archive bad_version_archive bad_compatibility_archive missing_jar_archive
+  local temp_dir fake_bin curl_log archive archive_sha256 bad_archive bad_version_archive bad_compatibility_archive dirty_archive wrong_source_archive missing_jar_archive source_sha
   temp_dir=$(mktemp -d)
   fake_bin="$temp_dir/bin"
   curl_log="$temp_dir/curl.log"
@@ -107,7 +107,11 @@ test_canary_artifact_publication() {
   bad_archive="$temp_dir/bad/jetbrains-inspection-api-1.2.3-canary.1.zip"
   bad_version_archive="$temp_dir/bad-version/jetbrains-inspection-api-1.2.3-canary.1.zip"
   bad_compatibility_archive="$temp_dir/bad-compatibility/jetbrains-inspection-api-1.2.3-canary.1.zip"
+  dirty_archive="$temp_dir/dirty/jetbrains-inspection-api-1.2.3-canary.1.zip"
+  wrong_source_archive="$temp_dir/wrong-source/jetbrains-inspection-api-1.2.3-canary.1.zip"
   missing_jar_archive="$temp_dir/missing-jar/jetbrains-inspection-api-1.2.3-canary.1.zip"
+  source_sha="0123456789abcdef0123456789abcdef01234567"
+  export CANARY_SOURCE_SHA="$source_sha"
   trap 'rm -rf "$temp_dir"' RETURN
   mkdir -p "$temp_dir/scripts" "$fake_bin"
   cp \
@@ -119,12 +123,16 @@ test_canary_artifact_publication() {
     "$(dirname "$bad_archive")" \
     "$(dirname "$bad_version_archive")" \
     "$(dirname "$bad_compatibility_archive")" \
+    "$(dirname "$dirty_archive")" \
+    "$(dirname "$wrong_source_archive")" \
     "$(dirname "$missing_jar_archive")"
   python3 - \
     "$archive" \
     "$bad_archive" \
     "$bad_version_archive" \
     "$bad_compatibility_archive" \
+    "$dirty_archive" \
+    "$wrong_source_archive" \
     "$missing_jar_archive" <<'PY'
 from io import BytesIO
 from pathlib import Path
@@ -137,6 +145,8 @@ def write_archive(
     version: str,
     since_build: str = "262",
     until_build: str = "262.*",
+    build_commit: str = "0123456789abcdef0123456789abcdef01234567",
+    build_dirty: bool = False,
 ) -> None:
     plugin_xml = (
         f"<idea-plugin><id>{plugin_id}</id>"
@@ -144,9 +154,22 @@ def write_archive(
         f'<idea-version since-build="{since_build}" until-build="{until_build}"/>'
         "</idea-plugin>"
     )
+    state = "dirty" if build_dirty else "clean"
+    build_info = "\n".join(
+        [
+            f"plugin.version={version}",
+            f"plugin.build.commit={build_commit}",
+            f"plugin.build.short_commit={build_commit[:12]}",
+            f"plugin.build.dirty={str(build_dirty).lower()}",
+            f"plugin.build.fingerprint={build_commit}-{state}",
+            "plugin.build.time=2026-08-09T00\\:00\\:00Z",
+            "",
+        ]
+    )
     plugin_jar = BytesIO()
     with zipfile.ZipFile(plugin_jar, "w") as jar:
         jar.writestr("META-INF/plugin.xml", plugin_xml)
+        jar.writestr("com/shiny/inspectionmcp/inspection-build.properties", build_info)
     with zipfile.ZipFile(path, "w") as plugin_zip:
         plugin_zip.writestr(
             "jetbrains-inspection-api/lib/jetbrains-inspection-api-1.2.3-canary.1.jar",
@@ -162,7 +185,19 @@ write_archive(
     "1.2.3-canary.1",
     until_build="271.*",
 )
-with zipfile.ZipFile(Path(sys.argv[5]), "w") as plugin_zip:
+write_archive(
+    Path(sys.argv[5]),
+    "com.shiny.inspection.api",
+    "1.2.3-canary.1",
+    build_dirty=True,
+)
+write_archive(
+    Path(sys.argv[6]),
+    "com.shiny.inspection.api",
+    "1.2.3-canary.1",
+    build_commit="89abcdef0123456789abcdef0123456789abcdef",
+)
+with zipfile.ZipFile(Path(sys.argv[7]), "w") as plugin_zip:
     plugin_zip.writestr("unexpected.txt", "missing plugin jar")
 PY
   archive_sha256=$(shasum -a 256 "$archive" | awk '{print $1}')
@@ -171,6 +206,11 @@ PY
 printf '%s\n' "$@" > "$CURL_LOG"
 CURL
   chmod +x "$fake_bin/curl"
+
+  if (cd "$temp_dir" && PATH="$fake_bin:$PATH" CURL_LOG="$curl_log" PUBLISH_TOKEN=test MARKETPLACE_CHANNEL=canary CANARY_SOURCE_SHA='' ./scripts/publish-canary-artifact.sh --archive "$archive" --tag canary/v1.2.3-canary.1 >/dev/null 2>&1); then
+    fail "canary artifact publisher accepted an absent source SHA"
+  fi
+  [ ! -e "$curl_log" ] || fail "canary artifact publisher invoked curl without source provenance"
 
   if (cd "$temp_dir" && PATH="$fake_bin:$PATH" CURL_LOG="$curl_log" PUBLISH_TOKEN=test ./scripts/publish-canary-artifact.sh --archive "$archive" --tag canary/v1.2.3-canary.1 >/dev/null 2>&1); then
     fail "canary artifact publisher accepted an absent channel"
@@ -202,6 +242,16 @@ CURL
   fi
   [ ! -e "$curl_log" ] || fail "canary artifact publisher invoked curl for an untrusted compatibility range"
 
+  if (cd "$temp_dir" && PATH="$fake_bin:$PATH" CURL_LOG="$curl_log" PUBLISH_TOKEN=test MARKETPLACE_CHANNEL=canary ./scripts/publish-canary-artifact.sh --archive "$dirty_archive" --tag canary/v1.2.3-canary.1 >/dev/null 2>&1); then
+    fail "canary artifact publisher accepted dirty source provenance"
+  fi
+  [ ! -e "$curl_log" ] || fail "canary artifact publisher invoked curl for dirty source provenance"
+
+  if (cd "$temp_dir" && PATH="$fake_bin:$PATH" CURL_LOG="$curl_log" PUBLISH_TOKEN=test MARKETPLACE_CHANNEL=canary ./scripts/publish-canary-artifact.sh --archive "$wrong_source_archive" --tag canary/v1.2.3-canary.1 >/dev/null 2>&1); then
+    fail "canary artifact publisher accepted a mismatched source commit"
+  fi
+  [ ! -e "$curl_log" ] || fail "canary artifact publisher invoked curl for a mismatched source commit"
+
   if (cd "$temp_dir" && PATH="$fake_bin:$PATH" CURL_LOG="$curl_log" PUBLISH_TOKEN=test MARKETPLACE_CHANNEL=canary ./scripts/publish-canary-artifact.sh --archive "$missing_jar_archive" --tag canary/v1.2.3-canary.1 >/dev/null 2>&1); then
     fail "canary artifact publisher accepted an archive without the plugin jar"
   fi
@@ -222,6 +272,7 @@ CURL
   assert_contains "$curl_log" "file=@$archive"
   assert_contains "$curl_log" "channel=canary"
 
+  unset CANARY_SOURCE_SHA
   rm -rf "$temp_dir"
   trap - RETURN
 }
@@ -349,7 +400,7 @@ MANIFEST
 }
 
 test_canary_verification_trust_boundary() {
-  local temp_dir trusted source archive gradle_log java_home_21 java_home_25
+  local temp_dir trusted source archive gradle_log java_home_21 java_home_25 source_sha
   temp_dir=$(mktemp -d)
   trusted="$temp_dir/trusted"
   source="$temp_dir/source"
@@ -357,6 +408,7 @@ test_canary_verification_trust_boundary() {
   gradle_log="$temp_dir/gradle.log"
   java_home_21="$temp_dir/jdk-21"
   java_home_25="$temp_dir/jdk-25"
+  source_sha="0123456789abcdef0123456789abcdef01234567"
   trap 'rm -rf "$temp_dir"' RETURN
 
   mkdir -p \
@@ -408,13 +460,14 @@ MALICIOUS
   printf 'fabricated manifest\n' > \
     "$source/config/plugin-verifier/canary-internal-api-allowlist.txt"
 
-  python3 - "$archive" <<'PY'
+  python3 - "$archive" "$source_sha" <<'PY'
 from io import BytesIO
 from pathlib import Path
 import sys
 import zipfile
 
 archive = Path(sys.argv[1])
+source_sha = sys.argv[2]
 plugin_jar = BytesIO()
 with zipfile.ZipFile(plugin_jar, "w") as jar:
     jar.writestr(
@@ -423,6 +476,20 @@ with zipfile.ZipFile(plugin_jar, "w") as jar:
         "<version>1.2.3-canary.1</version>"
         '<idea-version since-build="262" until-build="262.*"/>'
         "</idea-plugin>",
+    )
+    jar.writestr(
+        "com/shiny/inspectionmcp/inspection-build.properties",
+        "\n".join(
+            [
+                "plugin.version=1.2.3-canary.1",
+                f"plugin.build.commit={source_sha}",
+                f"plugin.build.short_commit={source_sha[:12]}",
+                "plugin.build.dirty=false",
+                f"plugin.build.fingerprint={source_sha}-clean",
+                "plugin.build.time=2026-08-09T00\\:00\\:00Z",
+                "",
+            ]
+        ),
     )
 with zipfile.ZipFile(archive, "w") as plugin_zip:
     plugin_zip.writestr(
@@ -442,7 +509,8 @@ PY
     "$trusted/scripts/verify-canary-artifact.sh" \
       --archive "$archive" \
       --tag canary/v1.2.3-canary.1 \
-      --channel canary >/dev/null
+      --channel canary \
+      --source-sha "$source_sha" >/dev/null
   )
 
   [ ! -e "$temp_dir/tampered" ] || \
@@ -670,9 +738,9 @@ build_steps = [
     "Validate canary source metadata",
     "Verify exact canary tag and branch isolation",
     "Set up JDK 25",
-    "Prepare Gradle wrapper without source drift",
     "Run canary commit gate",
-    "Run canary structure gate",
+    "Restore exact source for artifact build",
+    "Build clean canary artifact",
     "Upload canary plugin artifact",
 ]
 if [build.index(step) for step in build_steps] != sorted(build.index(step) for step in build_steps):
@@ -683,14 +751,13 @@ if "verify-internal-api-allowlist.py" in build or "internal-api-usages.txt" in b
     raise SystemExit("canary build job must not make the trusted verification decision")
 if "release-compatibility-gate.sh" in build or " verifyPlugin\n" in build:
     raise SystemExit("canary build job must not run branch-controlled compatibility verification")
-if 'GRADLE_OPTS: "-Dorg.gradle.caching=false"' not in build or "--no-build-cache verifyPluginStructure" not in build:
+if 'GRADLE_OPTS: "-Dorg.gradle.caching=false"' not in build or "--no-build-cache buildPlugin verifyPluginStructure" not in build:
     raise SystemExit("canary build job must disable the Gradle build cache")
 if 'java-version: "25"' not in build:
     raise SystemExit("canary source build must provision Java 25")
-if "git config core.fileMode false" not in build or "chmod +x gradlew" not in build:
-    raise SystemExit("canary build must preserve clean provenance around the Gradle wrapper mode")
-if build.index("git config core.fileMode false") > build.index("chmod +x gradlew"):
-    raise SystemExit("canary build must ignore file-mode drift before making the wrapper executable")
+for clean_command in ["git reset --hard HEAD", "git clean -ffdx", "test -x gradlew", "git status --porcelain --untracked-files=all"]:
+    if clean_command not in build:
+        raise SystemExit(f"canary build must restore exact source before artifact creation: {clean_command}")
 if build.count("persist-credentials: false") != 2:
     raise SystemExit("canary build checkouts must not persist credentials")
 
@@ -713,6 +780,8 @@ if "persist-credentials: false" not in verify:
     raise SystemExit("trusted verification checkout must not persist credentials")
 if "trusted/scripts/verify-canary-artifact.sh" not in verify:
     raise SystemExit("trusted verification job must independently inspect the downloaded artifact")
+if '--source-sha "$EXPECTED_SOURCE_SHA"' not in verify:
+    raise SystemExit("trusted verification must inspect embedded clean source provenance")
 if "Set up JDK 21" not in verify or 'java-version: "21"' not in verify:
     raise SystemExit("trusted artifact verification must preserve Java 21")
 if "archive_sha256:" not in verify:
@@ -744,6 +813,8 @@ if 'test "$actual_sha256" = "$EXPECTED_ARCHIVE_SHA256"' not in publish:
     raise SystemExit("canary publication must compare the downloaded artifact to the trusted digest")
 if '--expected-sha256 "$EXPECTED_ARCHIVE_SHA256"' not in publish:
     raise SystemExit("Marketplace upload must recheck the independently verified artifact digest")
+if publish.count('--source-sha "$EXPECTED_SOURCE_SHA"') != 2:
+    raise SystemExit("Marketplace validation and upload must recheck embedded clean source provenance")
 if "test \"$(git rev-parse \"refs/tags/$CANARY_TAG^{commit}\")\" = \"$EXPECTED_SOURCE_SHA\"" not in publish:
     raise SystemExit("canary publication must enforce the source tag digest")
 if publish.index("EXPECTED_ARCHIVE_SHA256") > publish.index("Verify canary Marketplace token"):

--- a/scripts/validate-canary-artifact.sh
+++ b/scripts/validate-canary-artifact.sh
@@ -6,6 +6,7 @@ ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 ARCHIVE=""
 TAG="${GITHUB_REF_NAME:-}"
 CHANNEL="${MARKETPLACE_CHANNEL:-}"
+SOURCE_SHA="${CANARY_SOURCE_SHA:-}"
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -20,6 +21,10 @@ while [ $# -gt 0 ]; do
     --channel)
       shift
       CHANNEL="${1:-}"
+      ;;
+    --source-sha)
+      shift
+      SOURCE_SHA="${1:-}"
       ;;
     *)
       echo "ERROR: Unknown argument: $1" >&2
@@ -37,8 +42,12 @@ if ! [[ "$TAG" =~ ^canary/v([0-9]+\.[0-9]+\.[0-9]+)-canary\.([1-9][0-9]*)$ ]]; t
   echo "ERROR: Canary tag must be in canary/vX.Y.Z-canary.N format (got '${TAG:-<empty>}')." >&2
   exit 1
 fi
-
 VERSION="${BASH_REMATCH[1]}-canary.${BASH_REMATCH[2]}"
+if ! [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "ERROR: --source-sha must be the lowercase 40-character canary source commit." >&2
+  exit 1
+fi
+
 EXPECTED_SINCE_BUILD="262"
 EXPECTED_UNTIL_BUILD="262.*"
 "$ROOT/scripts/validate-marketplace-publication.sh" \
@@ -72,10 +81,22 @@ if ! unzip -p "$TEMP_DIR/plugin.jar" META-INF/plugin.xml > "$TEMP_DIR/plugin.xml
   echo "ERROR: Canary plugin jar does not contain META-INF/plugin.xml." >&2
   exit 1
 fi
+BUILD_INFO_PATH="com/shiny/inspectionmcp/inspection-build.properties"
+BUILD_INFO_COUNT=$(unzip -Z1 "$TEMP_DIR/plugin.jar" | awk -v target="$BUILD_INFO_PATH" '$0 == target { count++ } END { print count + 0 }')
+if [ "$BUILD_INFO_COUNT" -ne 1 ]; then
+  echo "ERROR: Canary plugin jar must contain exactly one $BUILD_INFO_PATH." >&2
+  exit 1
+fi
+if ! unzip -p "$TEMP_DIR/plugin.jar" "$BUILD_INFO_PATH" > "$TEMP_DIR/inspection-build.properties"; then
+  echo "ERROR: Canary plugin jar does not contain $BUILD_INFO_PATH." >&2
+  exit 1
+fi
 
 python3 - \
   "$TEMP_DIR/plugin.xml" \
+  "$TEMP_DIR/inspection-build.properties" \
   "$VERSION" \
+  "$SOURCE_SHA" \
   "$EXPECTED_SINCE_BUILD" \
   "$EXPECTED_UNTIL_BUILD" <<'PY'
 from pathlib import Path
@@ -83,9 +104,11 @@ import sys
 import xml.etree.ElementTree as ET
 
 plugin_xml_path = Path(sys.argv[1])
-expected_version = sys.argv[2]
-expected_since_build = sys.argv[3]
-expected_until_build = sys.argv[4]
+build_info_path = Path(sys.argv[2])
+expected_version = sys.argv[3]
+expected_source_sha = sys.argv[4]
+expected_since_build = sys.argv[5]
+expected_until_build = sys.argv[6]
 
 try:
     plugin_root = ET.parse(plugin_xml_path).getroot()
@@ -111,4 +134,29 @@ if since_build != expected_since_build or until_build != expected_until_build:
         f"{since_build or '<missing>'}..{until_build or '<missing>'} does not match "
         f"trusted range {expected_since_build}..{expected_until_build}."
     )
+
+build_info = {}
+for raw_line in build_info_path.read_text(encoding="utf-8").splitlines():
+    line = raw_line.strip()
+    if not line or line.startswith(("#", "!")):
+        continue
+    key, separator, value = line.partition("=")
+    if not separator:
+        raise SystemExit("ERROR: Canary archive build provenance is malformed.")
+    build_info[key.strip()] = value.strip()
+
+expected_provenance = {
+    "plugin.version": expected_version,
+    "plugin.build.commit": expected_source_sha,
+    "plugin.build.short_commit": expected_source_sha[:12],
+    "plugin.build.dirty": "false",
+    "plugin.build.fingerprint": f"{expected_source_sha}-clean",
+}
+for key, expected_value in expected_provenance.items():
+    actual_value = build_info.get(key, "")
+    if actual_value != expected_value:
+        raise SystemExit(
+            f"ERROR: Canary archive provenance {key}={actual_value or '<missing>'} "
+            f"does not match trusted value {expected_value}."
+        )
 PY

--- a/scripts/verify-canary-artifact.sh
+++ b/scripts/verify-canary-artifact.sh
@@ -6,6 +6,7 @@ ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 ARCHIVE=""
 TAG="${GITHUB_REF_NAME:-}"
 CHANNEL="${MARKETPLACE_CHANNEL:-}"
+SOURCE_SHA="${CANARY_SOURCE_SHA:-}"
 
 java_major_version() {
   local java_home="$1"
@@ -50,6 +51,10 @@ while [ $# -gt 0 ]; do
       shift
       CHANNEL="${1:-}"
       ;;
+    --source-sha)
+      shift
+      SOURCE_SHA="${1:-}"
+      ;;
     *)
       echo "ERROR: Unknown argument: $1" >&2
       exit 1
@@ -61,7 +66,8 @@ done
 "$ROOT/scripts/validate-canary-artifact.sh" \
   --archive "$ARCHIVE" \
   --tag "$TAG" \
-  --channel "$CHANNEL"
+  --channel "$CHANNEL" \
+  --source-sha "$SOURCE_SHA"
 
 ARCHIVE=$(cd "$(dirname "$ARCHIVE")" && pwd)/$(basename "$ARCHIVE")
 VERSION="${TAG#canary/v}"


### PR DESCRIPTION
## Summary

- discard the untrusted test runner before packaging
- rebuild the distributable and structure report on a fresh runner checked out directly at the captured tagged source SHA with no build cache
- require embedded source SHA, `dirty=false`, and `<source-sha>-clean` fingerprint during trusted verify and immediately before upload

## Evidence

- `./scripts/test-release-contracts.sh`
- `bash -n` on changed shell scripts
- `shellcheck --severity=warning` on changed shell scripts
- `actionlint .github/workflows/canary-release.yml`
- full commit gate passed
- preserved exact-tag Java 25 build passes the new provenance validator
- run `31331144072` artifact fails the new validator specifically on `plugin.build.dirty=true`
- independent review feedback that same-runner `HEAD` could move was resolved by splitting packaging into a separate pinned job

## Publication Context

Fresh run `31331144072` passed digest, 262-only identity, and exact 73-finding verification, but remained dirty on the hosted runner. It was canceled before environment approval. This PR changes no Stable workflow, product source, Marketplace channel, or token boundary.

Refs #274
