### PR TITLE
Add residual inspectEx evidence matrix

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -241,11 +241,15 @@ runs `./scripts/test-red-lane-smoke-script.sh`, which stubs the helper and
 checks the IntelliJ, PyCharm, and WebStorm fixture contracts without requiring a
 GUI IDE.
 
-### Inspection execution proof (issues #239, #259, and #284)
+### Inspection execution proof (issues #239, #259, #284, and #296)
 
 For `current_file`, `files`, and `changed_files` scopes, GREEN requires complete execution of every exact-file applicable batch-runnable obligation within the 25-file/60-second bounds. Replay is parallelized by exact file; each obligation executes through the supported `InspectionEngine.inspectEx` API with an isolated copied wrapper whose cleanup completes before proof returns, and every worker shares the same deadline and cancellation state. The API returns a sparse map containing only tools with descriptors, so the plugin keeps separate submitted, applicable, runnable, executed, and failed obligation evidence; an empty descriptor map is never sufficient by itself. Globally enabled tools that the selected profile disables for the file or whose declared language is positively non-applicable are counted but excluded. Applicable non-batch tools, unresolved keys/wrappers, failures, timeouts, unvisited obligations, or unmapped descriptors keep clean proof `UNKNOWN`/`capture_incomplete` with `capture_incomplete_reason: "execution_not_proven"`. Current mapped findings remain decisive RED even when clean proof is incomplete. The platform test exercises these semantics on the 2025.1.1 development runtime, while `verifyPlugin` checks the compiled API use across every configured 251, 252, 253, 261, and 262 IDE line.
 
 For `whole_project` and `directory`, the plugin uses the JetBrains native inspection run instead of repeating every local tool against every file. `InspectionEngine.inspectEx` accepts local inspection wrappers only, so it does not replace the remaining global and global-simple execution evidence. The plugin opens the platform's synchronous file-traversal gate and installs a run-bounded `InspectListener` subscription on the same inspection event topic used by local and global tools. GREEN requires a normal native return, at least one traversed physical file, at least one completed local or global-simple file inspection, zero inspection failures, zero unmapped native problem counts, and unchanged run/session/scope/profile/input evidence. Global-only completion or lifecycle activity without file traversal remains `UNKNOWN`/`execution_not_proven`.
+
+The #296 evidence suite drives the real bounded adapter with a synthetic non-default `InspectionProfileImpl`. It proves profile-disabled obligations are excluded without hiding enabled findings, a zero deadline remains fail-closed, and `AnalysisScope` traversal agrees between native expected-file accounting and supported submission for exact files, directories, and the whole test project. It also records a remaining fidelity boundary: `inspectEx` descriptors carry their `ProblemHighlightType`, not the selected profile's configured display level. The current problem mapper therefore reports descriptor-derived severity even when the profile raises the tool to ERROR; resolving that mapping belongs to the evidence-backed #297 reduction rather than this qualification slice.
+
+Automated wrapper tests prove only API reachability: local wrappers can use `inspectEx`, while global-simple and true-global wrappers cannot. Native execution of global kinds and live RED/UNKNOWN preservation require disposable IDE smoke projects. Use `dogfood-red-lane-smoke.sh`, which copies maintained fixtures outside the plugin checkout; do not use a helper-owned open of this repository as #296 evidence because IDE project-model writes can invalidate the worktree snapshot.
 
 Run the focused regression suite:
 
@@ -262,6 +266,10 @@ JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :test \
 Key expectations:
 - supported `inspectEx` execution returns direct descriptors for findings, omits clean/inapplicable/suppressed tools from its sparse result map, and propagates failures and cancellation
 - the caller-selected wrapper set is recorded separately from sparse results; profile and applicability classification remain explicit caller responsibilities
