### PR TITLE
Add deterministic canary advertiser-cache qualification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,12 @@ jobs:
           distribution: "temurin"
           cache: "gradle"
 
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          java-version: "25"
+          distribution: "temurin"
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
@@ -47,7 +53,10 @@ jobs:
         run: shellcheck --severity=warning scripts/*.sh
 
       - name: Run commit gate
-        run: ./scripts/commit-gate.sh --ci
+        run: |
+          export JAVA_HOME_21="$JAVA_HOME_21_X64"
+          export JAVA_HOME_25="$JAVA_HOME_25_X64"
+          ./scripts/commit-gate.sh --ci
 
       - name: Upload test results
         uses: actions/upload-artifact@v7

--- a/TESTING.md
+++ b/TESTING.md
@@ -348,6 +348,51 @@ manifest with the sorted canonical first sentence of each approved finding, and
 rerun `./gradlew verifyPlugin` across every configured IDE. Never add a broader
 class-name pattern to make a report pass.
 
+### Private recommendation canary cache qualification
+
+The 262-only recommendation canary must prove deterministic advertiser-cache
+`recommended` behavior before Marketplace upload. Build and independently
+verify the exact canary archive first, then prepare a disposable profile using a
+JetBrains 262 product that bundles Properties but not Go, such as PyCharm:
+
+```bash
+artifact=build/canary-qualification/trusted-run-31334693870/jetbrains-inspection-api-1.14.0-canary.1.zip
+profile_parent=$(mktemp -d)
+profile_root="$profile_parent/profile"
+CANARY_TEST_IDE_HOME="$HOME/Applications/PyCharm.app/Contents" \
+  ./scripts/test-plugin-recommendation-canary-profile.sh
+./scripts/prepare-plugin-recommendation-canary-profile.sh \
+  --ide-home "$HOME/Applications/PyCharm.app/Contents" \
+  --plugin-archive "$artifact" \
+  --canary-tag canary/v1.14.0-canary.1 \
+  --expected-sha256 3153c695ec204cd24f97da71aae2e8929d6868f10db6e305c685251155bbdee4 \
+  --expected-source-commit 61e74b59d8adae9f684ff911c8baf6e3a6fe24f1 \
+  --profile-root "$profile_root"
+```
+
+Start the non-GUI backend with `"$profile_root/launch-headless.sh"`. Resolve the
+exact route from its isolated registry and query only the canary endpoint for
+the copied fixture paths. `main.go` must return `recommended` for
+`org.jetbrains.plugins.go` with installation state `absent`;
+`disabled.canary.properties` must return `recommended` for
+`com.intellij.properties` with installation state `disabled`.
+`irrelevant.canary_fixture` must return no recommendation. Preserve the response
+JSON, IDE build, candidate source commit, archive SHA-256, and generated
+`qualification.json` with the issue evidence. Stop the backend and delete the
+disposable profile after evidence capture.
+
+The preparation path is qualification-only and is not packaged in the plugin.
+It serializes a two-row cache with the selected IDE's own 262 classes into a new
+profile, disables Properties only in that profile, refuses existing state, and
+never accepts plugin IDs from the caller. It also pre-trusts only the fixture,
+marks the 262 What's New content as shown, disables startup tips and automatic
+plugin updates, blocks Marketplace cache refreshes, copies the fixture out of
+the source tree, and requires the trusted artifact digest plus embedded clean
+source commit before extraction. Properties is suppressed only through the
+isolated backend's `idea.suppressed.plugins.id` VM property; no normal IDE plugin
+state is changed. The canary endpoint remains read-only, and the qualification
+uses the remote-development backend so it opens no local IDE window.
+
 Canary tags use `canary/vX.Y.Z-canary.N` but do not trigger publication.
 `.github/workflows/canary-release.yml` must be dispatched explicitly from the
 default branch with an existing isolated tag. Its build job treats the source,

--- a/scripts/prepare-plugin-recommendation-canary-profile.sh
+++ b/scripts/prepare-plugin-recommendation-canary-profile.sh
@@ -1,0 +1,342 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+CANARY_TAG=""
+EXPECTED_SHA256=""
+EXPECTED_SOURCE_COMMIT=""
+IDE_HOME=""
+PLUGIN_ARCHIVE=""
+PROFILE_ROOT=""
+PROFILE_CREATED=0
+TEMP_DIR=""
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/prepare-plugin-recommendation-canary-profile.sh \
+  --ide-home <IDE Contents directory> \
+  --plugin-archive <verified canary zip> \
+  --canary-tag <canary/vX.Y.Z-canary.N> \
+  --expected-sha256 <64 lowercase hex characters> \
+  --expected-source-commit <40 lowercase hex characters> \
+  --profile-root <new directory>
+
+Creates a disposable, non-GUI JetBrains 262 profile with a deterministic
+advertiser cache for *.go and *.properties. The source fixture is copied into the
+profile so qualification cannot create .idea or module files in the checkout.
+USAGE
+}
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+cleanup() {
+  local status=$?
+  if [ -n "$TEMP_DIR" ]; then
+    rm -rf "$TEMP_DIR"
+  fi
+  if [ "$status" -ne 0 ] && [ "$PROFILE_CREATED" -eq 1 ]; then
+    rm -rf "$PROFILE_ROOT"
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --ide-home)
+      [ "$#" -ge 2 ] || fail "--ide-home requires a value"
+      IDE_HOME=$2
+      shift 2
+      ;;
+    --plugin-archive)
+      [ "$#" -ge 2 ] || fail "--plugin-archive requires a value"
+      PLUGIN_ARCHIVE=$2
+      shift 2
+      ;;
+    --canary-tag)
+      [ "$#" -ge 2 ] || fail "--canary-tag requires a value"
+      CANARY_TAG=$2
+      shift 2
+      ;;
+    --expected-sha256)
+      [ "$#" -ge 2 ] || fail "--expected-sha256 requires a value"
+      EXPECTED_SHA256=$2
+      shift 2
+      ;;
+    --expected-source-commit)
+      [ "$#" -ge 2 ] || fail "--expected-source-commit requires a value"
+      EXPECTED_SOURCE_COMMIT=$2
+      shift 2
+      ;;
+    --profile-root)
+      [ "$#" -ge 2 ] || fail "--profile-root requires a value"
+      PROFILE_ROOT=$2
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "Unknown argument: $1"
+      ;;
+  esac
+done
+
+for command_name in git jq python3 rg rsync shasum unzip; do
+  command -v "$command_name" >/dev/null 2>&1 || fail "Required command not found: $command_name"
+done
+
+[ -n "$IDE_HOME" ] || fail "--ide-home is required"
+[ -n "$PLUGIN_ARCHIVE" ] || fail "--plugin-archive is required"
+[ -n "$CANARY_TAG" ] || fail "--canary-tag is required"
+[ -n "$EXPECTED_SHA256" ] || fail "--expected-sha256 is required"
+[ -n "$EXPECTED_SOURCE_COMMIT" ] || fail "--expected-source-commit is required"
+[ -n "$PROFILE_ROOT" ] || fail "--profile-root is required"
+[[ "$EXPECTED_SHA256" =~ ^[0-9a-f]{64}$ ]] || fail "--expected-sha256 must be 64 lowercase hex characters"
+[[ "$EXPECTED_SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]] || fail "--expected-source-commit must be 40 lowercase hex characters"
+[[ "$CANARY_TAG" =~ ^canary/v([0-9]+\.[0-9]+\.[0-9]+)-canary\.([1-9][0-9]*)$ ]] || {
+  fail "--canary-tag must use canary/vX.Y.Z-canary.N"
+}
+CANARY_VERSION="${BASH_REMATCH[1]}-canary.${BASH_REMATCH[2]}"
+
+[ -d "$IDE_HOME" ] || fail "IDE home not found: $IDE_HOME"
+IDE_HOME=$(cd "$IDE_HOME" && pwd)
+[ -d "$IDE_HOME/lib" ] || fail "IDE library directory not found: $IDE_HOME/lib"
+[ -f "$IDE_HOME/Resources/product-info.json" ] || fail "IDE product metadata not found"
+[ -f "$PLUGIN_ARCHIVE" ] || fail "Plugin archive not found: $PLUGIN_ARCHIVE"
+PLUGIN_ARCHIVE=$(cd "$(dirname "$PLUGIN_ARCHIVE")" && pwd)/$(basename "$PLUGIN_ARCHIVE")
+PROFILE_ROOT=$(python3 -c 'import os, sys; print(os.path.abspath(sys.argv[1]))' "$PROFILE_ROOT")
+[ ! -e "$PROFILE_ROOT" ] || fail "Profile root must not already exist: $PROFILE_ROOT"
+
+ACTUAL_SHA256=$(shasum -a 256 "$PLUGIN_ARCHIVE" | awk '{print $1}')
+[ "$ACTUAL_SHA256" = "$EXPECTED_SHA256" ] || {
+  fail "Plugin archive SHA-256 $ACTUAL_SHA256 does not match expected $EXPECTED_SHA256"
+}
+"$ROOT/scripts/validate-canary-artifact.sh" \
+  --archive "$PLUGIN_ARCHIVE" \
+  --tag "$CANARY_TAG" \
+  --channel canary
+
+TEMP_DIR=$(mktemp -d)
+PLUGIN_JAR_PATH="jetbrains-inspection-api/lib/jetbrains-inspection-api-$CANARY_VERSION.jar"
+unzip -p "$PLUGIN_ARCHIVE" "$PLUGIN_JAR_PATH" > "$TEMP_DIR/plugin.jar" || {
+  fail "Plugin archive does not contain $PLUGIN_JAR_PATH"
+}
+BUILD_INFO_PATH="com/shiny/inspectionmcp/inspection-build.properties"
+unzip -p "$TEMP_DIR/plugin.jar" "$BUILD_INFO_PATH" > "$TEMP_DIR/inspection-build.properties" || {
+  fail "Plugin jar does not contain $BUILD_INFO_PATH"
+}
+SOURCE_COMMIT=$(sed -n 's/^plugin.build.commit=//p' "$TEMP_DIR/inspection-build.properties")
+SOURCE_DIRTY=$(sed -n 's/^plugin.build.dirty=//p' "$TEMP_DIR/inspection-build.properties")
+SOURCE_VERSION=$(sed -n 's/^plugin.version=//p' "$TEMP_DIR/inspection-build.properties")
+[ "$SOURCE_COMMIT" = "$EXPECTED_SOURCE_COMMIT" ] || {
+  fail "Embedded source commit $SOURCE_COMMIT does not match expected $EXPECTED_SOURCE_COMMIT"
+}
+[ "$SOURCE_DIRTY" = "false" ] || fail "Canary archive must embed plugin.build.dirty=false"
+[ "$SOURCE_VERSION" = "$CANARY_VERSION" ] || {
+  fail "Embedded plugin version $SOURCE_VERSION does not match $CANARY_VERSION"
+}
+
+BUILD_NUMBER=$(jq -r '.buildNumber // empty' "$IDE_HOME/Resources/product-info.json")
+[[ "$BUILD_NUMBER" == 262.* ]] || fail "Expected a 262 IDE, found build '$BUILD_NUMBER'"
+ENV_VAR_BASE_NAME=$(jq -r '.envVarBaseName // empty' "$IDE_HOME/Resources/product-info.json")
+[ -n "$ENV_VAR_BASE_NAME" ] || fail "IDE environment metadata not found"
+VM_OPTIONS_ENV="${ENV_VAR_BASE_NAME}_VM_OPTIONS"
+REMOTE_DEV_SERVER="$IDE_HOME/bin/remote-dev-server.sh"
+[ -x "$REMOTE_DEV_SERVER" ] || fail "Remote development server not found: $REMOTE_DEV_SERVER"
+
+JDK_HOME="$IDE_HOME/jbr"
+if [ -d "$JDK_HOME/Contents/Home" ]; then
+  JDK_HOME="$JDK_HOME/Contents/Home"
+fi
+[ -x "$JDK_HOME/bin/java" ] || fail "IDE runtime java not found"
+[ -x "$JDK_HOME/bin/javac" ] || fail "IDE runtime javac not found"
+
+plugin_id_present() {
+  local plugin_id=$1
+  local descriptor jar plugin_xml
+  while IFS= read -r -d '' descriptor; do
+    if rg -q -F "<id>$plugin_id</id>" "$descriptor"; then
+      return 0
+    fi
+  done < <(find "$IDE_HOME/plugins" -type f -path '*/META-INF/plugin.xml' -print0 2>/dev/null)
+  while IFS= read -r -d '' jar; do
+    plugin_xml=$(unzip -p "$jar" META-INF/plugin.xml 2>/dev/null || true)
+    if [[ "$plugin_xml" == *"<id>$plugin_id</id>"* ]]; then
+      return 0
+    fi
+  done < <(find "$IDE_HOME/plugins" -type f -name '*.jar' -print0)
+  return 1
+}
+
+plugin_id_present "com.intellij.properties" || fail "Selected IDE does not bundle the Properties plugin"
+if plugin_id_present "org.jetbrains.plugins.go"; then
+  fail "Selected IDE bundles the Go plugin; the absent-plugin fixture would be invalid"
+fi
+
+mkdir -p \
+  "$PROFILE_ROOT/config/options" \
+  "$PROFILE_ROOT/system" \
+  "$PROFILE_ROOT/plugins" \
+  "$PROFILE_ROOT/log" \
+  "$PROFILE_ROOT/registry" \
+  "$PROFILE_ROOT/project" \
+  "$PROFILE_ROOT/evidence"
+PROFILE_CREATED=1
+
+SOURCE_FIXTURE="$ROOT/test-fixtures/plugin-recommendation-canary"
+rsync -a \
+  --exclude '.idea/' \
+  --exclude '*.iml' \
+  "$SOURCE_FIXTURE/" \
+  "$PROFILE_ROOT/project/"
+FIXTURE_PROJECT="$PROFILE_ROOT/project"
+FIXTURE_PROJECT_XML=$(printf '%s' "$FIXTURE_PROJECT" | python3 -c 'import html, sys; print(html.escape(sys.stdin.read(), quote=True))')
+
+python3 - "$PLUGIN_ARCHIVE" "$PROFILE_ROOT/plugins" <<'PY'
+from pathlib import Path, PurePosixPath
+import stat
+import sys
+import zipfile
+
+archive = Path(sys.argv[1])
+destination = Path(sys.argv[2]).resolve()
+with zipfile.ZipFile(archive) as plugin_zip:
+    for entry in plugin_zip.infolist():
+        path = PurePosixPath(entry.filename)
+        mode = entry.external_attr >> 16
+        if path.is_absolute() or ".." in path.parts or "\\" in entry.filename:
+            raise SystemExit(f"ERROR: Unsafe archive entry: {entry.filename}")
+        if stat.S_ISLNK(mode):
+            raise SystemExit(f"ERROR: Symlink archive entry is not allowed: {entry.filename}")
+    plugin_zip.extractall(destination)
+PY
+
+cat > "$PROFILE_ROOT/config/options/trusted-paths.xml" <<EOF
+<application>
+  <component name="Trusted.Paths">
+    <option name="TRUSTED_PROJECT_PATHS">
+      <map>
+        <entry key="$FIXTURE_PROJECT_XML" value="true" />
+      </map>
+    </option>
+  </component>
+  <component name="Trusted.Paths.Settings">
+    <option name="TRUSTED_PATHS">
+      <list>
+        <option value="$FIXTURE_PROJECT_XML" />
+      </list>
+    </option>
+  </component>
+</application>
+EOF
+
+cat > "$PROFILE_ROOT/config/options/updates.xml" <<EOF
+<application>
+  <component name="UpdatesConfigurable">
+    <option name="LAST_BUILD_CHECKED" value="$BUILD_NUMBER" />
+    <option name="PLUGINS_AUTO_UPDATE" value="false" />
+    <option name="WHATS_NEW_SHOWN_FOR" value="262" />
+  </component>
+</application>
+EOF
+
+cat > "$PROFILE_ROOT/config/options/ide.general.xml" <<'EOF'
+<application>
+  <component name="GeneralSettings">
+    <option name="confirmExit" value="false" />
+    <option name="showTipsOnStartup" value="false" />
+  </component>
+</application>
+EOF
+
+CLASS_OUTPUT="$TEMP_DIR/classes"
+mkdir -p "$CLASS_OUTPUT"
+"$JDK_HOME/bin/javac" \
+  --release 25 \
+  -cp "$IDE_HOME/lib/*" \
+  -d "$CLASS_OUTPUT" \
+  "$ROOT/scripts/support/PluginRecommendationCanaryProfileSeeder.java"
+"$JDK_HOME/bin/java" \
+  -cp "$CLASS_OUTPUT:$IDE_HOME/lib/*" \
+  PluginRecommendationCanaryProfileSeeder write "$PROFILE_ROOT/config"
+
+JVM_PROPERTY_PREFIX=-D
+VM_OPTIONS_FILE="$PROFILE_ROOT/qualification.vm-options"
+printf '%s\n' \
+  "${JVM_PROPERTY_PREFIX}idea.config.path=$PROFILE_ROOT/config" \
+  "${JVM_PROPERTY_PREFIX}idea.system.path=$PROFILE_ROOT/system" \
+  "${JVM_PROPERTY_PREFIX}idea.plugins.path=$PROFILE_ROOT/plugins" \
+  "${JVM_PROPERTY_PREFIX}idea.log.path=$PROFILE_ROOT/log" \
+  "${JVM_PROPERTY_PREFIX}idea.suppressed.plugins.id=com.intellij.properties" \
+  "${JVM_PROPERTY_PREFIX}idea.plugins.host=http://127.0.0.1:1" \
+  "${JVM_PROPERTY_PREFIX}ide.no.platform.update=true" \
+  "${JVM_PROPERTY_PREFIX}ide.show.tips.on.startup.default.value=false" \
+  > "$VM_OPTIONS_FILE"
+
+{
+  echo '#!/usr/bin/env bash'
+  echo 'set -euo pipefail'
+  printf 'export JETBRAINS_INSPECTION_REGISTRY_DIR=%q\n' "$PROFILE_ROOT/registry"
+  printf 'export %s=%q\n' "$VM_OPTIONS_ENV" "$VM_OPTIONS_FILE"
+  echo 'export REMOTE_DEV_TRUST_PROJECTS=1'
+  echo 'export REMOTE_DEV_NON_INTERACTIVE=1'
+  printf 'exec %q run %q\n' "$REMOTE_DEV_SERVER" "$FIXTURE_PROJECT"
+} > "$PROFILE_ROOT/launch-headless.sh"
+chmod +x "$PROFILE_ROOT/launch-headless.sh"
+
+jq -n \
+  --arg canary_tag "$CANARY_TAG" \
+  --arg canary_version "$CANARY_VERSION" \
+  --arg expected_sha256 "$EXPECTED_SHA256" \
+  --arg source_commit "$SOURCE_COMMIT" \
+  --arg ide_home "$IDE_HOME" \
+  --arg ide_build "$BUILD_NUMBER" \
+  --arg plugin_archive "$PLUGIN_ARCHIVE" \
+  --arg profile_root "$PROFILE_ROOT" \
+  --arg fixture_project "$FIXTURE_PROJECT" \
+  --arg headless_launcher "$PROFILE_ROOT/launch-headless.sh" \
+  --arg registry_dir "$PROFILE_ROOT/registry" \
+  --arg vm_options "$VM_OPTIONS_FILE" \
+  '{
+    schema_version: 1,
+    canary_tag: $canary_tag,
+    canary_version: $canary_version,
+    artifact_sha256: $expected_sha256,
+    source_commit: $source_commit,
+    ide_home: $ide_home,
+    ide_build: $ide_build,
+    plugin_archive: $plugin_archive,
+    profile_root: $profile_root,
+    fixture_project: $fixture_project,
+    headless_launcher: $headless_launcher,
+    registry_dir: $registry_dir,
+    vm_options: $vm_options
+  }' > "$PROFILE_ROOT/qualification.json"
+
+{
+  printf 'CANARY_TAG=%q\n' "$CANARY_TAG"
+  printf 'CANARY_VERSION=%q\n' "$CANARY_VERSION"
+  printf 'CANARY_ARTIFACT_SHA256=%q\n' "$EXPECTED_SHA256"
+  printf 'CANARY_SOURCE_COMMIT=%q\n' "$SOURCE_COMMIT"
+  printf 'CANARY_IDE_HOME=%q\n' "$IDE_HOME"
+  printf 'CANARY_IDE_BUILD=%q\n' "$BUILD_NUMBER"
+  printf 'CANARY_PLUGIN_ARCHIVE=%q\n' "$PLUGIN_ARCHIVE"
+  printf 'CANARY_PROFILE_ROOT=%q\n' "$PROFILE_ROOT"
+  printf 'CANARY_FIXTURE_PROJECT=%q\n' "$FIXTURE_PROJECT"
+  printf 'CANARY_HEADLESS_LAUNCHER=%q\n' "$PROFILE_ROOT/launch-headless.sh"
+} > "$PROFILE_ROOT/qualification.env"
+
+echo "Prepared deterministic canary profile: $PROFILE_ROOT"
+echo "IDE build: $BUILD_NUMBER"
+echo "Artifact SHA-256: $EXPECTED_SHA256"
+echo "Source commit: $SOURCE_COMMIT"
+echo "Headless launcher: $PROFILE_ROOT/launch-headless.sh"
+echo "Fixture copy: $FIXTURE_PROJECT"
+echo "Expected main.go: recommended / org.jetbrains.plugins.go / absent"
+echo "Expected disabled.canary.properties: recommended / com.intellij.properties / disabled"

