### PR TITLE
Publish Stable releases from one verified artifact

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -33,6 +33,8 @@
       "verifyPluginCompatibility": "./gradlew verifyPlugin",
       "releaseCompatibilityGate": "./scripts/release-compatibility-gate.sh",
       "validateReleaseVersion": "./scripts/validate-release-version.sh --tag vX.Y.Z",
+      "verifyStableArtifact": "./scripts/verify-stable-artifact.sh --archive /path/to/jetbrains-inspection-api-X.Y.Z.zip --tag vX.Y.Z --source-sha <40-character-source-sha>",
+      "publishStableArtifact": "PUBLISH_TOKEN=$PUBLISH_TOKEN ./scripts/publish-stable-artifact.sh --archive /path/to/jetbrains-inspection-api-X.Y.Z.zip --tag vX.Y.Z --expected-sha256 <verified-sha256> --source-sha <40-character-source-sha>",
       "validateCanaryReleaseVersion": "./scripts/validate-canary-release-version.sh --tag canary/vX.Y.Z-canary.N --channel canary",
       "verifyCanaryArtifact": "MARKETPLACE_CHANNEL=canary ./scripts/verify-canary-artifact.sh --archive /path/to/jetbrains-inspection-api-X.Y.Z-canary.N.zip --tag canary/vX.Y.Z-canary.N --channel canary --source-sha <40-character-source-sha>",
       "publishCanaryArtifact": "PUBLISH_TOKEN=$CANARY_PUBLISH_TOKEN MARKETPLACE_CHANNEL=canary ./scripts/publish-canary-artifact.sh --archive /path/to/jetbrains-inspection-api-X.Y.Z-canary.N.zip --tag canary/vX.Y.Z-canary.N --channel canary --expected-sha256 <verified-sha256> --source-sha <40-character-source-sha>",

--- a/.github/github.json
+++ b/.github/github.json
@@ -59,10 +59,10 @@
     "releaseCompatibility": {
       "jetbrainsBuildRange": "251-262.*",
       "automatedTagGate": [
+        "qualityGate.test.commitGate",
         "qualityGate.build.buildPlugin",
         "qualityGate.build.verifyPluginStructure",
-        "qualityGate.build.verifyPluginCompatibility",
-        "qualityGate.build.releaseCompatibilityGate"
+        "qualityGate.build.verifyStableArtifact"
       ],
       "manualEvidenceFor262": [
         "qualityGate.manualSmoke.redLaneDogfoodIntelliJ",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,41 +8,54 @@ name: Release
 
 run-name: "Release ${{ github.ref_name }}"
 
+concurrency:
+  group: "release-${{ github.ref_name }}"
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    outputs:
+      source_sha: ${{ steps.source.outputs.sha }}
+      version: ${{ steps.release_version.outputs.version }}
 
     steps:
-      - uses: actions/checkout@v7
+      - name: Check out exact release source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
 
       - name: Validate release version
-        run: ./scripts/validate-release-version.sh --tag "$GITHUB_REF_NAME"
+        id: release_version
+        run: |
+          version="$(./scripts/validate-release-version.sh --tag "$GITHUB_REF_NAME")"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
-      - name: Verify tag commit is current default branch
+      - name: Verify exact tag and current default branch
+        id: source
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
-          git fetch origin "$DEFAULT_BRANCH"
+          git fetch origin "refs/tags/$GITHUB_REF_NAME:refs/tags/$GITHUB_REF_NAME" "$DEFAULT_BRANCH"
+          test "$(git rev-parse HEAD)" = "$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")"
           test "$(git rev-parse HEAD)" = "$(git rev-parse "origin/$DEFAULT_BRANCH")"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Set up JDK 21
-        uses: actions/setup-java@v5
+      - name: Set up JDK 25
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
-          java-version: "21"
+          java-version: "25"
           distribution: "temurin"
-          cache: "gradle"
-
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
 
       - name: Run commit gate
         run: ./scripts/commit-gate.sh --ci
 
       - name: Upload test results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: test-results
@@ -52,50 +65,237 @@ jobs:
             mcp-server-jvm/build/reports/tests/test/
           retention-days: 7
 
-  release:
+  package:
     needs: [test]
+    runs-on: ubuntu-latest
+    env:
+      GRADLE_OPTS: "-Dorg.gradle.caching=false"
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out captured release source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ needs.test.outputs.source_sha }}
+
+      - name: Revalidate exact release source
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          EXPECTED_SOURCE_SHA: ${{ needs.test.outputs.source_sha }}
+        run: |
+          git fetch origin "refs/tags/$GITHUB_REF_NAME:refs/tags/$GITHUB_REF_NAME" "$DEFAULT_BRANCH"
+          test "$(git rev-parse HEAD)" = "$EXPECTED_SOURCE_SHA"
+          test "$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")" = "$EXPECTED_SOURCE_SHA"
+          test "$(git rev-parse "origin/$DEFAULT_BRANCH")" = "$EXPECTED_SOURCE_SHA"
+          test -x gradlew
+          test -z "$(git status --porcelain --untracked-files=all)"
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          java-version: "25"
+          distribution: "temurin"
+
+      - name: Build clean Stable artifact
+        run: ./gradlew --no-build-cache buildPlugin verifyPluginStructure
+
+      - name: Validate clean Stable artifact
+        env:
+          EXPECTED_SOURCE_SHA: ${{ needs.test.outputs.source_sha }}
+        run: |
+          scripts/validate-stable-artifact.sh \
+            --archive "build/distributions/jetbrains-inspection-api-${{ needs.test.outputs.version }}.zip" \
+            --tag "$GITHUB_REF_NAME" \
+            --source-sha "$EXPECTED_SOURCE_SHA"
+
+      - name: Upload Stable plugin artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: stable-plugin-${{ needs.test.outputs.version }}
+          path: build/distributions/jetbrains-inspection-api-${{ needs.test.outputs.version }}.zip
+          if-no-files-found: error
+          retention-days: 7
+
+  verify:
+    needs: [test, package]
+    runs-on: ubuntu-latest
+    outputs:
+      plugin_zip_sha256: ${{ steps.archive_digest.outputs.sha256 }}
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out trusted verification controls
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ needs.test.outputs.source_sha }}
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          java-version: "21"
+          distribution: "temurin"
+
+      - name: Download Stable plugin artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: stable-plugin-${{ needs.test.outputs.version }}
+          path: artifact
+
+      - name: Revalidate release tag provenance
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          EXPECTED_SOURCE_SHA: ${{ needs.test.outputs.source_sha }}
+        run: |
+          git fetch origin "refs/tags/$GITHUB_REF_NAME:refs/tags/$GITHUB_REF_NAME" "$DEFAULT_BRANCH"
+          test "$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")" = "$EXPECTED_SOURCE_SHA"
+          test "$(git rev-parse "origin/$DEFAULT_BRANCH")" = "$EXPECTED_SOURCE_SHA"
+
+      - name: Independently verify Stable artifact
+        env:
+          EXPECTED_SOURCE_SHA: ${{ needs.test.outputs.source_sha }}
+        run: |
+          scripts/verify-stable-artifact.sh \
+            --archive "artifact/jetbrains-inspection-api-${{ needs.test.outputs.version }}.zip" \
+            --tag "$GITHUB_REF_NAME" \
+            --source-sha "$EXPECTED_SOURCE_SHA"
+
+      - name: Record verified plugin zip digest
+        id: archive_digest
+        run: |
+          archive="artifact/jetbrains-inspection-api-${{ needs.test.outputs.version }}.zip"
+          echo "sha256=$(shasum -a 256 "$archive" | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+
+      - name: Upload trusted Plugin Verifier reports
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: always()
+        with:
+          name: stable-plugin-verifier-${{ needs.test.outputs.version }}
+          path: build/reports/pluginVerifier/
+          if-no-files-found: warn
+          retention-days: 30
+
+  release:
+    needs: [test, package, verify]
     runs-on: ubuntu-latest
     permissions:
       contents: write
 
     steps:
-      - uses: actions/checkout@v7
+      - name: Check out trusted release controls
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ needs.test.outputs.source_sha }}
 
-      - name: Validate release version
-        id: release_version
-        run: |
-          version="$(./scripts/validate-release-version.sh --tag "$GITHUB_REF_NAME")"
-          echo "tag_name=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Download verified Stable plugin artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: stable-plugin-${{ needs.test.outputs.version }}
+          path: artifact
 
-      - name: Verify tag commit is current default branch
+      - name: Revalidate verified artifact and tag
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          EXPECTED_PLUGIN_ZIP_SHA256: ${{ needs.verify.outputs.plugin_zip_sha256 }}
+          EXPECTED_SOURCE_SHA: ${{ needs.test.outputs.source_sha }}
         run: |
-          git fetch origin "$DEFAULT_BRANCH"
-          test "$(git rev-parse HEAD)" = "$(git rev-parse "origin/$DEFAULT_BRANCH")"
+          archive="artifact/jetbrains-inspection-api-${{ needs.test.outputs.version }}.zip"
+          actual_sha256="$(shasum -a 256 "$archive" | awk '{print $1}')"
+          test "$actual_sha256" = "$EXPECTED_PLUGIN_ZIP_SHA256"
+          git fetch origin "refs/tags/$GITHUB_REF_NAME:refs/tags/$GITHUB_REF_NAME" "$DEFAULT_BRANCH"
+          test "$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")" = "$EXPECTED_SOURCE_SHA"
+          test "$(git rev-parse "origin/$DEFAULT_BRANCH")" = "$EXPECTED_SOURCE_SHA"
+          scripts/validate-stable-artifact.sh \
+            --archive "$archive" \
+            --tag "$GITHUB_REF_NAME" \
+            --source-sha "$EXPECTED_SOURCE_SHA"
 
-      - name: Set up JDK 21
-        uses: actions/setup-java@v5
-        with:
-          java-version: "21"
-          distribution: "temurin"
-
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-
-      - name: Run release compatibility gate
-        run: ./scripts/release-compatibility-gate.sh
-
-      - name: Generate release notes
-        run: |
-          scripts/generate-release-notes.sh \
-            --version "${{ steps.release_version.outputs.version }}" \
-            --output release-notes.md
+      - name: Generate release notes outside source checkout
         env:
           GH_TOKEN: ${{ github.token }}
+          PLUGIN_ZIP_SHA256: ${{ needs.verify.outputs.plugin_zip_sha256 }}
+          SOURCE_SHA: ${{ needs.test.outputs.source_sha }}
+        run: |
+          notes_file="$RUNNER_TEMP/release-notes.md"
+          scripts/generate-release-notes.sh \
+            --version "${{ needs.test.outputs.version }}" \
+            --output "$notes_file"
+          printf '\nSource commit: %s\nPlugin archive SHA-256: %s\n' \
+            "$SOURCE_SHA" \
+            "$PLUGIN_ZIP_SHA256" \
+            >> "$notes_file"
+          {
+            echo "Source commit: \`$SOURCE_SHA\`"
+            echo "Plugin archive SHA-256: \`$PLUGIN_ZIP_SHA256\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Create or update GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          archive="artifact/jetbrains-inspection-api-${{ needs.test.outputs.version }}.zip"
+          notes_file="$RUNNER_TEMP/release-notes.md"
+          if gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release upload "$GITHUB_REF_NAME" "$archive" --clobber --repo "$GITHUB_REPOSITORY"
+            gh release edit "$GITHUB_REF_NAME" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "Release $GITHUB_REF_NAME" \
+              --notes-file "$notes_file" \
+              --draft=false \
+              --prerelease=false \
+              --latest
+          else
+            gh release create "$GITHUB_REF_NAME" "$archive" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "Release $GITHUB_REF_NAME" \
+              --notes-file "$notes_file" \
+              --latest \
+              --verify-tag
+          fi
+
+  publish:
+    needs: [test, package, verify, release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out trusted publication controls
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ needs.test.outputs.source_sha }}
+
+      - name: Download verified Stable plugin artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: stable-plugin-${{ needs.test.outputs.version }}
+          path: artifact
+
+      - name: Revalidate verified artifact and tag
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          EXPECTED_PLUGIN_ZIP_SHA256: ${{ needs.verify.outputs.plugin_zip_sha256 }}
+          EXPECTED_SOURCE_SHA: ${{ needs.test.outputs.source_sha }}
+        run: |
+          archive="artifact/jetbrains-inspection-api-${{ needs.test.outputs.version }}.zip"
+          actual_sha256="$(shasum -a 256 "$archive" | awk '{print $1}')"
+          test "$actual_sha256" = "$EXPECTED_PLUGIN_ZIP_SHA256"
+          git fetch origin "refs/tags/$GITHUB_REF_NAME:refs/tags/$GITHUB_REF_NAME" "$DEFAULT_BRANCH"
+          test "$(git rev-parse "refs/tags/$GITHUB_REF_NAME^{commit}")" = "$EXPECTED_SOURCE_SHA"
+          test "$(git rev-parse "origin/$DEFAULT_BRANCH")" = "$EXPECTED_SOURCE_SHA"
+          scripts/validate-stable-artifact.sh \
+            --archive "$archive" \
+            --tag "$GITHUB_REF_NAME" \
+            --source-sha "$EXPECTED_SOURCE_SHA"
 
       - name: Verify Marketplace token
         env:
@@ -106,18 +306,14 @@ jobs:
             exit 1
           fi
 
