### PR TITLE
Prepare 1.14.0-canary.2 candidate

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion=1.14.0-canary.1
+pluginVersion=1.14.0-canary.2
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
 kotlin.stdlib.default.dependency=false
 # Enable Gradle Configuration Cache -> https://docs.gradle.org/current/userguide/configuration_cache.html

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.shiny.inspection.api</id>
     <name>Inspection API</name>
-    <version>1.14.0-canary.1</version>
+    <version>1.14.0-canary.2</version>
     <vendor email="info@shinycomputers.com" url="https://github.com/cbusillo/jetbrains-inspection-api">Shiny Computers (Chris Busillo)</vendor>
     <resource-bundle>messages.InspectionApiBundle</resource-bundle>
     
@@ -27,7 +27,7 @@
     ]]></description>
     
     <change-notes><![CDATA[
-        <b>Version 1.14.0-canary.1</b>
+        <b>Version 1.14.0-canary.2</b>
         <ul>
             <li>Adds a read-only 262-only experiment exposing IDE-derived plugin recommendations for explicitly selected project files.</li>
             <li>Keeps recommendation metadata separate from inspection verdict, execution proof, freshness, retry, routing, and cleanup semantics.</li>


### PR DESCRIPTION
## Summary
- bump the isolated canary version to `1.14.0-canary.2`
- keep Gradle, plugin metadata, and Marketplace-visible change notes aligned
- preserve the immutable `canary/v1.14.0-canary.1` tag and prior evidence

## Validation
- `./scripts/validate-canary-release-version.sh --repo . --tag canary/v1.14.0-canary.2 --channel canary`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew --no-daemon buildPlugin verifyPluginStructure`
- commit gate hook, including root/core/MCP tests, release contracts, and `buildPlugin`
- independent Opus and Gemini release-path reviews: READY, no blockers

Refs #274