--- a/scripts/support/PluginRecommendationCanaryProfileSeeder.java
+++ b/scripts/support/PluginRecommendationCanaryProfileSeeder.java
@@ -1,0 +1,166 @@
+import com.intellij.openapi.application.impl.ApplicationInfoImpl;
+import com.intellij.openapi.extensions.PluginId;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import kotlinx.serialization.DeserializationStrategy;
+import kotlinx.serialization.SerializationStrategy;
+import kotlinx.serialization.cbor.Cbor;
+import org.h2.mvstore.MVMap;
+import org.h2.mvstore.MVStore;
+
+public final class PluginRecommendationCanaryProfileSeeder {
+    private static final String CACHE_MAP = "cache_v3";
+    private static final String CACHE_KEY = "com.intellij.pluginAdvertiserExtensions";
+    private static final String GO_EXTENSION = "*.go";
+    private static final String PROPERTIES_EXTENSION = "*.properties";
+
+    private PluginRecommendationCanaryProfileSeeder() {
+    }
+
+    public static void main(String[] args) {
+        try {
+            run(args);
+        } catch (Exception error) {
+            throw new IllegalStateException(error.getMessage(), error);
+        }
+    }
+
+    private static void run(String[] args) throws Exception {
+        if (args.length != 2 || !(args[0].equals("write") || args[0].equals("verify"))) {
+            throw new IllegalArgumentException("Usage: PluginRecommendationCanaryProfileSeeder <write|verify> <config-dir>");
+        }
+
+        var configDirectory = Path.of(args[1]).toAbsolutePath().normalize();
+        var database = configDirectory.resolve("app-internal-state.db");
+        switch (args[0]) {
+            case "write" -> {
+                write(database);
+            }
+            case "verify" -> {
+                verify(database);
+            }
+            default -> {
+                throw new IllegalArgumentException("Unsupported command: " + args[0]);
+            }
+        }
+    }
+
+    private static void write(Path database) throws Exception {
+        if (Files.exists(database)) {
+            throw new IllegalStateException("Refusing to replace existing state database: " + database);
+        }
+        if (ApplicationInfoImpl.getShadowInstance().isEssentialPlugin(PluginId.getId("com.intellij.properties"))) {
+            throw new IllegalStateException("Selected IDE treats com.intellij.properties as essential");
+        }
+        Files.createDirectories(database.getParent());
+
+        var plugins = expectedPlugins();
+        var state = newState(plugins);
+        var encodedState = cbor().encodeToByteArray(serializer(), state);
+
+        var store = new MVStore.Builder().fileName(database.toString()).open();
+        try {
+            openCacheMap(store).put(CACHE_KEY, encodedState);
+            store.commit();
+        } finally {
+            store.close();
+        }
+        verify(database);
+    }
+
+    private static void verify(Path database) throws Exception {
+        if (!Files.isRegularFile(database)) {
+            throw new IllegalStateException("Missing state database: " + database);
+        }
+
+        var store = new MVStore.Builder().fileName(database.toString()).readOnly().open();
+        try {
+            var encodedState = openCacheMap(store).get(CACHE_KEY);
+            if (encodedState == null) {
+                throw new IllegalStateException("Missing advertiser cache key: " + CACHE_KEY);
+            }
+            var state = cbor().decodeFromByteArray(deserializer(), encodedState);
+            var actualPlugins = plugins(state);
+            var expectedPlugins = expectedPlugins();
+            if (!actualPlugins.equals(expectedPlugins)) {
+                throw new IllegalStateException("Unexpected advertiser cache: " + actualPlugins);
+            }
+            System.out.println("advertiser_cache=" + CACHE_KEY);
+            System.out.println("cache_entries=" + actualPlugins.size());
+            System.out.println(GO_EXTENSION + "=" + actualPlugins.get(GO_EXTENSION));
+            System.out.println(PROPERTIES_EXTENSION + "=" + actualPlugins.get(PROPERTIES_EXTENSION));
+        } finally {
+            store.close();
+        }
+    }
+
+    private static LinkedHashMap<String, Object> expectedPlugins() throws Exception {
+        var pluginDataClass = Class.forName("com.intellij.ide.plugins.advertiser.PluginData");
+        var constructor = pluginDataClass.getConstructor(
+            String.class,
+            String.class,
+            boolean.class,
+            boolean.class
+        );
+        var plugins = new LinkedHashMap<String, Object>();
+        plugins.put(GO_EXTENSION, constructor.newInstance("org.jetbrains.plugins.go", "Go", false, false));
+        plugins.put(
+            PROPERTIES_EXTENSION,
+            constructor.newInstance("com.intellij.properties", "Properties", true, false)
+        );
+        return plugins;
+    }
+
+    private static Object newState(LinkedHashMap<String, Object> plugins) throws Exception {
+        var stateClass = stateClass();
+        var constructor = stateClass.getDeclaredConstructor(LinkedHashMap.class);
+        constructor.setAccessible(true);
+        return constructor.newInstance(plugins);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> plugins(Object state) throws Exception {
+        var field = stateClass().getDeclaredField("plugins");
+        field.setAccessible(true);
+        return (Map<String, Object>) field.get(state);
+    }
+
+    private static Class<?> stateClass() throws ClassNotFoundException {
+        return Class.forName(
+            "com.intellij.openapi.updateSettings.impl.pluginsAdvertisement.PluginAdvertiserExtensionsState"
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    private static SerializationStrategy<Object> serializer() throws Exception {
+        return (SerializationStrategy<Object>) serializerObject();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static DeserializationStrategy<Object> deserializer() throws Exception {
+        return (DeserializationStrategy<Object>) serializerObject();
+    }
+
+    private static Object serializerObject() throws Exception {
+        var companionField = stateClass().getDeclaredField("Companion");
+        companionField.setAccessible(true);
+        var companion = companionField.get(null);
+        var serializerMethod = companion.getClass().getMethod("serializer");
+        return serializerMethod.invoke(companion);
+    }
+
+    private static Cbor cbor() throws Exception {
+        var storageHelpers = Class.forName("com.intellij.platform.settings.local.InternalStateStorageServiceKt");
+        return (Cbor) storageHelpers.getMethod("getCborFormat").invoke(null);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static MVMap<String, byte[]> openCacheMap(MVStore store) throws Exception {
+        var mapHelpers = Class.forName("com.intellij.platform.settings.local.MvMapManagerKt");
+        var openMap = mapHelpers.getDeclaredMethod("access$openMap", MVStore.class, String.class);
+        openMap.setAccessible(true);
+        return (MVMap<String, byte[]>) openMap.invoke(null, store, CACHE_MAP);
+    }
+}

--- a/scripts/test-plugin-recommendation-canary-profile.sh
+++ b/scripts/test-plugin-recommendation-canary-profile.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+IDE_HOME=${CANARY_TEST_IDE_HOME:-}
+
+if [ -z "$IDE_HOME" ]; then
+  echo "SKIP: Set CANARY_TEST_IDE_HOME to a JetBrains 262 Contents directory."
+  exit 0
+fi
+
+JDK_HOME="$IDE_HOME/jbr"
+if [ -d "$JDK_HOME/Contents/Home" ]; then
+  JDK_HOME="$JDK_HOME/Contents/Home"
+fi
+
+TEMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TEMP_DIR"' EXIT
+CLASS_OUTPUT="$TEMP_DIR/classes"
+CONFIG_DIR="$TEMP_DIR/config"
+mkdir -p "$CLASS_OUTPUT" "$CONFIG_DIR"
+
+"$JDK_HOME/bin/javac" \
+  --release 25 \
+  -cp "$IDE_HOME/lib/*" \
+  -d "$CLASS_OUTPUT" \
+  "$ROOT/scripts/support/PluginRecommendationCanaryProfileSeeder.java"
+
+WRITE_OUTPUT=$("$JDK_HOME/bin/java" \
+  -cp "$CLASS_OUTPUT:$IDE_HOME/lib/*" \
+  PluginRecommendationCanaryProfileSeeder write "$CONFIG_DIR")
+VERIFY_OUTPUT=$("$JDK_HOME/bin/java" \
+  -cp "$CLASS_OUTPUT:$IDE_HOME/lib/*" \
+  PluginRecommendationCanaryProfileSeeder verify "$CONFIG_DIR")
+
+[ "$WRITE_OUTPUT" = "$VERIFY_OUTPUT" ] || {
+  echo "ERROR: cache verification output changed after reopening the database" >&2
+  exit 1
+}
+printf '%s\n' "$VERIFY_OUTPUT" | rg -q -F 'cache_entries=2'
+printf '%s\n' "$VERIFY_OUTPUT" | rg -q -F '*.go=PluginData(pluginIdString=org.jetbrains.plugins.go'
+printf '%s\n' "$VERIFY_OUTPUT" | rg -q -F '*.properties=PluginData(pluginIdString=com.intellij.properties'
+
+if "$JDK_HOME/bin/java" \
+  -cp "$CLASS_OUTPUT:$IDE_HOME/lib/*" \
+  PluginRecommendationCanaryProfileSeeder write "$CONFIG_DIR" >/dev/null 2>&1; then
+  echo "ERROR: seeder replaced an existing state database" >&2
+  exit 1
+fi
+
+echo "Plugin recommendation canary profile seeder test passed."

--- a/test-fixtures/plugin-recommendation-canary/FIXTURE.md
+++ b/test-fixtures/plugin-recommendation-canary/FIXTURE.md
@@ -1,13 +1,25 @@
 # Private Plugin Recommendation Canary Fixture
 
-This fixture is read-only evidence for issue #273.
+This fixture is read-only evidence for issues #273 and #274.
 
 - `main.go` recreates the issue #263 missing-Go-plugin recommendation case.
 - `Main.java` exercises an already-installed bundled language plugin.
-- `main.js` exercises installed and isolated-config disabled-plugin states in PyCharm.
+- `main.js` preserves the previously qualified installed-plugin case.
+- `disabled.canary.properties` deterministically exercises the
+  installed-but-disabled state with the bundled Properties plugin in an
+  isolated profile.
 - `main.rs` provides an additional missing-plugin/cold-cache probe.
 - `irrelevant.canary_fixture` exercises the no-recommendation path.
 
 The canary endpoint accepts only project file paths and never accepts plugin IDs.
 Opening these files or querying the endpoint must not install, enable, disable,
 download, update, or prompt for plugins.
+
+For deterministic `recommended` coverage, prepare a disposable JetBrains 262
+profile with `scripts/prepare-plugin-recommendation-canary-profile.sh`. The
+profile contains only two advertiser-cache rows: `*.go` maps to the absent Go
+plugin, and `*.properties` maps to the bundled Properties plugin while that plugin is
+disabled in the isolated profile. The script refuses existing profiles,
+products that bundle Go, and products without Properties; it never reads or
+changes the operator's normal IDE configuration or writes project metadata into
+the source fixture.

--- a/test-fixtures/plugin-recommendation-canary/disabled.canary.properties
+++ b/test-fixtures/plugin-recommendation-canary/disabled.canary.properties
@@ -1,0 +1,1 @@
+canary.state=disabled


### PR DESCRIPTION
## Summary

- add a deterministic two-row JetBrains 262 advertiser-cache fixture for absent Go and disabled Properties recommendations
- require the exact trusted archive digest, embedded clean source commit, canary tag, and 262 artifact identity before profile creation
- copy the fixture into a disposable profile and run through the non-GUI remote-development backend so qualification cannot create project metadata in the source tree or show IDE popups
- isolate plugin state, block Marketplace cache refreshes, verify cache contents after the run, and document the evidence procedure

## Qualification Evidence

Using the trusted artifact from canary release run `31334693870`:

- SHA-256: `3153c695ec204cd24f97da71aae2e8929d6868f10db6e305c685251155bbdee4`
- embedded source: `61e74b59d8adae9f684ff911c8baf6e3a6fe24f1-clean`
- IDE: PyCharm `262.8665.369`
- `main.go`: `recommended`, `org.jetbrains.plugins.go`, `absent`
- `disabled.canary.properties`: `recommended`, `com.intellij.properties`, `disabled`
- `irrelevant.canary_fixture`: `none`, `no_recommendation`
- post-run advertiser cache verification: exact two-row equality

No local IDE window was opened; the backend route and fixture copy were isolated under a disposable profile.

## Validation

- `bash -n scripts/prepare-plugin-recommendation-canary-profile.sh scripts/test-plugin-recommendation-canary-profile.sh`
- `shellcheck --severity=warning scripts/prepare-plugin-recommendation-canary-profile.sh scripts/test-plugin-recommendation-canary-profile.sh`
- `CANARY_TEST_IDE_HOME="$HOME/Applications/PyCharm.app/Contents" ./scripts/test-plugin-recommendation-canary-profile.sh`
- wrong-digest fail-closed profile preparation check
- `./scripts/test-release-contracts.sh`
- `JAVA_HOME="$HOME/Applications/PyCharm.app/Contents/jbr/Contents/Home" ./gradlew :test --tests 'com.shiny.inspectionmcp.PrivatePluginRecommendationProbeTest' --tests 'com.shiny.inspectionmcp.PrivatePluginRecommendationBoundaryTest' --tests 'com.shiny.inspectionmcp.PrivatePluginRecommendationEndpointTest'`
- commit gate hook: root tests, inspection-core tests, MCP server tests, and `buildPlugin`

JetBrains changed-files inspection was attempted twice. Both runs were fail-closed `UNKNOWN` because the helper-owned lifecycle generated `.idea/editor.xml` in the worktree; cleanup closed and the generated file was removed. The reports contained only advisory proofreading/style suggestions for the qualification scripts/helper, not a runtime defect.

Refs #274