-      - name: Create GitHub Release
-        id: create_release
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: ${{ steps.release_version.outputs.tag_name }}
-          name: Release ${{ steps.release_version.outputs.tag_name }}
-          body_path: release-notes.md
-          draft: false
-          prerelease: false
-          files: ./build/distributions/*.zip
-
-      - name: Publish to JetBrains Marketplace
+      - name: Publish verified Stable artifact to JetBrains Marketplace
         env:
+          EXPECTED_PLUGIN_ZIP_SHA256: ${{ needs.verify.outputs.plugin_zip_sha256 }}
+          EXPECTED_SOURCE_SHA: ${{ needs.test.outputs.source_sha }}
           PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
-        run: ./gradlew publishPlugin
+        run: |
+          scripts/publish-stable-artifact.sh \
+            --archive "artifact/jetbrains-inspection-api-${{ needs.test.outputs.version }}.zip" \
+            --tag "$GITHUB_REF_NAME" \
+            --expected-sha256 "$EXPECTED_PLUGIN_ZIP_SHA256" \
+            --source-sha "$EXPECTED_SOURCE_SHA"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,10 @@ jobs:
           test "$(git rev-parse HEAD)" = "$(git rev-parse "origin/$DEFAULT_BRANCH")"
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Set up JDK 25
+      - name: Set up JDK 21
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
-          java-version: "25"
+          java-version: "21"
           distribution: "temurin"
 
       - name: Run commit gate
@@ -93,10 +93,10 @@ jobs:
           test -x gradlew
           test -z "$(git status --porcelain --untracked-files=all)"
 
-      - name: Set up JDK 25
+      - name: Set up JDK 21
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
-          java-version: "25"
+          java-version: "21"
           distribution: "temurin"
 
       - name: Build clean Stable artifact
@@ -217,7 +217,19 @@ jobs:
             --tag "$GITHUB_REF_NAME" \
             --source-sha "$EXPECTED_SOURCE_SHA"
 
+      - name: Determine GitHub Release state
+        id: release_state
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Generate release notes outside source checkout
+        if: steps.release_state.outputs.exists != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PLUGIN_ZIP_SHA256: ${{ needs.verify.outputs.plugin_zip_sha256 }}
@@ -231,34 +243,54 @@ jobs:
             "$SOURCE_SHA" \
             "$PLUGIN_ZIP_SHA256" \
             >> "$notes_file"
-          {
-            echo "Source commit: \`$SOURCE_SHA\`"
-            echo "Plugin archive SHA-256: \`$PLUGIN_ZIP_SHA256\`"
-          } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Create or update GitHub Release
+      - name: Create or reuse GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          archive="artifact/jetbrains-inspection-api-${{ needs.test.outputs.version }}.zip"
           notes_file="$RUNNER_TEMP/release-notes.md"
-          if gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            gh release upload "$GITHUB_REF_NAME" "$archive" --clobber --repo "$GITHUB_REPOSITORY"
-            gh release edit "$GITHUB_REF_NAME" \
-              --repo "$GITHUB_REPOSITORY" \
-              --title "Release $GITHUB_REF_NAME" \
-              --notes-file "$notes_file" \
-              --draft=false \
-              --prerelease=false \
-              --latest
-          else
-            gh release create "$GITHUB_REF_NAME" "$archive" \
+          if [ "${{ steps.release_state.outputs.exists }}" != "true" ]; then
+            gh release create "$GITHUB_REF_NAME" \
               --repo "$GITHUB_REPOSITORY" \
               --title "Release $GITHUB_REF_NAME" \
               --notes-file "$notes_file" \
               --latest \
               --verify-tag
           fi
+
+      - name: Attach or verify GitHub Release artifact
+        env:
+          EXPECTED_PLUGIN_ZIP_SHA256: ${{ needs.verify.outputs.plugin_zip_sha256 }}
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ needs.test.outputs.source_sha }}
+        run: |
+          archive="artifact/jetbrains-inspection-api-${{ needs.test.outputs.version }}.zip"
+          archive_name="$(basename "$archive")"
+          release_json="$(gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --json assets)"
+          asset_count="$(jq --arg name "$archive_name" '[.assets[] | select(.name == $name)] | length' <<< "$release_json")"
+          test "$asset_count" -le 1
+
+          if [ "$asset_count" -eq 1 ]; then
+            existing_dir="$RUNNER_TEMP/existing-release-asset"
+            rm -rf "$existing_dir"
+            mkdir -p "$existing_dir"
+            gh release download "$GITHUB_REF_NAME" \
+              --repo "$GITHUB_REPOSITORY" \
+              --pattern "$archive_name" \
+              --dir "$existing_dir"
+            existing_sha256="$(shasum -a 256 "$existing_dir/$archive_name" | awk '{print $1}')"
+            if [ "$existing_sha256" != "$EXPECTED_PLUGIN_ZIP_SHA256" ]; then
+              echo "ERROR: Existing GitHub Release asset digest does not match the verified artifact; refusing to replace it." >&2
+              exit 1
+            fi
+          else
+            gh release upload "$GITHUB_REF_NAME" "$archive" --repo "$GITHUB_REPOSITORY"
+          fi
+
+          {
+            echo "Source commit: \`$SOURCE_SHA\`"
+            echo "Plugin archive SHA-256: \`$EXPECTED_PLUGIN_ZIP_SHA256\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   publish:
     needs: [test, package, verify, release]

--- a/README.md
+++ b/README.md
@@ -773,6 +773,12 @@ GitHub Release and Marketplace jobs independently download and recheck that
 digest before consuming the same bytes. Release notes are generated under the
 runner's temporary directory, not inside the source checkout.
 
+Stable reruns preserve an existing GitHub Release and its notes. If the expected
+zip is already attached, the workflow downloads it and requires its SHA-256 to
+match before continuing; it never uses a clobbering upload. A missing asset is
+attached on rerun, while a mismatched existing asset fails closed for explicit
+operator recovery.
+
 The GitHub Release is created before Marketplace publication, preserving the
 existing Stable failure semantics. Its job has GitHub contents write permission
 but never receives `PUBLISH_TOKEN`. The final Marketplace job has read-only

--- a/README.md
+++ b/README.md
@@ -773,11 +773,14 @@ GitHub Release and Marketplace jobs independently download and recheck that
 digest before consuming the same bytes. Release notes are generated under the
 runner's temporary directory, not inside the source checkout.
 
-Stable reruns preserve an existing GitHub Release and its notes. If the expected
-zip is already attached, the workflow downloads it and requires its SHA-256 to
-match before continuing; it never uses a clobbering upload. A missing asset is
-attached on rerun, while a mismatched existing asset fails closed for explicit
-operator recovery.
+Stable reruns preserve an existing GitHub Release and its notes. Use GitHub's
+**Re-run failed jobs** action while the original workflow artifact is retained;
+that path reuses the verified zip. A full workflow rerun rebuilds timestamped
+plugin bytes and intentionally fails against an existing different asset. If
+the expected zip is already attached, the workflow downloads it and requires
+its SHA-256 to match before continuing; it never uses a clobbering upload. A
+missing asset is attached on rerun, while a mismatched existing asset fails
+closed for explicit operator recovery.
 
 The GitHub Release is created before Marketplace publication, preserving the
 existing Stable failure semantics. Its job has GitHub contents write permission

--- a/README.md
+++ b/README.md
@@ -763,9 +763,43 @@ full release gates, pushes that branch, and opens a PR into the protected
 default branch. After the PR merges, its separate `tag` mode verifies that the
 tag, `pluginVersion`, and `plugin.xml` versions match before pushing the tag.
 The tag-triggered GitHub Actions workflow also proves the tag points at the
-current default-branch commit, repeats the version check, runs plugin structure
-and compatibility verification, creates the GitHub Release, and then publishes
-to JetBrains Marketplace (requires `PUBLISH_TOKEN`).
+current default-branch commit and repeats the version check. A fresh packaging
+job builds one clean, explicitly named plugin zip without a Gradle build cache
+and runs the structure check before uploading those bytes as a workflow
+artifact. A separate verification job downloads that zip, validates its
+embedded plugin identity and clean source provenance, runs Plugin Verifier
+against the downloaded archive, and records the plugin zip's SHA-256. The
+GitHub Release and Marketplace jobs independently download and recheck that
+digest before consuming the same bytes. Release notes are generated under the
+runner's temporary directory, not inside the source checkout.
+
+The GitHub Release is created before Marketplace publication, preserving the
+existing Stable failure semantics. Its job has GitHub contents write permission
+but never receives `PUBLISH_TOKEN`. The final Marketplace job has read-only
+repository permission, runs no Gradle tasks, and uploads through the bounded
+`scripts/publish-stable-artifact.sh` after revalidating the tag, archive,
+embedded clean source commit, and independently recorded digest. Existing
+Marketplace updates are never replaced or resubmitted by this workflow change.
+
+For manual verification or recovery, run the trusted scripts from a clean
+checkout pinned to the exact Stable tag commit:
+
+```bash
+source_sha="$(git rev-list -n 1 vX.Y.Z)"
+archive=/path/to/jetbrains-inspection-api-X.Y.Z.zip
+
+./scripts/verify-stable-artifact.sh \
+  --archive "$archive" \
+  --tag vX.Y.Z \
+  --source-sha "$source_sha"
+
+verified_sha256="$(shasum -a 256 "$archive" | awk '{print $1}')"
+PUBLISH_TOKEN="$PUBLISH_TOKEN" ./scripts/publish-stable-artifact.sh \
+  --archive "$archive" \
+  --tag vX.Y.Z \
+  --expected-sha256 "$verified_sha256" \
+  --source-sha "$source_sha"
+```
 
 Canary publication is a separate branch-only path and does not change Stable's
 plugin ID, `vX.Y.Z` tags, version validator, workflow, or default Marketplace

--- a/TESTING.md
+++ b/TESTING.md
@@ -358,6 +358,9 @@ commit and archive SHA-256. The Marketplace job has read-only repository
 permission, receives `PUBLISH_TOKEN` only for its bounded publication steps,
 runs no Gradle tasks, and calls `scripts/publish-stable-artifact.sh`; it cannot
 silently rebuild or substitute the artifact attached to the GitHub Release.
+Reruns do not rewrite existing release notes or clobber attached assets. They
+download an existing same-name asset and require the verified SHA-256, attach a
+missing asset, and fail closed when an existing asset has different bytes.
 
 `verifyPlugin` treats internal API usage as a release failure except for the
 existing inspection-engine Marketplace exemption. Every configured IDE report

--- a/TESTING.md
+++ b/TESTING.md
@@ -358,9 +358,13 @@ commit and archive SHA-256. The Marketplace job has read-only repository
 permission, receives `PUBLISH_TOKEN` only for its bounded publication steps,
 runs no Gradle tasks, and calls `scripts/publish-stable-artifact.sh`; it cannot
 silently rebuild or substitute the artifact attached to the GitHub Release.
-Reruns do not rewrite existing release notes or clobber attached assets. They
-download an existing same-name asset and require the verified SHA-256, attach a
-missing asset, and fail closed when an existing asset has different bytes.
+Use **Re-run failed jobs** for Stable recovery while the original workflow
+artifact is retained. This reuses the verified zip without rewriting existing
+release notes or clobbering attached assets. The workflow downloads an existing
+same-name asset and requires the verified SHA-256, attaches a missing asset, and
+fails closed when an existing asset has different bytes. A full workflow rerun
+rebuilds timestamped plugin bytes and therefore fails against an existing asset
+instead of replacing it.
 
 `verifyPlugin` treats internal API usage as a release failure except for the
 existing inspection-engine Marketplace exemption. Every configured IDE report

--- a/TESTING.md
+++ b/TESTING.md
@@ -341,12 +341,27 @@ before that check is considered stable enough to require.
 
 Version tags (`v*`) run `.github/workflows/release.yml`, which rejects tag,
 `pluginVersion`, or `plugin.xml` mismatches before publication, repeats the
-commit gate, runs `buildPlugin`, `verifyPluginStructure`, and `verifyPlugin`,
-creates the GitHub Release, then publishes to JetBrains Marketplace. The
-workflow also rejects tags that do not point at the current default-branch
-commit. `verifyPlugin` treats internal API usage as a release failure except
-for the existing inspection-engine Marketplace exemption. Every configured IDE
-report must match the exact, sorted canonical findings in
+commit gate, and rejects tags that do not point at the current default-branch
+commit. A fresh packaging runner proves its exact checkout is clean, builds one
+explicitly named archive without a Gradle build cache, runs
+`verifyPluginStructure`, and uploads that zip. A separate Java 21 verification
+runner downloads the archive, validates its embedded plugin ID, version,
+compatibility range, source commit, and clean fingerprint, then runs
+`verifyPlugin` against those exact bytes through
+`-PpluginVerificationArchive` and records the plugin zip SHA-256.
+
+The GitHub Release job and the later Marketplace job each download that same
+workflow artifact, re-resolve the remote tag and default-branch commit, and
+recheck the independently recorded plugin zip digest. Release notes are written
+under `$RUNNER_TEMP`, and the notes and workflow summary record both the source
+commit and archive SHA-256. The Marketplace job has read-only repository
+permission, receives `PUBLISH_TOKEN` only for its bounded publication steps,
+runs no Gradle tasks, and calls `scripts/publish-stable-artifact.sh`; it cannot
+silently rebuild or substitute the artifact attached to the GitHub Release.
+
+`verifyPlugin` treats internal API usage as a release failure except for the
+existing inspection-engine Marketplace exemption. Every configured IDE report
+must match the exact, sorted canonical findings in
 `config/plugin-verifier/stable-internal-api-allowlist.txt`; additional findings,
 missing expected findings, malformed report lines, or absent reports fail the
 build. This replaces broad class-name substring acceptance.

--- a/scripts/generate-release-notes.sh
+++ b/scripts/generate-release-notes.sh
@@ -108,7 +108,7 @@ write_section() {
   echo ""
   echo "- Commit gate passed in CI."
   echo "- Plugin distribution was built with Gradle."
-  echo "- Plugin was published to JetBrains Marketplace."
+  echo "- Plugin artifact passed independent verification."
   echo ""
   echo "## Installation & Setup"
   echo ""

--- a/scripts/publish-stable-artifact.sh
+++ b/scripts/publish-stable-artifact.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+ARCHIVE=""
+TAG="${GITHUB_REF_NAME:-}"
+EXPECTED_SHA256=""
+SOURCE_SHA="${STABLE_SOURCE_SHA:-}"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --archive)
+      shift
+      ARCHIVE="${1:-}"
+      ;;
+    --tag)
+      shift
+      TAG="${1:-}"
+      ;;
+    --expected-sha256)
+      shift
+      EXPECTED_SHA256="${1:-}"
+      ;;
+    --source-sha)
+      shift
+      SOURCE_SHA="${1:-}"
+      ;;
+    *)
+      echo "ERROR: Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+"$ROOT/scripts/validate-stable-artifact.sh" \
+  --archive "$ARCHIVE" \
+  --tag "$TAG" \
+  --source-sha "$SOURCE_SHA"
+
+if ! [[ "$EXPECTED_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+  echo "ERROR: --expected-sha256 must be the lowercase SHA-256 of the verified Stable artifact." >&2
+  exit 1
+fi
+ACTUAL_SHA256=$(shasum -a 256 "$ARCHIVE" | awk '{print $1}')
+if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
+  echo "ERROR: Stable artifact SHA-256 does not match the independently verified artifact." >&2
+  exit 1
+fi
+
+if [ -z "${PUBLISH_TOKEN:-}" ]; then
+  echo "ERROR: PUBLISH_TOKEN is not available." >&2
+  exit 1
+fi
+
+curl \
+  --fail-with-body \
+  --silent \
+  --show-error \
+  --header "Authorization: Bearer $PUBLISH_TOKEN" \
+  --form "xmlId=com.shiny.inspection.api" \
+  --form "file=@$ARCHIVE" \
+  https://plugins.jetbrains.com/api/updates/upload

--- a/scripts/test-release-contracts.sh
+++ b/scripts/test-release-contracts.sh
@@ -277,6 +277,148 @@ CURL
   trap - RETURN
 }
 
+test_stable_artifact_publication() {
+  local temp_dir fake_bin curl_log archive archive_sha256 invalid_id_archive invalid_version_archive invalid_range_archive dirty_archive wrong_source_archive missing_jar_archive source_sha
+  temp_dir=$(mktemp -d)
+  fake_bin="$temp_dir/bin"
+  curl_log="$temp_dir/curl.log"
+  archive="$temp_dir/jetbrains-inspection-api-1.2.3.zip"
+  invalid_id_archive="$temp_dir/invalid-id/jetbrains-inspection-api-1.2.3.zip"
+  invalid_version_archive="$temp_dir/invalid-version/jetbrains-inspection-api-1.2.3.zip"
+  invalid_range_archive="$temp_dir/invalid-range/jetbrains-inspection-api-1.2.3.zip"
+  dirty_archive="$temp_dir/dirty/jetbrains-inspection-api-1.2.3.zip"
+  wrong_source_archive="$temp_dir/wrong-source/jetbrains-inspection-api-1.2.3.zip"
+  missing_jar_archive="$temp_dir/missing-jar/jetbrains-inspection-api-1.2.3.zip"
+  source_sha="0123456789abcdef0123456789abcdef01234567"
+  export STABLE_SOURCE_SHA="$source_sha"
+  trap 'rm -rf "$temp_dir"' RETURN
+  mkdir -p "$temp_dir/scripts" "$fake_bin"
+  cp \
+    scripts/publish-stable-artifact.sh \
+    scripts/validate-stable-artifact.sh \
+    scripts/validate-marketplace-publication.sh \
+    "$temp_dir/scripts/"
+  mkdir -p \
+    "$(dirname "$invalid_id_archive")" \
+    "$(dirname "$invalid_version_archive")" \
+    "$(dirname "$invalid_range_archive")" \
+    "$(dirname "$dirty_archive")" \
+    "$(dirname "$wrong_source_archive")" \
+    "$(dirname "$missing_jar_archive")"
+  python3 - \
+    "$archive" \
+    "$invalid_id_archive" \
+    "$invalid_version_archive" \
+    "$invalid_range_archive" \
+    "$dirty_archive" \
+    "$wrong_source_archive" \
+    "$missing_jar_archive" <<'PY'
+from io import BytesIO
+from pathlib import Path
+import sys
+import zipfile
+
+def write_archive(
+    path: Path,
+    plugin_id: str,
+    version: str,
+    since_build: str = "251",
+    until_build: str = "262.*",
+    build_commit: str = "0123456789abcdef0123456789abcdef01234567",
+    build_dirty: bool = False,
+) -> None:
+    plugin_xml = (
+        f"<idea-plugin><id>{plugin_id}</id>"
+        f"<version>{version}</version>"
+        f'<idea-version since-build="{since_build}" until-build="{until_build}"/>'
+        "</idea-plugin>"
+    )
+    state = "dirty" if build_dirty else "clean"
+    build_info = "\n".join(
+        [
+            f"plugin.version={version}",
+            f"plugin.build.commit={build_commit}",
+            f"plugin.build.short_commit={build_commit[:12]}",
+            f"plugin.build.dirty={str(build_dirty).lower()}",
+            f"plugin.build.fingerprint={build_commit}-{state}",
+            "plugin.build.time=2026-08-10T00\\:00\\:00Z",
+            "",
+        ]
+    )
+    plugin_jar = BytesIO()
+    with zipfile.ZipFile(plugin_jar, "w") as jar:
+        jar.writestr("META-INF/plugin.xml", plugin_xml)
+        jar.writestr("com/shiny/inspectionmcp/inspection-build.properties", build_info)
+    with zipfile.ZipFile(path, "w") as plugin_zip:
+        plugin_zip.writestr(
+            "jetbrains-inspection-api/lib/jetbrains-inspection-api-1.2.3.jar",
+            plugin_jar.getvalue(),
+        )
+
+write_archive(Path(sys.argv[1]), "com.shiny.inspection.api", "1.2.3")
+write_archive(Path(sys.argv[2]), "different.plugin.id", "1.2.3")
+write_archive(Path(sys.argv[3]), "com.shiny.inspection.api", "1.2.4")
+write_archive(Path(sys.argv[4]), "com.shiny.inspection.api", "1.2.3", since_build="262")
+write_archive(Path(sys.argv[5]), "com.shiny.inspection.api", "1.2.3", build_dirty=True)
+write_archive(
+    Path(sys.argv[6]),
+    "com.shiny.inspection.api",
+    "1.2.3",
+    build_commit="89abcdef0123456789abcdef0123456789abcdef",
+)
+with zipfile.ZipFile(Path(sys.argv[7]), "w") as plugin_zip:
+    plugin_zip.writestr("unexpected.txt", "missing plugin jar")
+PY
+  archive_sha256=$(shasum -a 256 "$archive" | awk '{print $1}')
+  cat > "$fake_bin/curl" <<'CURL'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$CURL_LOG"
+CURL
+  chmod +x "$fake_bin/curl"
+
+  if (cd "$temp_dir" && PATH="$fake_bin:$PATH" CURL_LOG="$curl_log" PUBLISH_TOKEN=test STABLE_SOURCE_SHA='' ./scripts/publish-stable-artifact.sh --archive "$archive" --tag v1.2.3 >/dev/null 2>&1); then
+    fail "Stable artifact publisher accepted an absent source SHA"
+  fi
+  [ ! -e "$curl_log" ] || fail "Stable artifact publisher invoked curl without source provenance"
+
+  if (cd "$temp_dir" && PATH="$fake_bin:$PATH" CURL_LOG="$curl_log" PUBLISH_TOKEN=test ./scripts/publish-stable-artifact.sh --archive "$archive" --tag canary/v1.2.3-canary.1 >/dev/null 2>&1); then
+    fail "Stable artifact publisher accepted a canary tag"
+  fi
+  [ ! -e "$curl_log" ] || fail "Stable artifact publisher invoked curl for a canary tag"
+
+  for invalid_archive in \
+    "$invalid_id_archive" \
+    "$invalid_version_archive" \
+    "$invalid_range_archive" \
+    "$dirty_archive" \
+    "$wrong_source_archive" \
+    "$missing_jar_archive"; do
+    if (cd "$temp_dir" && PATH="$fake_bin:$PATH" CURL_LOG="$curl_log" PUBLISH_TOKEN=test ./scripts/publish-stable-artifact.sh --archive "$invalid_archive" --tag v1.2.3 >/dev/null 2>&1); then
+      fail "Stable artifact publisher accepted invalid artifact $invalid_archive"
+    fi
+    [ ! -e "$curl_log" ] || fail "Stable artifact publisher invoked curl for invalid artifact $invalid_archive"
+  done
+
+  if (cd "$temp_dir" && PATH="$fake_bin:$PATH" CURL_LOG="$curl_log" PUBLISH_TOKEN='' ./scripts/publish-stable-artifact.sh --archive "$archive" --tag v1.2.3 --expected-sha256 "$archive_sha256" >/dev/null 2>&1); then
+    fail "Stable artifact publisher accepted an absent token"
+  fi
+  [ ! -e "$curl_log" ] || fail "Stable artifact publisher invoked curl without a token"
+
+  if (cd "$temp_dir" && PATH="$fake_bin:$PATH" CURL_LOG="$curl_log" PUBLISH_TOKEN=test ./scripts/publish-stable-artifact.sh --archive "$archive" --tag v1.2.3 --expected-sha256 "$(printf '0%.0s' {1..64})" >/dev/null 2>&1); then
+    fail "Stable artifact publisher accepted an unverified artifact digest"
+  fi
+  [ ! -e "$curl_log" ] || fail "Stable artifact publisher invoked curl for an unverified artifact digest"
+
+  (cd "$temp_dir" && PATH="$fake_bin:$PATH" CURL_LOG="$curl_log" PUBLISH_TOKEN=test ./scripts/publish-stable-artifact.sh --archive "$archive" --tag v1.2.3 --expected-sha256 "$archive_sha256" >/dev/null)
+  assert_contains "$curl_log" "xmlId=com.shiny.inspection.api"
+  assert_contains "$curl_log" "file=@$archive"
+  assert_not_contains "$curl_log" "channel="
+
+  unset STABLE_SOURCE_SHA
+  rm -rf "$temp_dir"
+  trap - RETURN
+}
+
 test_marketplace_publication_policy() {
   ./scripts/validate-marketplace-publication.sh --version 1.2.3
   ./scripts/validate-marketplace-publication.sh --version 1.2.3-canary.1 --channel canary
@@ -666,32 +808,75 @@ from pathlib import Path
 import re
 
 build = Path("build.gradle.kts").read_text(encoding="utf-8")
-validator = Path("scripts/validate-canary-artifact.sh").read_text(encoding="utf-8")
+canary_validator = Path("scripts/validate-canary-artifact.sh").read_text(encoding="utf-8")
+stable_validator = Path("scripts/validate-stable-artifact.sh").read_text(encoding="utf-8")
 build_since = re.search(r'sinceBuild = "([^"]+)"', build)
 build_until = re.search(r'untilBuild = "([^"]+)"', build)
-validator_since = re.search(r'EXPECTED_SINCE_BUILD="([^"]+)"', validator)
-validator_until = re.search(r'EXPECTED_UNTIL_BUILD="([^"]+)"', validator)
-if not all((build_since, build_until, validator_since, validator_until)):
+canary_since = re.search(r'EXPECTED_SINCE_BUILD="([^"]+)"', canary_validator)
+canary_until = re.search(r'EXPECTED_UNTIL_BUILD="([^"]+)"', canary_validator)
+stable_since = re.search(r'EXPECTED_SINCE_BUILD="([^"]+)"', stable_validator)
+stable_until = re.search(r'EXPECTED_UNTIL_BUILD="([^"]+)"', stable_validator)
+if not all((build_since, build_until, canary_since, canary_until, stable_since, stable_until)):
     raise SystemExit("trusted compatibility policy could not be resolved")
 if build_since.group(1) != "251" or build_until.group(1) != "262.*":
     raise SystemExit("Stable Gradle compatibility policy changed")
-if validator_since.group(1) != "262" or validator_until.group(1) != "262.*":
+if stable_since.group(1) != build_since.group(1) or stable_until.group(1) != build_until.group(1):
+    raise SystemExit("Stable artifact compatibility policy must match Gradle")
+if canary_since.group(1) != "262" or canary_until.group(1) != "262.*":
     raise SystemExit("canary artifact compatibility policy must remain 262-only")
 
 workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
-validate = workflow.index("Validate release version")
-default_branch = workflow.index("Verify tag commit is current default branch")
-compatibility = workflow.index("Run release compatibility gate")
-github_release = workflow.index("Create GitHub Release")
-publish = workflow.index("Publish to JetBrains Marketplace")
-if not validate < default_branch < compatibility < github_release < publish:
-    raise SystemExit("release workflow validation/verifier/publish ordering is unsafe")
+test = workflow.split("\n  test:\n", 1)[1].split("\n  package:\n", 1)[0]
+package = workflow.split("\n  package:\n", 1)[1].split("\n  verify:\n", 1)[0]
+verify = workflow.split("\n  verify:\n", 1)[1].split("\n  release:\n", 1)[0]
+release = workflow.split("\n  release:\n", 1)[1].split("\n  publish:\n", 1)[0]
+publish = workflow.split("\n  publish:\n", 1)[1]
+
+for line in workflow.splitlines():
+    stripped = line.strip()
+    if stripped.startswith("uses:") and not re.search(r"@[0-9a-f]{40}(?:\s+#\s+v\d+)?$", stripped):
+        raise SystemExit(f"Stable workflow action is not pinned to a full commit SHA: {stripped}")
+
+if "Run commit gate" not in test or "PUBLISH_TOKEN" in test:
+    raise SystemExit("Stable test job trust boundary is invalid")
+if "needs: [test]" not in package or "PUBLISH_TOKEN" in package:
+    raise SystemExit("Stable packaging job trust boundary is invalid")
+if "--no-build-cache buildPlugin verifyPluginStructure" not in package:
+    raise SystemExit("Stable packaging must build and structure-check one uncached archive")
+if "git status --porcelain --untracked-files=all" not in package:
+    raise SystemExit("Stable packaging must require a clean exact source checkout")
+if "needs: [test, package]" not in verify or "plugin_zip_sha256:" not in verify:
+    raise SystemExit("Stable verification must bind consumers to the plugin zip digest")
+if "verify-stable-artifact.sh" not in verify or "PUBLISH_TOKEN" in verify:
+    raise SystemExit("Stable verification trust boundary is invalid")
+if "contents: write" not in release or "PUBLISH_TOKEN" in release:
+    raise SystemExit("GitHub Release authority must remain isolated from Marketplace authority")
+if "$RUNNER_TEMP/release-notes.md" not in release:
+    raise SystemExit("Stable release notes must be generated outside the source checkout")
+if "needs: [test, package, verify, release]" not in publish:
+    raise SystemExit("Stable Marketplace publication must follow GitHub Release creation")
+if "contents: read" not in publish or "contents: write" in publish:
+    raise SystemExit("Stable Marketplace publication must have read-only repository permission")
+if "publish-stable-artifact.sh" not in publish or "./gradlew publishPlugin" in publish:
+    raise SystemExit("Stable Marketplace publication must use the bounded artifact publisher")
+for section_name, section in (("release", release), ("publish", publish)):
+    if "EXPECTED_PLUGIN_ZIP_SHA256" not in section:
+        raise SystemExit(f"{section_name} must consume the independently verified plugin zip digest")
+    if 'test "$actual_sha256" = "$EXPECTED_PLUGIN_ZIP_SHA256"' not in section:
+        raise SystemExit(f"{section_name} must recheck the plugin zip digest")
+if "artifact-digest" in workflow:
+    raise SystemExit("Stable publication must not confuse the Actions wrapper digest with the plugin zip digest")
 PY
 
   assert_contains .github/workflows/release.yml '- "v*"'
   assert_not_contains .github/workflows/release.yml 'canary/v'
   assert_not_contains .github/workflows/release.yml 'validate-canary-release-version.sh'
-  assert_contains .github/workflows/release.yml 'run: ./gradlew publishPlugin'
+  assert_contains .github/workflows/release.yml 'scripts/publish-stable-artifact.sh'
+  assert_not_contains .github/workflows/release.yml './gradlew publishPlugin'
+  assert_not_contains .github/workflows/release.yml 'softprops/action-gh-release'
+  assert_not_contains .github/workflows/release.yml 'build/distributions/*.zip'
+  assert_contains scripts/publish-stable-artifact.sh '--expected-sha256'
+  assert_contains scripts/verify-stable-artifact.sh '-PpluginVerificationArchive=$ARCHIVE'
 
   assert_contains .github/workflows/canary-release.yml 'workflow_dispatch:'
   assert_contains .github/workflows/canary-release.yml 'group: "canary-release-${{ inputs.tag }}"'
@@ -880,6 +1065,7 @@ PY
 test_version_validator
 test_canary_version_validator
 test_canary_artifact_publication
+test_stable_artifact_publication
 test_marketplace_publication_policy
 test_canary_branch_isolation
 test_internal_api_allowlist

--- a/scripts/test-release-contracts.sh
+++ b/scripts/test-release-contracts.sh
@@ -853,6 +853,18 @@ if "contents: write" not in release or "PUBLISH_TOKEN" in release:
     raise SystemExit("GitHub Release authority must remain isolated from Marketplace authority")
 if "$RUNNER_TEMP/release-notes.md" not in release:
     raise SystemExit("Stable release notes must be generated outside the source checkout")
+if "if: steps.release_state.outputs.exists != 'true'" not in release:
+    raise SystemExit("Stable reruns must preserve existing GitHub Release notes")
+if "gh release edit" in release or "--clobber" in release:
+    raise SystemExit("Stable reruns must not rewrite release notes or clobber release assets")
+if "gh release download" not in release or 'test "$asset_count" -le 1' not in release:
+    raise SystemExit("Stable reruns must download and uniquely identify an existing release asset")
+if 'existing_sha256" != "$EXPECTED_PLUGIN_ZIP_SHA256' not in release:
+    raise SystemExit("Stable reruns must fail closed when the existing release asset digest differs")
+if test.count('java-version: "21"') != 1 or 'java-version: "25"' in test:
+    raise SystemExit("Stable commit gate must run on Java 21")
+if package.count('java-version: "21"') != 1 or 'java-version: "25"' in package:
+    raise SystemExit("Stable packaging must run on Java 21")
 if "needs: [test, package, verify, release]" not in publish:
     raise SystemExit("Stable Marketplace publication must follow GitHub Release creation")
 if "contents: read" not in publish or "contents: write" in publish:

--- a/scripts/test-release-contracts.sh
+++ b/scripts/test-release-contracts.sh
@@ -887,6 +887,8 @@ PY
   assert_not_contains .github/workflows/release.yml './gradlew publishPlugin'
   assert_not_contains .github/workflows/release.yml 'softprops/action-gh-release'
   assert_not_contains .github/workflows/release.yml 'build/distributions/*.zip'
+  assert_contains scripts/generate-release-notes.sh 'Plugin artifact passed independent verification.'
+  assert_not_contains scripts/generate-release-notes.sh 'Plugin was published to JetBrains Marketplace.'
   assert_contains scripts/publish-stable-artifact.sh '--expected-sha256'
   assert_contains scripts/verify-stable-artifact.sh '-PpluginVerificationArchive=$ARCHIVE'
 

--- a/scripts/validate-stable-artifact.sh
+++ b/scripts/validate-stable-artifact.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+ARCHIVE=""
+TAG="${GITHUB_REF_NAME:-}"
+SOURCE_SHA="${STABLE_SOURCE_SHA:-}"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --archive)
+      shift
+      ARCHIVE="${1:-}"
+      ;;
+    --tag)
+      shift
+      TAG="${1:-}"
+      ;;
+    --source-sha)
+      shift
+      SOURCE_SHA="${1:-}"
+      ;;
+    *)
+      echo "ERROR: Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+if [ -z "$ARCHIVE" ] || [ ! -f "$ARCHIVE" ]; then
+  echo "ERROR: --archive must identify an existing Stable plugin zip." >&2
+  exit 1
+fi
+if ! [[ "$TAG" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+  echo "ERROR: Stable tag must be in vX.Y.Z format (got '${TAG:-<empty>}')." >&2
+  exit 1
+fi
+VERSION="${BASH_REMATCH[1]}"
+if ! [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "ERROR: --source-sha must be the lowercase 40-character Stable source commit." >&2
+  exit 1
+fi
+
+EXPECTED_SINCE_BUILD="251"
+EXPECTED_UNTIL_BUILD="262.*"
+"$ROOT/scripts/validate-marketplace-publication.sh" --version "$VERSION"
+
+EXPECTED_ARCHIVE_NAME="jetbrains-inspection-api-$VERSION.zip"
+if [ "$(basename "$ARCHIVE")" != "$EXPECTED_ARCHIVE_NAME" ]; then
+  echo "ERROR: Stable archive must be named $EXPECTED_ARCHIVE_NAME." >&2
+  exit 1
+fi
+
+TEMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TEMP_DIR"' EXIT
+PLUGIN_JAR_PATH="jetbrains-inspection-api/lib/jetbrains-inspection-api-$VERSION.jar"
+PLUGIN_JAR_COUNT=$(unzip -Z1 "$ARCHIVE" | awk -v target="$PLUGIN_JAR_PATH" '$0 == target { count++ } END { print count + 0 }')
+if [ "$PLUGIN_JAR_COUNT" -ne 1 ]; then
+  echo "ERROR: Stable archive must contain exactly one $PLUGIN_JAR_PATH." >&2
+  exit 1
+fi
+unzip -p "$ARCHIVE" "$PLUGIN_JAR_PATH" > "$TEMP_DIR/plugin.jar"
+
+PLUGIN_XML_COUNT=$(unzip -Z1 "$TEMP_DIR/plugin.jar" | awk '$0 == "META-INF/plugin.xml" { count++ } END { print count + 0 }')
+if [ "$PLUGIN_XML_COUNT" -ne 1 ]; then
+  echo "ERROR: Stable plugin jar must contain exactly one META-INF/plugin.xml." >&2
+  exit 1
+fi
+unzip -p "$TEMP_DIR/plugin.jar" META-INF/plugin.xml > "$TEMP_DIR/plugin.xml"
+
+BUILD_INFO_PATH="com/shiny/inspectionmcp/inspection-build.properties"
+BUILD_INFO_COUNT=$(unzip -Z1 "$TEMP_DIR/plugin.jar" | awk -v target="$BUILD_INFO_PATH" '$0 == target { count++ } END { print count + 0 }')
+if [ "$BUILD_INFO_COUNT" -ne 1 ]; then
+  echo "ERROR: Stable plugin jar must contain exactly one $BUILD_INFO_PATH." >&2
+  exit 1
+fi
+unzip -p "$TEMP_DIR/plugin.jar" "$BUILD_INFO_PATH" > "$TEMP_DIR/inspection-build.properties"
+
+python3 - \
+  "$TEMP_DIR/plugin.xml" \
+  "$TEMP_DIR/inspection-build.properties" \
+  "$VERSION" \
+  "$SOURCE_SHA" \
+  "$EXPECTED_SINCE_BUILD" \
+  "$EXPECTED_UNTIL_BUILD" <<'PY'
+from pathlib import Path
+import sys
+import xml.etree.ElementTree as ET
+
+plugin_xml_path = Path(sys.argv[1])
+build_info_path = Path(sys.argv[2])
+expected_version = sys.argv[3]
+expected_source_sha = sys.argv[4]
+expected_since_build = sys.argv[5]
+expected_until_build = sys.argv[6]
+
+try:
+    plugin_root = ET.parse(plugin_xml_path).getroot()
+except ET.ParseError as error:
+    raise SystemExit(f"ERROR: Stable archive plugin.xml is not valid XML: {error}") from error
+
+plugin_id = (plugin_root.findtext("id") or "").strip()
+plugin_version = (plugin_root.findtext("version") or "").strip()
+idea_version = plugin_root.find("idea-version")
+if plugin_id != "com.shiny.inspection.api":
+    raise SystemExit("ERROR: Stable archive does not preserve plugin ID com.shiny.inspection.api.")
+if plugin_version != expected_version:
+    raise SystemExit(
+        f"ERROR: Stable archive version {plugin_version or '<missing>'} "
+        f"does not match tag version {expected_version}."
+    )
+if idea_version is None:
+    raise SystemExit("ERROR: Stable archive does not declare an idea-version compatibility range.")
+since_build = (idea_version.get("since-build") or "").strip()
+until_build = (idea_version.get("until-build") or "").strip()
+if since_build != expected_since_build or until_build != expected_until_build:
+    raise SystemExit(
+        "ERROR: Stable archive compatibility range "
+        f"{since_build or '<missing>'}..{until_build or '<missing>'} does not match "
+        f"trusted range {expected_since_build}..{expected_until_build}."
+    )
+
+build_info = {}
+for raw_line in build_info_path.read_text(encoding="utf-8").splitlines():
+    line = raw_line.strip()
+    if not line or line.startswith(("#", "!")):
+        continue
+    key, separator, value = line.partition("=")
+    if not separator:
+        raise SystemExit("ERROR: Stable archive build provenance is malformed.")
+    build_info[key.strip()] = value.strip()
+
+expected_provenance = {
+    "plugin.version": expected_version,
+    "plugin.build.commit": expected_source_sha,
+    "plugin.build.short_commit": expected_source_sha[:12],
+    "plugin.build.dirty": "false",
+    "plugin.build.fingerprint": f"{expected_source_sha}-clean",
+}
+for key, expected_value in expected_provenance.items():
+    actual_value = build_info.get(key, "")
+    if actual_value != expected_value:
+        raise SystemExit(
+            f"ERROR: Stable archive provenance {key}={actual_value or '<missing>'} "
+            f"does not match trusted value {expected_value}."
+        )
+PY

--- a/scripts/verify-stable-artifact.sh
+++ b/scripts/verify-stable-artifact.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+ARCHIVE=""
+TAG="${GITHUB_REF_NAME:-}"
+SOURCE_SHA="${STABLE_SOURCE_SHA:-}"
+
+java_major_version() {
+  local java_home="$1"
+  "$java_home/bin/java" -version 2>&1 | awk -F '[\".]' '/version/ { print $2; exit }'
+}
+
+use_java_21() {
+  local candidate=""
+  if [ -n "${JAVA_HOME:-}" ] && [ -x "$JAVA_HOME/bin/java" ] && \
+    [ "$(java_major_version "$JAVA_HOME")" = "21" ]; then
+    return
+  fi
+  if [ -n "${JAVA_HOME_21:-}" ] && [ -x "$JAVA_HOME_21/bin/java" ]; then
+    candidate="$JAVA_HOME_21"
+  elif [ -x /usr/libexec/java_home ]; then
+    candidate=$(/usr/libexec/java_home -v 21 2>/dev/null || true)
+  fi
+  if [ -z "$candidate" ] || [ ! -x "$candidate/bin/java" ] || \
+    [ "$(java_major_version "$candidate")" != "21" ]; then
+    echo "ERROR: Stable verification requires Java 21. Set JAVA_HOME_21 to a JDK 21 installation." >&2
+    exit 1
+  fi
+  export JAVA_HOME="$candidate"
+  export PATH="$JAVA_HOME/bin:$PATH"
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --archive)
+      shift
+      ARCHIVE="${1:-}"
+      ;;
+    --tag)
+      shift
+      TAG="${1:-}"
+      ;;
+    --source-sha)
+      shift
+      SOURCE_SHA="${1:-}"
+      ;;
+    *)
+      echo "ERROR: Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+"$ROOT/scripts/validate-stable-artifact.sh" \
+  --archive "$ARCHIVE" \
+  --tag "$TAG" \
+  --source-sha "$SOURCE_SHA"
+
+ARCHIVE=$(cd "$(dirname "$ARCHIVE")" && pwd)/$(basename "$ARCHIVE")
+VERSION="${TAG#v}"
+
+cd "$ROOT"
+use_java_21
+rm -rf build/reports/pluginVerifier
+./gradlew \
+  --no-build-cache \
+  --no-daemon \
+  verifyPlugin \
+  "-PpluginVersion=$VERSION" \
+  "-PpluginVerificationArchive=$ARCHIVE"


### PR DESCRIPTION
## Summary
- split Stable release packaging, verification, GitHub Release, and Marketplace publication into isolated jobs
- build one clean uncached plugin zip, independently verify it, record its SHA-256, and make every consumer recheck the same bytes
- isolate GitHub contents-write authority from `PUBLISH_TOKEN` and publish through a bounded direct artifact uploader
- make GitHub Release reruns preserve notes and fail closed instead of clobbering an existing asset
- document the supported **Re-run failed jobs** recovery path and keep existing Marketplace update `1130387` unchanged

## Validation
- `./scripts/test-release-contracts.sh`
- `actionlint .github/workflows/release.yml`
- `shellcheck --severity=warning` on changed release scripts
- `bash -n` on changed release scripts
- `git diff --check`
- `./scripts/commit-gate.sh --ci` via the commit hook, including plugin/core/MCP tests and `buildPlugin`
- independent Opus and Sol final reviews: READY

JetBrains `inspect-closeout` was attempted for the exact worktree but returned `UNKNOWN execution_not_proven` after the helper-owned IDE lifecycle changed `.idea` metadata; the helper cleaned up, and no source finding was reported.

Closes #291