+- a selected non-default profile excludes disabled obligations while preserving enabled findings, and a zero proof deadline remains `execution_not_proven`
+- exact-file, directory, and whole-project `AnalysisScope` traversal matches the native expected-file set on physical test content
+- selected profile severity remains external to `inspectEx` descriptors; current mapped severity is derived from `ProblemHighlightType`
+- local/global-simple/true-global wrapper routing is automated evidence only; native global execution requires live IDE evidence
 - `current_file`/`files`/`changed_files` inspection with zero executed tools → `execution_not_proven`, not GREEN
 - `current_file`/`files`/`changed_files` inspection with tool errors → `execution_not_proven`, not GREEN
 - bounded inspection with all applicable runnable obligations executed, no blocking obligations, and no findings → GREEN

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -107,7 +107,7 @@ import javax.swing.tree.TreeNode
 private const val EXACT_PROJECT_PATH_SELECTOR_PREFIX = "exact-project-path:"
 private const val EXACT_WORKTREE_PATH_SELECTOR_PREFIX = "exact-worktree-path:"
 private const val MAX_SCOPE_FILE_DIAGNOSTICS = 25
-private const val BOUNDED_EXECUTION_PROOF_TIMEOUT_MS = 60_000L
+private const val DEFAULT_BOUNDED_EXECUTION_PROOF_TIMEOUT_MS = 60_000L
 private const val SCOPE_FILE_SEMANTIC_COVERAGE_SCHEMA_VERSION = 1
 private const val SCOPE_SEMANTIC_COVERAGE_MISSING_REASON = "scope_semantic_coverage_missing"
 private const val LIFECYCLE_FALLBACK_MODULE_PREFIX = "__jetbrains_inspection_api_lifecycle_fallback__"
@@ -1539,6 +1539,7 @@ class InspectionHandler : HttpRequestHandler() {
         ProjectManagerEx.getInstanceEx().forceCloseProject(project, save)
     }
     internal var closeVerificationTimeoutMs: Long = 10_000
+    internal var boundedExecutionProofTimeoutMs: Long = DEFAULT_BOUNDED_EXECUTION_PROOF_TIMEOUT_MS
     internal var closeVerificationPollMs: Long = 100
     internal var closeVerificationNow: () -> Long = { System.currentTimeMillis() }
     internal var closeVerificationSleep: (Long) -> Unit = { millis -> Thread.sleep(millis) }
@@ -7341,7 +7342,7 @@ class InspectionHandler : HttpRequestHandler() {
         }
     }
 
