### PR TITLE
Require core and MCP coverage thresholds in CI

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -14,8 +14,8 @@
       "commitGate": "./scripts/commit-gate.sh --ci",
       "commitGateIncludes": [
         "./gradlew :test",
-        "./gradlew :inspection-core:test",
-        "./gradlew :mcp-server-jvm:test",
+        "./gradlew :inspection-core:jacocoTestCoverageVerification",
+        "./gradlew :mcp-server-jvm:jacocoTestCoverageVerification",
         "./scripts/test-release-contracts.sh",
         "./gradlew buildPlugin"
       ],

--- a/TESTING.md
+++ b/TESTING.md
@@ -236,10 +236,12 @@ Use `--ide` for the inspection identity selector and `--ide-app` for the exact
 macOS app bundle to launch. Keep the bundle selector aligned with the installed
 application name even when channel and version selectors identify an EAP line.
 
-This is a live IDE smoke, not a normal CI unit test. `./scripts/test-all.sh`
-runs `./scripts/test-red-lane-smoke-script.sh`, which stubs the helper and
-checks the IntelliJ, PyCharm, and WebStorm fixture contracts without requiring a
-GUI IDE.
+This is a live IDE smoke, not a normal CI unit test. The red-lane smoke-script contract remains local-only
+under `./scripts/test-all.sh` because the contract
+invokes the developer-facing helper through `uv run`, which is not part of the
+required CI toolchain. `./scripts/test-red-lane-smoke-script.sh` stubs the helper
+and checks the IntelliJ, PyCharm, and WebStorm fixture contracts without
+requiring a GUI IDE. Run it whenever the red-lane fixtures or dogfood CLI change.
 
 ### Inspection execution proof (issues #239, #259, #284, #296, and #301)
 
@@ -349,7 +351,10 @@ requests and pushes to `main` via `.github/workflows/ci.yml`:
 
 The commit gate sync-checks `plugin.xml` against `gradle.properties`, runs the
 fast release/workflow contract tests, requires Java 21, then runs plugin tests,
-core tests, MCP server tests, and `buildPlugin`.
+the core and MCP 85% JaCoCo verification tasks, and `buildPlugin`. Each coverage
+verification task depends on its module's tests and report, so tests are not run
+twice. The plugin's own 0% JaCoCo minimum remains report-only and is not required
+by CI.
 Code scanning is tracked through the required `Analyze (actions)` and
 `Analyze (python)` checks alongside `commit-gate`. `Analyze (java-kotlin)` also
 runs as a non-required signal so Kotlin and plugin upgrades can be validated
@@ -440,10 +445,10 @@ broader rule. Manual verification and recovery publication must run from a
 separate, clean checkout pinned to the reviewed default-branch dispatch commit,
 never from the canary source worktree.
 
-`./scripts/test-all.sh` reports the configured JaCoCo contracts accurately:
-plugin coverage is a 0% minimum report-only signal because IntelliJ classloader
-isolation prevents reliable plugin instrumentation, while `inspection-core`
-and `mcp-server-jvm` each enforce 85% minimum coverage.
+The required commit gate owns the 85% coverage thresholds for `inspection-core`
+and `mcp-server-jvm`. Plugin coverage remains a 0% minimum report-only signal
+because IntelliJ classloader isolation prevents reliable plugin instrumentation;
+`./scripts/test-all.sh` reports that signal without making it a required check.
 
 Release preparation is a two-phase protected-branch flow:
 

--- a/scripts/commit-gate.sh
+++ b/scripts/commit-gate.sh
@@ -124,6 +124,6 @@ JAVA_HOME=$(resolve_java_home) || {
 export JAVA_HOME
 
 ./gradlew :test
-./gradlew :inspection-core:test
-./gradlew :mcp-server-jvm:test
+./gradlew :inspection-core:jacocoTestCoverageVerification
+./gradlew :mcp-server-jvm:jacocoTestCoverageVerification
 ./gradlew buildPlugin

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -192,7 +192,7 @@ print_result $RELEASE_CONTRACT_RESULT "Release workflow contracts"
 print_section "5. Coverage Verification"
 
 echo "Plugin JaCoCo verification (0% minimum; report-only signal)"
-if ./gradlew jacocoTestCoverageVerification; then
+if ./gradlew :jacocoTestCoverageVerification; then
   PLUGIN_COVERAGE_RESULT=0
 else
   PLUGIN_COVERAGE_RESULT=1

--- a/scripts/test-release-contracts.sh
+++ b/scripts/test-release-contracts.sh
@@ -1110,8 +1110,14 @@ if "test \"$(git rev-parse \"refs/tags/$CANARY_TAG^{commit}\")\" = \"$EXPECTED_S
 PY
 
   assert_contains scripts/test-all.sh 'Plugin JaCoCo verification (0% minimum; report-only signal)'
+  assert_contains scripts/test-all.sh './gradlew :jacocoTestCoverageVerification'
   assert_contains scripts/test-all.sh 'Core coverage is below the configured 85% threshold'
   assert_contains scripts/test-all.sh 'MCP coverage is below the configured 85% threshold'
+  assert_contains scripts/commit-gate.sh ':inspection-core:jacocoTestCoverageVerification'
+  assert_contains scripts/commit-gate.sh ':mcp-server-jvm:jacocoTestCoverageVerification'
+  assert_not_contains scripts/commit-gate.sh './gradlew jacocoTestCoverageVerification'
+  assert_not_contains scripts/commit-gate.sh 'test-red-lane-smoke-script.sh'
+  assert_contains scripts/test-all.sh './scripts/test-red-lane-smoke-script.sh'
 }
 
 test_version_validator


### PR DESCRIPTION
## Summary
- make the existing 85% core and MCP coverage thresholds part of the required commit gate
- keep plugin coverage report-only and root-scoped because its configured minimum is intentionally 0%
- keep the red-lane smoke-script contract local because it requires the developer `uv` toolchain; document and contract-test that ownership
- update repository workflow metadata and testing documentation

## Evidence
- red-lane contract passed 5/5 runs in 0.62–0.74s locally, but invokes `uv run` and would require a new CI toolchain install
- module coverage verification adds about 0.3–0.5s after tests/reports and runs no tests twice
- Opus final review approved with no blocking findings; Gemini-family review was requested but returned an empty artifact

## Validation
- `./scripts/test-release-contracts.sh`
- `./scripts/commit-gate.sh --ci`
- `./scripts/test-all.sh`
- `git diff --check`

Closes #306
Part of #302