-    private fun nativeInspectionExpectedFilePaths(scope: AnalysisScope): Set<String> {
+    internal fun nativeInspectionExpectedFilePaths(scope: AnalysisScope): Set<String> {
         val paths = linkedSetOf<String>()
         scope.accept(object : PsiElementVisitor() {
             override fun visitFile(file: com.intellij.psi.PsiFile) {
@@ -8579,7 +8580,7 @@ class InspectionHandler : HttpRequestHandler() {
         ).filterValues { it != null }
     }
 
-    private data class EnabledLocalToolEnumeration(
+    internal data class EnabledLocalToolEnumeration(
         val shortNames: Set<String>,
         val errorCount: Int,
         val errorExamples: List<Map<String, Any?>>,
@@ -8692,7 +8693,7 @@ class InspectionHandler : HttpRequestHandler() {
     }
 
     @Suppress("UnstableApiUsage")
-    private fun runBoundedExecutionProof(
+    internal fun runBoundedExecutionProof(
         enabledTools: EnabledLocalToolEnumeration,
         profile: InspectionProfileImpl,
         project: Project,
@@ -8708,7 +8709,7 @@ class InspectionHandler : HttpRequestHandler() {
             )
         }
         val proofStartNanos = System.nanoTime()
-        val proofTimeoutNanos = BOUNDED_EXECUTION_PROOF_TIMEOUT_MS * 1_000_000L
+        val proofTimeoutNanos = boundedExecutionProofTimeoutMs * 1_000_000L
 
         fun proofDeadlineExceeded(): Boolean = System.nanoTime() - proofStartNanos > proofTimeoutNanos
 
@@ -8983,7 +8984,7 @@ class InspectionHandler : HttpRequestHandler() {
             enabledLocalToolCount = enabledTools.shortNames.size,
             candidates = candidates,
             enumerationErrorCount = enabledTools.errorCount,
-            timeoutMs = BOUNDED_EXECUTION_PROOF_TIMEOUT_MS,
+            timeoutMs = boundedExecutionProofTimeoutMs,
             nowNanos = System::nanoTime,
             startNanos = proofStartNanos,
             cancellationCheck = cancellationCheck,
@@ -9001,7 +9002,7 @@ class InspectionHandler : HttpRequestHandler() {
         }
     }
 
-    private fun buildProblemMap(
+    internal fun buildProblemMap(
         descriptor: com.intellij.codeInspection.CommonProblemDescriptor,
         wrapper: com.intellij.codeInspection.ex.InspectionToolWrapper<*, *>,
         project: Project,

--- a/src/test/kotlin/com/shiny/inspectionmcp/SupportedInspectionExecutorPlatformTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/SupportedInspectionExecutorPlatformTest.kt
@@ -1,11 +1,16 @@
 package com.shiny.inspectionmcp
 
 import com.intellij.analysis.AnalysisScope
+import com.intellij.codeHighlighting.HighlightDisplayLevel
+import com.intellij.codeInsight.daemon.HighlightDisplayKey
 import com.intellij.codeInspection.GlobalInspectionTool
 import com.intellij.codeInspection.LocalInspectionTool
 import com.intellij.codeInspection.LocalInspectionToolSession
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.codeInspection.ex.GlobalInspectionToolWrapper
+import com.intellij.codeInspection.ex.InspectionProfileImpl
+import com.intellij.codeInspection.ex.InspectionToolWrapper
+import com.intellij.codeInspection.ex.InspectionToolsSupplier
 import com.intellij.codeInspection.ex.LocalInspectionToolWrapper
 import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.application.WriteAction
@@ -17,6 +22,8 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
+import com.intellij.profile.codeInspection.BaseInspectionProfileManager
+import com.intellij.profile.codeInspection.InspectionProfileManager
 import com.intellij.testFramework.ProjectExtension
 import com.intellij.testFramework.runInEdtAndGet
 import org.assertj.core.api.Assertions.assertThat
@@ -138,6 +145,103 @@ class SupportedInspectionExecutorPlatformTest {
     fun `inspectEx routing accepts local wrappers and preserves global fallback`() {
         assertThat(canExecuteWithInspectEx(LocalInspectionToolWrapper(CleanInspection()))).isTrue()
         assertThat(canExecuteWithInspectEx(GlobalInspectionToolWrapper(TestGlobalInspection()))).isFalse()
+        assertThat(canExecuteWithInspectEx(GlobalInspectionToolWrapper(TestGlobalSimpleInspection()))).isFalse()
+    }
+
+    @Test
+    fun `selected profile disables one obligation without weakening executed findings`() {
+        val project = projectExtension.project
+        val enabledTool = EnabledProfileFindingInspection()
+        val disabledTool = DisabledProfileFindingInspection()
+        resetVisits(enabledTool)
+        resetVisits(disabledTool)
+        val psiFile = createPhysicalFile()
+        val profile = profileWith(enabledTool, disabledTool)
+        profile.setToolEnabled(enabledTool.shortName, true, project)
+        profile.setToolEnabled(disabledTool.shortName, false, project)
+
+        val result = InspectionHandler().runBoundedExecutionProof(
+            enabledTools = enabledTools(enabledTool, disabledTool),
+            profile = profile,
+            project = project,
+            scopeFiles = listOf(psiFile),
+            cancellationCheck = {},
+        )
+
+        assertThat(result.profileEnabledObligationCount).isEqualTo(1)
+        assertThat(result.profileDisabledObligationCount).isEqualTo(1)
+        assertThat(result.batchRunnableObligationCount).isEqualTo(1)
+        assertThat(result.executedToolCount).isEqualTo(1)
+        assertThat(result.proofEstablished).isTrue()
+        assertThat(result.proofProblems).hasSize(1)
+        assertThat(visitCount(enabledTool)).isEqualTo(1)
+        assertThat(visitCount(disabledTool)).isZero()
+    }
+
+    @Test
+    fun `zero proof deadline deterministically remains unproven`() {
+        val project = projectExtension.project
+        val tool = TimeoutProfileInspection()
+        val psiFile = createPhysicalFile()
+        val profile = profileWith(tool)
+        val handler = InspectionHandler().apply { boundedExecutionProofTimeoutMs = 0 }
+
+        val result = handler.runBoundedExecutionProof(
+            enabledTools = enabledTools(tool),
+            profile = profile,
+            project = project,
+            scopeFiles = listOf(psiFile),
+            cancellationCheck = {},
+        )
+
+        assertThat(result.hitTimeLimit).isTrue()
+        assertThat(result.proofEstablished).isFalse()
+        assertThat(result.proofBlockReason).isEqualTo("time_limit")
+        assertThat(result.unvisitedClassificationObligationCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `inspectEx descriptors do not carry selected profile severity`() {
+        val project = projectExtension.project
+        val tool = SeverityProfileFindingInspection()
+        val psiFile = createPhysicalFile()
+        val profile = profileWith(tool)
+        val key = requireNotNull(HighlightDisplayKey.find(tool.shortName))
+        profile.setErrorLevel(key, HighlightDisplayLevel.ERROR, project)
+        val wrapper = requireNotNull(profile.getInspectionTool(tool.shortName, psiFile)) as LocalInspectionToolWrapper
+        val descriptor = ReadAction.compute<com.intellij.codeInspection.ProblemDescriptor, RuntimeException> {
+            SupportedInspectionExecutor().executePreparedFile(
+                psiFile,
+                listOf(wrapper),
+                EmptyProgressIndicator(),
+            ).returnedDescriptorsByToolShortName.getValue(tool.shortName).single()
+        }
+        val mapped = InspectionHandler().buildProblemMap(descriptor, wrapper, project)
+
+        assertThat(profile.getErrorLevel(key, psiFile)).isEqualTo(HighlightDisplayLevel.ERROR)
+        assertThat(mapped).isNotNull()
+        assertThat(mapped!!["severity"]).isEqualTo("warning")
+    }
+
+    @Test
+    fun `expected and submitted files match for exact directory and project scopes`() {
+        val project = projectExtension.project
+        val outsideFile = createPhysicalFile()
+        val directoryFiles = createPhysicalDirectoryFiles(2)
+        val exactScope = AnalysisScope(project, directoryFiles.mapTo(linkedSetOf()) { it.virtualFile })
+        val directoryScope = ReadAction.compute<AnalysisScope, RuntimeException> {
+            AnalysisScope(requireNotNull(directoryFiles.first().containingDirectory))
+        }
+        val projectScope = AnalysisScope(project)
+        val handler = InspectionHandler()
+
+        assertScopeParity(handler, exactScope, directoryFiles.mapTo(linkedSetOf()) { it.virtualFile.path })
+        assertScopeParity(handler, directoryScope, directoryFiles.mapTo(linkedSetOf()) { it.virtualFile.path })
+
+        val projectPaths = scopePaths(handler, projectScope)
+        assertThat(projectPaths.first).isEqualTo(projectPaths.second)
+        assertThat(projectPaths.first).contains(outsideFile.virtualFile.path)
+        assertThat(projectPaths.first).containsAll(directoryFiles.map { it.virtualFile.path })
     }
 
     private fun execute(
@@ -182,6 +286,59 @@ class SupportedInspectionExecutorPlatformTest {
         }
     }
 
+    private fun createPhysicalDirectoryFiles(count: Int): List<PsiFile> {
+        val project = projectExtension.project
+        val module = projectExtension.module
+        return runInEdtAndGet {
+            WriteAction.compute<List<PsiFile>, RuntimeException> {
+                val contentRoot = ModuleRootManager.getInstance(module).contentRoots.single()
+                val directory = contentRoot.createChildDirectory(this, "evidence-directory-${fileCounter.incrementAndGet()}")
+                (1..count).map { index ->
+                    val virtualFile = directory.createChildData(this, "fixture-$index.txt")
+                    VfsUtil.saveText(virtualFile, "directory evidence $index")
+                    requireNotNull(PsiManager.getInstance(project).findFile(virtualFile))
+                }
+            }
+        }
+    }
+
+    private fun assertScopeParity(handler: InspectionHandler, scope: AnalysisScope, expectedPaths: Set<String>) {
+        val paths = scopePaths(handler, scope)
+        assertThat(paths.first).isEqualTo(paths.second)
+        assertThat(paths.first).containsExactlyInAnyOrderElementsOf(expectedPaths)
+    }
+
+    private fun scopePaths(handler: InspectionHandler, scope: AnalysisScope): Pair<Set<String>, Set<String>> =
+        ReadAction.compute<Pair<Set<String>, Set<String>>, RuntimeException> {
+            handler.nativeInspectionExpectedFilePaths(scope) to
+                SupportedInspectionExecutor().collectScopeFiles(scope)
+                    .mapNotNullTo(linkedSetOf()) { it.virtualFile?.path }
+        }
+
+    private fun profileWith(vararg tools: LocalInspectionTool): InspectionProfileImpl {
+        val project = projectExtension.project
+        val wrappers = tools.map(::LocalInspectionToolWrapper)
+        wrappers.forEach { HighlightDisplayKey.findOrRegister(it.shortName, it.displayName) }
+        val supplier = InspectionToolsSupplier.Simple(wrappers.map { it as InspectionToolWrapper<*, *> })
+        val manager = InspectionProfileManager.getInstance() as BaseInspectionProfileManager
+        val profile = InspectionProfileImpl("evidence-${profileCounter.incrementAndGet()}", supplier, manager)
+        val previousInitInspections = InspectionProfileImpl.INIT_INSPECTIONS
+        InspectionProfileImpl.INIT_INSPECTIONS = true
+        try {
+            profile.initInspectionTools(project)
+        } finally {
+            InspectionProfileImpl.INIT_INSPECTIONS = previousInitInspections
+        }
+        return profile
+    }
+
+    private fun enabledTools(vararg tools: LocalInspectionTool): InspectionHandler.EnabledLocalToolEnumeration =
+        InspectionHandler.EnabledLocalToolEnumeration(
+            shortNames = tools.mapTo(linkedSetOf()) { it.shortName },
+            errorCount = 0,
+            errorExamples = emptyList(),
+        )
+
     private open class RecordingInspection : LocalInspectionTool() {
         override fun getDisplayName(): String = shortName
 
@@ -223,10 +380,22 @@ class SupportedInspectionExecutorPlatformTest {
         }
     }
 
-    private class TestGlobalInspection : GlobalInspectionTool() {
+    private class EnabledProfileFindingInspection : FindingInspection()
+
+    private class DisabledProfileFindingInspection : FindingInspection()
+
+    private class SeverityProfileFindingInspection : FindingInspection()
+
+    private class TimeoutProfileInspection : RecordingInspection()
+
+    private open class TestGlobalInspection : GlobalInspectionTool() {
         override fun getDisplayName(): String = shortName
 
         override fun getGroupDisplayName(): String = "Supported Inspection Tests"
+    }
+
+    private class TestGlobalSimpleInspection : TestGlobalInspection() {
+        override fun isGlobalSimpleInspectionTool(): Boolean = true
     }
 
     companion object {
@@ -235,6 +404,7 @@ class SupportedInspectionExecutorPlatformTest {
         val projectExtension = ProjectExtension()
 
         private val fileCounter = AtomicInteger()
+        private val profileCounter = AtomicInteger()
         private val visitCounts = ConcurrentHashMap<String, AtomicInteger>()
 
         private fun resetVisits(tool: LocalInspectionTool) {


### PR DESCRIPTION
## Summary

- drive the real bounded proof adapter with a synthetic non-default inspection profile
- prove profile-disabled accounting, deterministic fail-closed timeout behavior, and physical-file scope parity
- record that `inspectEx` descriptors do not carry selected-profile severity
- distinguish local, global-simple, and true-global wrapper reachability without claiming native global execution
- document automated versus live-only evidence boundaries

## Evidence

- focused platform/proof suite passed
- full `./scripts/commit-gate.sh --ci` passed
- Plugin Verifier passed across configured 251/252/253/261/262 lines with the existing 57-finding allowlist
- IntelliJ red lane: RED, 18 findings, cleanup closed
- WebStorm red lane: RED, 2 findings, cleanup closed
- PyCharm red lane: fail-closed UNKNOWN (`project_analysis_not_ready`), cleanup closed, terminal/no retry
- exact-SHA final reviews: Opus APPROVE; Gemini NOT APPROVE because it objects to widening private implementation details to `internal` test seams, not because it found an incorrect result or false evidence claim

## Decision Boundary

This PR adds evidence and test seams only; it does not change production routing. The matrix confirms local supported execution, preserves the global/native boundary, and identifies selected-profile severity mapping as #297 work. The internal seams follow existing repository test-hook practice, retain module-only visibility, and preserve production defaults; Gemini's objection is recorded as review dissent rather than silently discarded.

Refs #290
Refs #296
Refs #297
