### PR TITLE
Expose lifecycle open progress safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,15 @@ clients should keep using `/route`, `/trigger`, `/wait`, `/status`, and
   `lease_id`. Identity and endpoint responses advertise
   `lifecycle_ownership_protocol: "lease_bound_v1"`; an
   `ownership_registered: true` open response records only the pending request,
-  not ownership of the eventual project instance.
+  not ownership of the eventual project instance. A same-target probe during
+  or after an attempt may also include the bounded
+  `lifecycle_open_diagnostic` object with safe lifecycle phase/outcome,
+  timestamps/elapsed time, state booleans, and a project instance identifier
+  when available. It reports progress such as `scheduled`, `edt_started`,
+  `readiness_wait`, and `ready`, plus terminal null, mismatch/reuse,
+  unresolved, and failed outcomes; it is diagnostic only and does not grant
+  close authority. Pass `probe=true` for a strictly read-only state query; the
+  probe never trusts, opens, schedules, or claims a project.
 - `GET /api/inspection/lifecycle/claim`: resolves the same selectors as
   `/route` and verifies optional `project_instance_id`. It returns a one-use
   `close_token` only when the supplied `lease_id` is bound to the exact project

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -111,7 +111,10 @@ private const val REQUIRED_PYTHON_SDK_READY_OBSERVATIONS = 2
 private const val SCOPE_FILE_SEMANTIC_COVERAGE_SCHEMA_VERSION = 1
 private const val SCOPE_SEMANTIC_COVERAGE_MISSING_REASON = "scope_semantic_coverage_missing"
 private const val LIFECYCLE_FALLBACK_MODULE_PREFIX = "__jetbrains_inspection_api_lifecycle_fallback__"
+private const val DEFAULT_LIFECYCLE_OPEN_DIAGNOSTIC_TTL_MS = 10 * 60_000L
+private const val DEFAULT_MAX_LIFECYCLE_OPEN_DIAGNOSTICS = 128
 internal const val LIFECYCLE_OWNERSHIP_PROTOCOL = "lease_bound_v1"
+internal const val LIFECYCLE_OPEN_DIAGNOSTIC_VERSION = 1
 private const val INSPECTION_ATTRIBUTION_SCHEMA_VERSION = 1
 private val NON_SEMANTIC_SCOPE_FILE_VALUES = setOf("text", "plaintext", "textmate")
 private val NON_SEMANTIC_SCOPE_FILE_CLASS_MARKERS = setOf("plaintext", "textmate")
@@ -1618,6 +1621,22 @@ class InspectionHandler : HttpRequestHandler() {
         val project: Project,
     )
 
+    private data class LifecycleOpenDiagnostic(
+        val phase: String,
+        val reason: String?,
+        val startedAtMs: Long,
+        val updatedAtMs: Long,
+        val outcomePhase: String? = null,
+        val outcomeReason: String? = null,
+        val outcomeAtMs: Long? = null,
+        val openingScheduled: Boolean = false,
+        val openReturned: Boolean = false,
+        val ownershipRegistered: Boolean = false,
+        val readinessWaiting: Boolean = false,
+        val unresolved: Boolean = false,
+        val projectInstanceId: String? = null,
+    )
+
     internal data class LifecycleContentRootReadiness(
         val ready: Boolean,
         val reason: String,
@@ -1656,6 +1675,7 @@ class InspectionHandler : HttpRequestHandler() {
     private val openingProjectRequests = java.util.concurrent.ConcurrentHashMap<String, LifecycleOpenRequest>()
     private val lifecycleOpenOwnershipByProjectInstance = java.util.concurrent.ConcurrentHashMap<String, LifecycleOpenOwnership>()
     private val unresolvedLifecycleOpenProjects = java.util.concurrent.ConcurrentHashMap<String, Project>()
+    private val lifecycleOpenDiagnosticsByTarget = java.util.concurrent.ConcurrentHashMap<String, LifecycleOpenDiagnostic>()
     internal var forceCloseProject: (Project, Boolean) -> Boolean = { project, save ->
         ProjectManagerEx.getInstanceEx().forceCloseProject(project, save)
     }
@@ -1675,6 +1695,9 @@ class InspectionHandler : HttpRequestHandler() {
     internal var lifecycleFallbackFailureThreshold: Int = 3
     internal var lifecycleOpenGuardNow: () -> Long = { System.currentTimeMillis() }
     internal var lifecycleOpenGuardSleep: (Long) -> Unit = { millis -> Thread.sleep(millis) }
+    internal var lifecycleOpenDiagnosticNow: () -> Long = { System.currentTimeMillis() }
+    internal var lifecycleOpenDiagnosticTtlMs: Long = DEFAULT_LIFECYCLE_OPEN_DIAGNOSTIC_TTL_MS
+    internal var maxLifecycleOpenDiagnostics: Int = DEFAULT_MAX_LIFECYCLE_OPEN_DIAGNOSTICS
     internal var inspectionRunExpirationMs: Long = 300000L
     internal var inspectionProcessRunner: (Runnable, ProgressIndicator) -> Unit = { task, indicator ->
         ProgressManager.getInstance().runProcess(task, indicator)
@@ -2926,10 +2949,13 @@ class InspectionHandler : HttpRequestHandler() {
                         )
                     }
                     unresolvedLifecycleOpenProjects.remove(entry.key, project)
-                }
+            }
             return lifecycleOpenAlreadyOpen(project)
         }
         val target = resolveLifecycleOpenTarget(path)
+        if (parseBooleanParameter(parameters, "probe", defaultValue = false)) {
+            return probeLifecycleOpen(target)
+        }
         unresolvedLifecycleOpenProjects[target.key]?.let { project ->
             if (isUnresolvedLifecycleOpenActive(project)) {
                 return lifecycleOpenStateUnknown(target, project)
@@ -2972,9 +2998,13 @@ class InspectionHandler : HttpRequestHandler() {
                 "ownership_registered" to sameLease,
                 "lease_id" to requestedLeaseId,
                 "lifecycle_ownership_protocol" to LIFECYCLE_OWNERSHIP_PROTOCOL,
-            ) to HttpResponseStatus.OK
+                "lifecycle_open_diagnostic_version" to LIFECYCLE_OPEN_DIAGNOSTIC_VERSION,
+            ).withLifecycleOpenDiagnostic(target.key) to HttpResponseStatus.OK
         }
         unresolvedLifecycleOpenProjects.remove(target.key)
+        recordLifecycleOpenDiagnostic(target.key, "scheduled", "open_scheduled") {
+            it.copy(openingScheduled = true)
+        }
 
         val scheduled = runCatching {
             ApplicationManager.getApplication().invokeLater {
@@ -2982,9 +3012,16 @@ class InspectionHandler : HttpRequestHandler() {
                 var keepOpeningGuard = false
                 var routeHidden = false
                 try {
+                    recordLifecycleOpenDiagnostic(target.key, "edt_started", "open_started")
                     val preexistingProject = findOpenProjectForLifecycleOpen(target.projectRoot.toString())
                     if (preexistingProject != null) {
                         opened = preexistingProject
+                        recordLifecycleOpenDiagnostic(
+                            target.key,
+                            "opened_mismatched_or_reused",
+                            "project_preexisted_before_open",
+                            preexistingProject,
+                        )
                         return@invokeLater
                     }
                     val projectsBeforeOpen = ProjectManager.getInstance().openProjects.toList()
@@ -2996,6 +3033,11 @@ class InspectionHandler : HttpRequestHandler() {
                     opened = openProjectPath(target.openPath) { project ->
                         openedProjectCandidate.compareAndSet(null, project)
                     }
+                    if (opened == null) {
+                        recordLifecycleOpenDiagnostic(target.key, "open_returned_null", "project_open_returned_null") {
+                            it.copy(openReturned = true)
+                        }
+                    }
                     val ownershipProject = openedProjectCandidate.get()?.takeIf { project ->
                         project === opened &&
                             !project.isDefault &&
@@ -3005,14 +3047,33 @@ class InspectionHandler : HttpRequestHandler() {
                     }
                     if (ownershipProject != null && requestedLeaseId != null) {
                         registerLifecycleOpenOwnership(ownershipProject, requestedLeaseId, target.key)
+                        recordLifecycleOpenDiagnostic(
+                            target.key,
+                            "ownership_registered",
+                            "ownership_registered",
+                            ownershipProject,
+                        ) { it.copy(openReturned = true, ownershipRegistered = true) }
+                    } else if (opened != null && requestedLeaseId != null) {
+                        recordLifecycleOpenDiagnostic(
+                            target.key,
+                            "opened_mismatched_or_reused",
+                            "opened_project_not_eligible_for_ownership",
+                            opened,
+                        ) { it.copy(openReturned = true) }
                     }
                     LifecycleOpenRouteVisibility.reveal(target.key)
                     routeHidden = false
                     if (opened != null) {
                         refreshProjectRoot(target.projectRoot.toString())
                         keepOpeningGuard = true
+                        recordLifecycleOpenDiagnostic(target.key, "readiness_wait", "waiting_for_readiness", opened) {
+                            it.copy(openReturned = true, readinessWaiting = true)
+                        }
                         releaseLifecycleOpenGuardWhenUsable(target.key, opened, request)
                     }
+                } catch (error: Exception) {
+                    recordLifecycleOpenDiagnostic(target.key, "failed", "open_failed")
+                    throw error
                 } finally {
                     if (routeHidden) {
                         LifecycleOpenRouteVisibility.reveal(target.key)
@@ -3025,6 +3086,7 @@ class InspectionHandler : HttpRequestHandler() {
         }.isSuccess
         if (!scheduled) {
             openingProjectRequests.remove(target.key, request)
+            recordLifecycleOpenDiagnostic(target.key, "failed", "open_schedule_failed")
             return mapOf(
                 "status" to "failed",
                 "opened" to false,
@@ -3034,7 +3096,8 @@ class InspectionHandler : HttpRequestHandler() {
                 "project_root" to target.projectRoot.toString(),
                 "session_id" to InspectionIdeSession.sessionId,
                 "lifecycle_ownership_protocol" to LIFECYCLE_OWNERSHIP_PROTOCOL,
-            ) to HttpResponseStatus.CONFLICT
+                "lifecycle_open_diagnostic_version" to LIFECYCLE_OPEN_DIAGNOSTIC_VERSION,
+            ).withLifecycleOpenDiagnostic(target.key) to HttpResponseStatus.CONFLICT
         }
 
         return mapOf(
@@ -3047,13 +3110,45 @@ class InspectionHandler : HttpRequestHandler() {
             "ownership_registered" to (requestedLeaseId != null),
             "lease_id" to requestedLeaseId,
             "lifecycle_ownership_protocol" to LIFECYCLE_OWNERSHIP_PROTOCOL,
-        ) to HttpResponseStatus.OK
+            "lifecycle_open_diagnostic_version" to LIFECYCLE_OPEN_DIAGNOSTIC_VERSION,
+        ).withLifecycleOpenDiagnostic(target.key) to HttpResponseStatus.OK
+    }
+
+    private fun probeLifecycleOpen(target: LifecycleOpenTarget): Pair<Map<String, Any?>, HttpResponseStatus> {
+        unresolvedLifecycleOpenProjects[target.key]?.let { project ->
+            if (isUnresolvedLifecycleOpenActive(project)) {
+                return lifecycleOpenStateUnknown(target, project)
+            }
+        }
+        findOpenProjectForLifecycleOpenKey(target.key)?.let { project ->
+            return if (isUsableProject(project)) {
+                lifecycleOpenAlreadyOpen(project, target.key)
+            } else {
+                lifecycleOpenAlreadyOpening(target)
+            }
+        }
+        val opening = openingProjectRequests.containsKey(target.key)
+        val diagnostic = lifecycleOpenDiagnosticsByTarget[target.key]
+        return mapOf(
+            "status" to if (opening) "opening" else "not_open",
+            "opened" to false,
+            "opening_scheduled" to false,
+            "reason" to if (opening) "already_opening" else "project_not_open",
+            "worktree_path" to target.path.toString(),
+            "project_root" to target.projectRoot.toString(),
+            "session_id" to InspectionIdeSession.sessionId,
+            "probe" to true,
+            "diagnostic_available" to (diagnostic != null),
+            "lifecycle_ownership_protocol" to LIFECYCLE_OWNERSHIP_PROTOCOL,
+            "lifecycle_open_diagnostic_version" to LIFECYCLE_OPEN_DIAGNOSTIC_VERSION,
+        ).withLifecycleOpenDiagnostic(target.key) to HttpResponseStatus.OK
     }
 
     private fun releaseLifecycleOpenGuardWhenUsable(key: String, project: Project, request: LifecycleOpenRequest) {
         if (project.isDisposed) {
             openingProjectRequests.remove(key, request)
             unresolvedLifecycleOpenProjects.remove(key)
+            recordLifecycleOpenDiagnostic(key, "failed", "project_disposed", project)
             return
         }
         val submitted = runCatching {
@@ -3069,6 +3164,9 @@ class InspectionHandler : HttpRequestHandler() {
                     var fallbackAttemptCount = 0
                     while (openingProjectRequests.containsKey(key)) {
                         val nowMs = lifecycleOpenGuardNow()
+                        recordLifecycleOpenDiagnostic(key, "readiness_wait", "waiting_for_readiness", project) {
+                            it.copy(readinessWaiting = true)
+                        }
                         val lifecycleComplete = runCatching {
                             val readiness = lifecycleContentRootReadinessProvider(project, key)
                             val isOpenProject = readiness.reason != "project_not_open"
@@ -3120,6 +3218,15 @@ class InspectionHandler : HttpRequestHandler() {
                             }
                         }.getOrDefault(false)
                         if (lifecycleComplete) {
+                            if (unresolvedOpenState) {
+                                recordLifecycleOpenDiagnostic(key, "unresolved", "readiness_guard_timeout", project) {
+                                    it.copy(readinessWaiting = false, unresolved = true)
+                                }
+                            } else {
+                                recordLifecycleOpenDiagnostic(key, "ready", "readiness_ready", project) {
+                                    it.copy(readinessWaiting = false)
+                                }
+                            }
                             return@executeOnPooledThread
                         }
                         lifecycleOpenGuardSleep(lifecycleOpenGuardPollMs)
@@ -3135,8 +3242,87 @@ class InspectionHandler : HttpRequestHandler() {
         if (!submitted) {
             if (isUnresolvedLifecycleOpenActive(project)) {
                 unresolvedLifecycleOpenProjects[key] = project
+                recordLifecycleOpenDiagnostic(key, "unresolved", "readiness_wait_not_submitted", project) {
+                    it.copy(readinessWaiting = false, unresolved = true)
+                }
+            } else {
+                recordLifecycleOpenDiagnostic(key, "failed", "readiness_wait_not_submitted", project) {
+                    it.copy(readinessWaiting = false)
+                }
             }
             openingProjectRequests.remove(key, request)
+        }
+    }
+
+    private fun recordLifecycleOpenDiagnostic(
+        targetKey: String,
+        phase: String,
+        reason: String?,
+        project: Project? = null,
+        update: (LifecycleOpenDiagnostic) -> LifecycleOpenDiagnostic = { it },
+    ) {
+        val nowMs = lifecycleOpenDiagnosticNow()
+        cleanupLifecycleOpenDiagnostics(nowMs)
+        lifecycleOpenDiagnosticsByTarget.compute(targetKey) { _, existing ->
+            val base = if (phase == "scheduled") null else existing
+            val current = base ?: LifecycleOpenDiagnostic(
+                phase = phase,
+                reason = reason,
+                startedAtMs = nowMs,
+                updatedAtMs = nowMs,
+            )
+            val terminal = phase in setOf("ready", "unresolved", "failed", "open_returned_null", "opened_mismatched_or_reused")
+            update(current.copy(
+                phase = phase,
+                reason = reason,
+                updatedAtMs = nowMs,
+                outcomePhase = if (terminal) phase else current.outcomePhase,
+                outcomeReason = if (terminal) reason else current.outcomeReason,
+                outcomeAtMs = if (terminal) nowMs else current.outcomeAtMs,
+                projectInstanceId = project?.let(::projectInstanceId) ?: current.projectInstanceId,
+            ))
+        }
+        cleanupLifecycleOpenDiagnostics(nowMs)
+    }
+
+    private fun Map<String, Any?>.withLifecycleOpenDiagnostic(targetKey: String?): Map<String, Any?> {
+        if (targetKey == null) return this
+        val diagnostic = lifecycleOpenDiagnosticsByTarget[targetKey] ?: return this
+        val nowMs = lifecycleOpenDiagnosticNow()
+        cleanupLifecycleOpenDiagnostics(nowMs)
+        if (lifecycleOpenDiagnosticsByTarget[targetKey] !== diagnostic) return this
+        return toMutableMap().apply {
+            put("lifecycle_open_diagnostic", mapOf(
+                "phase" to diagnostic.phase,
+                "reason" to diagnostic.reason,
+                "started_at_ms" to diagnostic.startedAtMs,
+                "updated_at_ms" to diagnostic.updatedAtMs,
+                "elapsed_ms" to (nowMs - diagnostic.startedAtMs).coerceAtLeast(0),
+                "opening_scheduled" to diagnostic.openingScheduled,
+                "open_returned" to diagnostic.openReturned,
+                "ownership_registered" to diagnostic.ownershipRegistered,
+                "readiness_waiting" to diagnostic.readinessWaiting,
+                "unresolved" to diagnostic.unresolved,
+                "project_instance_id" to diagnostic.projectInstanceId,
+                "outcome_phase" to diagnostic.outcomePhase,
+                "outcome_reason" to diagnostic.outcomeReason,
+                "outcome_at_ms" to diagnostic.outcomeAtMs,
+            ).filterValues { value -> value != null })
+        }
+    }
+
+    private fun cleanupLifecycleOpenDiagnostics(nowMs: Long) {
+        val expirationMs = nowMs - lifecycleOpenDiagnosticTtlMs.coerceAtLeast(0)
+        lifecycleOpenDiagnosticsByTarget.entries.removeIf { (_, diagnostic) ->
+            diagnostic.updatedAtMs < expirationMs
+        }
+        val maxEntries = maxLifecycleOpenDiagnostics.coerceAtLeast(1)
+        val overflow = lifecycleOpenDiagnosticsByTarget.size - maxEntries
+        if (overflow > 0) {
+            lifecycleOpenDiagnosticsByTarget.entries
+                .sortedBy { (_, diagnostic) -> diagnostic.updatedAtMs }
+                .take(overflow)
+                .forEach { entry -> lifecycleOpenDiagnosticsByTarget.remove(entry.key, entry.value) }
         }
     }
 
@@ -3359,12 +3545,20 @@ class InspectionHandler : HttpRequestHandler() {
         )
     }
 
-    private fun lifecycleOpenAlreadyOpen(project: Project): Pair<Map<String, Any?>, HttpResponseStatus> {
+    private fun lifecycleOpenAlreadyOpen(
+        project: Project,
+        targetKey: String? = null,
+    ): Pair<Map<String, Any?>, HttpResponseStatus> {
         return mapOf(
             "status" to "already_open",
             "opened" to false,
             "session_id" to InspectionIdeSession.sessionId,
             "route" to routeMetadata(ResolvedInspectionRoute(project, safeInspectionIdentity(), openProjectIdentity(project))),
+            "lifecycle_open_diagnostic_version" to LIFECYCLE_OPEN_DIAGNOSTIC_VERSION,
+        ).withLifecycleOpenDiagnostic(
+            targetKey ?: lifecycleOpenKeys(project).firstOrNull { key ->
+                lifecycleOpenDiagnosticsByTarget.containsKey(key)
+            },
         ) to HttpResponseStatus.OK
     }
 
@@ -3377,7 +3571,8 @@ class InspectionHandler : HttpRequestHandler() {
             "worktree_path" to target.path.toString(),
             "project_root" to target.projectRoot.toString(),
             "session_id" to InspectionIdeSession.sessionId,
-        ) to HttpResponseStatus.OK
+            "lifecycle_open_diagnostic_version" to LIFECYCLE_OPEN_DIAGNOSTIC_VERSION,
+        ).withLifecycleOpenDiagnostic(target.key) to HttpResponseStatus.OK
     }
 
     private fun lifecycleOpenStateUnknown(
@@ -3407,7 +3602,8 @@ class InspectionHandler : HttpRequestHandler() {
             "project_root" to target.projectRoot.toString(),
             "session_id" to InspectionIdeSession.sessionId,
             "lifecycle_readiness" to lifecycleContentRootReadinessPayload(readiness),
-        ) to HttpResponseStatus.CONFLICT
+            "lifecycle_open_diagnostic_version" to LIFECYCLE_OPEN_DIAGNOSTIC_VERSION,
+        ).withLifecycleOpenDiagnostic(target.key) to HttpResponseStatus.CONFLICT
     }
 
     private fun resolveLifecycleOpenTarget(path: Path): LifecycleOpenTarget {

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -2932,6 +2932,28 @@ class InspectionHandler : HttpRequestHandler() {
         val normalizedPath = normalizeFileSystemPath(rawPath)
             ?: throw BadRequestException("worktree_path", "Parameter 'worktree_path' must be a valid local path.")
         val path = Paths.get(normalizedPath)
+        val probe = parseBooleanParameter(parameters, "probe", defaultValue = false)
+        if (probe) {
+            findOpenProjectForLifecycleOpen(path.toString())?.let { project ->
+                unresolvedLifecycleOpenProjects.entries
+                    .firstOrNull { entry -> entry.value === project && isUnresolvedLifecycleOpenActive(project) }
+                    ?.let { entry ->
+                        val projectRoot = Paths.get(entry.key)
+                        return lifecycleOpenStateUnknown(
+                            LifecycleOpenTarget(
+                                path = path,
+                                openPath = projectRoot,
+                                projectRoot = projectRoot,
+                                key = entry.key,
+                            ),
+                            project,
+                            probe = true,
+                        )
+                    }
+                return lifecycleOpenAlreadyOpen(project, probe = true)
+            }
+            return probeLifecycleOpen(resolveLifecycleOpenTarget(path))
+        }
         findOpenProjectForLifecycleOpen(path.toString())?.let { project ->
             unresolvedLifecycleOpenProjects.entries
                 .firstOrNull { entry -> entry.value === project }
@@ -2953,9 +2975,6 @@ class InspectionHandler : HttpRequestHandler() {
             return lifecycleOpenAlreadyOpen(project)
         }
         val target = resolveLifecycleOpenTarget(path)
-        if (parseBooleanParameter(parameters, "probe", defaultValue = false)) {
-            return probeLifecycleOpen(target)
-        }
         unresolvedLifecycleOpenProjects[target.key]?.let { project ->
             if (isUnresolvedLifecycleOpenActive(project)) {
                 return lifecycleOpenStateUnknown(target, project)
@@ -3118,14 +3137,14 @@ class InspectionHandler : HttpRequestHandler() {
         cleanupLifecycleOpenDiagnostics(lifecycleOpenDiagnosticNow())
         unresolvedLifecycleOpenProjects[target.key]?.let { project ->
             if (isUnresolvedLifecycleOpenActive(project)) {
-                return lifecycleOpenStateUnknown(target, project)
+                return lifecycleOpenStateUnknown(target, project, probe = true)
             }
         }
         findOpenProjectForLifecycleOpenKey(target.key)?.let { project ->
             return if (isUsableProject(project)) {
-                lifecycleOpenAlreadyOpen(project, target.key)
+                lifecycleOpenAlreadyOpen(project, target.key, probe = true)
             } else {
-                lifecycleOpenAlreadyOpening(target)
+                lifecycleOpenAlreadyOpening(target, probe = true)
             }
         }
         val opening = openingProjectRequests.containsKey(target.key)
@@ -3565,12 +3584,16 @@ class InspectionHandler : HttpRequestHandler() {
         ) to HttpResponseStatus.OK
     }
 
-    private fun lifecycleOpenAlreadyOpening(target: LifecycleOpenTarget): Pair<Map<String, Any?>, HttpResponseStatus> {
+    private fun lifecycleOpenAlreadyOpening(
+        target: LifecycleOpenTarget,
+        probe: Boolean = false,
+    ): Pair<Map<String, Any?>, HttpResponseStatus> {
         return mapOf(
             "status" to "opening",
             "opened" to false,
             "opening_scheduled" to false,
             "reason" to "already_opening",
+            "probe" to probe,
             "worktree_path" to target.path.toString(),
             "project_root" to target.projectRoot.toString(),
             "session_id" to InspectionIdeSession.sessionId,
@@ -3581,6 +3604,7 @@ class InspectionHandler : HttpRequestHandler() {
     private fun lifecycleOpenStateUnknown(
         target: LifecycleOpenTarget,
         project: Project,
+        probe: Boolean = false,
     ): Pair<Map<String, Any?>, HttpResponseStatus> {
         val observedReadiness = lifecycleContentRootReadinessProvider(project, target.key)
         val readiness = if (observedReadiness.ready) {
@@ -3594,6 +3618,7 @@ class InspectionHandler : HttpRequestHandler() {
             "opened" to false,
             "opening_scheduled" to false,
             "reason" to if (contentRootFailure) "project_content_roots_missing" else "open_state_unknown",
+            "probe" to probe,
             "message" to if (contentRootFailure) {
                 "The IDE opened the project but did not establish a content root covering the requested worktree before the guard timeout."
             } else if (readiness.reason == "project_configuration_unstable") {

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -3115,6 +3115,7 @@ class InspectionHandler : HttpRequestHandler() {
     }
 
     private fun probeLifecycleOpen(target: LifecycleOpenTarget): Pair<Map<String, Any?>, HttpResponseStatus> {
+        cleanupLifecycleOpenDiagnostics(lifecycleOpenDiagnosticNow())
         unresolvedLifecycleOpenProjects[target.key]?.let { project ->
             if (isUnresolvedLifecycleOpenActive(project)) {
                 return lifecycleOpenStateUnknown(target, project)
@@ -3548,10 +3549,12 @@ class InspectionHandler : HttpRequestHandler() {
     private fun lifecycleOpenAlreadyOpen(
         project: Project,
         targetKey: String? = null,
+        probe: Boolean = false,
     ): Pair<Map<String, Any?>, HttpResponseStatus> {
         return mapOf(
             "status" to "already_open",
             "opened" to false,
+            "probe" to probe,
             "session_id" to InspectionIdeSession.sessionId,
             "route" to routeMetadata(ResolvedInspectionRoute(project, safeInspectionIdentity(), openProjectIdentity(project))),
             "lifecycle_open_diagnostic_version" to LIFECYCLE_OPEN_DIAGNOSTIC_VERSION,

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionIdeIdentity.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionIdeIdentity.kt
@@ -84,6 +84,7 @@ internal fun buildInspectionIdentity(): Map<String, Any?> {
         "plugin_build_time" to buildInfo.time,
         "inspection_execution_proof_version" to INSPECTION_EXECUTION_PROOF_VERSION,
         "lifecycle_ownership_protocol" to LIFECYCLE_OWNERSHIP_PROTOCOL,
+        "lifecycle_open_diagnostic_version" to LIFECYCLE_OPEN_DIAGNOSTIC_VERSION,
         "open_projects" to openProjectIdentities(),
     )
 }

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -5530,6 +5530,20 @@ class InspectionHandlerTest {
     }
 
     @Test
+    fun `test lifecycle open probe marks already open response without scheduling`() {
+        every { mockProject.basePath } returns "/tmp/TestProject"
+        every { mockProject.projectFilePath } returns "/tmp/TestProject/.idea/misc.xml"
+
+        val response = processGetRequest(lifecycleOpenUri("/tmp/TestProject", probe = true))
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"status\": \"already_open\""))
+        assertTrue(body.contains("\"probe\": true"))
+        verify(exactly = 0) { mockApplication.invokeLater(any()) }
+    }
+
+    @Test
     fun `test lifecycle open resets diagnostic for a new attempt`() {
         val tempDir = Files.createTempDirectory("inspection-open-diagnostic-reset")
         every { mockProjectManager.openProjects } returns emptyArray()

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -4758,16 +4758,19 @@ class InspectionHandlerTest {
             basePath = tempDir.toString(),
             projectFilePath = tempDir.resolve(".idea/misc.xml").toString(),
         )
-        every { mockProjectManager.openProjects } returns emptyArray()
+        var openProjects = emptyArray<Project>()
+        every { mockProjectManager.openProjects } answers { openProjects }
         every { mockApplication.invokeLater(any()) } answers {
             firstArg<Runnable>().run()
         }
+        runPooledTasksInline()
         var trustedPath: Path? = null
         var openedPath: Path? = null
         handler.trustProjectPath = { path: Path -> trustedPath = path }
         handler.openProjectPath = { path: Path, beforeInit ->
             openedPath = path
             beforeInit(openedProject)
+            openProjects = arrayOf(openedProject)
             openedProject
         }
 
@@ -4779,6 +4782,10 @@ class InspectionHandlerTest {
         assertTrue(body.contains("\"opened\": false"))
         assertTrue(body.contains("\"opening_scheduled\": true"))
         assertTrue(body.contains("\"ownership_registered\": true"))
+        assertTrue(body.contains("\"lifecycle_open_diagnostic\""))
+        assertTrue(body.contains("\"phase\": \"ready\""))
+        assertTrue(body.contains("\"ownership_registered\": true"))
+        assertTrue(body.contains("\"project_instance_id\""))
         assertTrue(body.contains("\"lifecycle_ownership_protocol\": \"lease_bound_v1\""))
         assertTrue(body.contains(tempDir.toString()))
         assertEquals(tempDir.toAbsolutePath().normalize(), openedPath)
@@ -5469,11 +5476,80 @@ class InspectionHandlerTest {
         assertEquals(HttpResponseStatus.OK, second.status())
         assertEquals(1, scheduled.size)
         assertTrue(secondBody.contains("\"reason\": \"already_opening\""))
+        assertTrue(secondBody.contains("\"lifecycle_open_diagnostic\""))
+        assertTrue(secondBody.contains("\"phase\": \"scheduled\""))
         assertTrue(secondBody.contains("\"opening_scheduled\": false"))
         scheduled.single().run()
         val third = processGetRequest(lifecycleOpenUri(tempDir))
         assertEquals(2, scheduled.size)
         assertEquals(HttpResponseStatus.OK, third.status())
+    }
+
+    @Test
+    fun `test lifecycle open records null project result`() {
+        val tempDir = Files.createTempDirectory("inspection-open-null-result")
+        every { mockProjectManager.openProjects } returns emptyArray()
+        every { mockApplication.invokeLater(any()) } answers {
+            firstArg<Runnable>().run()
+        }
+        handler.openProjectPath = { _, _ -> null }
+
+        val response = processGetRequest(lifecycleOpenUri(tempDir))
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"lifecycle_open_diagnostic\""))
+        assertTrue(body.contains("\"phase\": \"open_returned_null\""))
+        assertTrue(body.contains("\"reason\": \"project_open_returned_null\""))
+        assertTrue(body.contains("\"open_returned\": true"))
+
+        val probeBody = processGetRequest(lifecycleOpenUri(tempDir, probe = true))
+            .content()
+            .toString(Charsets.UTF_8)
+
+        assertTrue(probeBody.contains("\"status\": \"not_open\""))
+        assertTrue(probeBody.contains("\"probe\": true"))
+        assertTrue(probeBody.contains("\"phase\": \"open_returned_null\""))
+        verify(exactly = 1) { mockApplication.invokeLater(any()) }
+    }
+
+    @Test
+    fun `test lifecycle open probe never schedules a project open`() {
+        val tempDir = Files.createTempDirectory("inspection-open-probe")
+        every { mockProjectManager.openProjects } returns emptyArray()
+
+        val response = processGetRequest(lifecycleOpenUri(tempDir, probe = true))
+        val body = response.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, response.status())
+        assertTrue(body.contains("\"status\": \"not_open\""))
+        assertTrue(body.contains("\"reason\": \"project_not_open\""))
+        assertTrue(body.contains("\"probe\": true"))
+        assertTrue(body.contains("\"opening_scheduled\": false"))
+        verify(exactly = 0) { mockApplication.invokeLater(any()) }
+    }
+
+    @Test
+    fun `test lifecycle open resets diagnostic for a new attempt`() {
+        val tempDir = Files.createTempDirectory("inspection-open-diagnostic-reset")
+        every { mockProjectManager.openProjects } returns emptyArray()
+        every { mockApplication.invokeLater(any()) } answers {
+            firstArg<Runnable>().run()
+        }
+        var nowMs = 10L
+        var openResult: Project? = null
+        handler.lifecycleOpenDiagnosticNow = { nowMs }
+        handler.openProjectPath = { _, callback ->
+            openResult?.also(callback)
+        }
+
+        processGetRequest(lifecycleOpenUri(tempDir))
+        nowMs = 100L
+        val second = processGetRequest(lifecycleOpenUri(tempDir))
+        val secondBody = second.content().toString(Charsets.UTF_8)
+
+        assertTrue(secondBody.contains("\"started_at_ms\": 100"))
+        assertTrue(secondBody.contains("\"outcome_at_ms\": 100"))
     }
 
     @Test
@@ -5748,6 +5824,9 @@ class InspectionHandlerTest {
         assertTrue(secondBody.contains("\"status\": \"failed\""))
         assertTrue(secondBody.contains("\"reason\": \"open_state_unknown\""))
         assertTrue(secondBody.contains("\"opening_scheduled\": false"))
+        assertTrue(secondBody.contains("\"lifecycle_open_diagnostic\""))
+        assertTrue(secondBody.contains("\"phase\": \"unresolved\""))
+        assertTrue(secondBody.contains("\"outcome_reason\": \"readiness_guard_timeout\""))
     }
 
     @Test
@@ -7097,15 +7176,23 @@ class InspectionHandlerTest {
         return processGetRequest(uri)
     }
 
-    private fun lifecycleOpenUri(path: Path, leaseId: String = "test-open-lease"): String {
-        return lifecycleOpenUri(path.toString(), leaseId)
+    private fun lifecycleOpenUri(
+        path: Path,
+        leaseId: String = "test-open-lease",
+        probe: Boolean = false,
+    ): String {
+        return lifecycleOpenUri(path.toString(), leaseId, probe)
     }
 
-    private fun lifecycleOpenUri(path: String, leaseId: String = "test-open-lease"): String {
+    private fun lifecycleOpenUri(
+        path: String,
+        leaseId: String = "test-open-lease",
+        probe: Boolean = false,
+    ): String {
         val encodedPath = java.net.URLEncoder.encode(path, "UTF-8")
         val encodedSession = java.net.URLEncoder.encode(InspectionIdeSession.sessionId, "UTF-8")
         val encodedLeaseId = java.net.URLEncoder.encode(leaseId, "UTF-8")
-        return "/api/inspection/lifecycle/open?worktree_path=$encodedPath&session_id=$encodedSession&lease_id=$encodedLeaseId"
+        return "/api/inspection/lifecycle/open?worktree_path=$encodedPath&session_id=$encodedSession&lease_id=$encodedLeaseId&probe=$probe"
     }
 
     private fun runPooledTasksInline() {

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -5553,6 +5553,57 @@ class InspectionHandlerTest {
     }
 
     @Test
+    fun `test lifecycle open diagnostic expires after ttl`() {
+        val tempDir = Files.createTempDirectory("inspection-open-diagnostic-ttl")
+        every { mockProjectManager.openProjects } returns emptyArray()
+        every { mockApplication.invokeLater(any()) } answers {
+            firstArg<Runnable>().run()
+        }
+        var nowMs = 10L
+        handler.lifecycleOpenDiagnosticNow = { nowMs }
+        handler.lifecycleOpenDiagnosticTtlMs = 5L
+        handler.openProjectPath = { _, _ -> null }
+
+        processGetRequest(lifecycleOpenUri(tempDir))
+        nowMs = 20L
+        val probeBody = processGetRequest(lifecycleOpenUri(tempDir, probe = true))
+            .content()
+            .toString(Charsets.UTF_8)
+
+        assertTrue(probeBody.contains("\"diagnostic_available\": false"))
+        assertFalse(probeBody.contains("\"lifecycle_open_diagnostic\""))
+    }
+
+    @Test
+    fun `test lifecycle open diagnostic evicts oldest entry above limit`() {
+        val firstDir = Files.createTempDirectory("inspection-open-diagnostic-first")
+        val secondDir = Files.createTempDirectory("inspection-open-diagnostic-second")
+        every { mockProjectManager.openProjects } returns emptyArray()
+        every { mockApplication.invokeLater(any()) } answers {
+            firstArg<Runnable>().run()
+        }
+        var nowMs = 10L
+        handler.lifecycleOpenDiagnosticNow = { nowMs }
+        handler.maxLifecycleOpenDiagnostics = 1
+        handler.openProjectPath = { _, _ -> null }
+
+        processGetRequest(lifecycleOpenUri(firstDir))
+        nowMs = 20L
+        processGetRequest(lifecycleOpenUri(secondDir))
+
+        val firstProbe = processGetRequest(lifecycleOpenUri(firstDir, probe = true))
+            .content()
+            .toString(Charsets.UTF_8)
+        val secondProbe = processGetRequest(lifecycleOpenUri(secondDir, probe = true))
+            .content()
+            .toString(Charsets.UTF_8)
+
+        assertTrue(firstProbe.contains("\"diagnostic_available\": false"))
+        assertTrue(secondProbe.contains("\"diagnostic_available\": true"))
+        assertTrue(secondProbe.contains("\"phase\": \"open_returned_null\""))
+    }
+
+    @Test
     fun `test lifecycle open keeps opening guard until returned project is initialized`() {
         val tempDir = Files.createTempDirectory("inspection-open-initializing")
         val openProjects = arrayOfNulls<Project>(1)


### PR DESCRIPTION
## Summary
- record bounded per-target lifecycle-open progress and terminal outcomes without changing project-open behavior
- advertise `lifecycle_open_diagnostic_version: 1` and expose `probe=true` as a strictly non-scheduling, non-trusting, non-claiming state query
- preserve exact-worktree routing, route hiding, lease ownership, trust prompts, timeout length, and cleanup behavior
- bound diagnostics by 10-minute TTL and 128 entries with direct regression coverage

## Evidence
- current PyCharm 2026.2.1: root and first linked-worktree cold imports completed in ~155–161s; warm and three fresh linked paths completed in 4–6s
- original August 10 accepted request never exposed its target route before the IDE restarted
- no speculative open retry or timeout change is included; this PR makes the next recurrence explainable

## Validation
- focused `InspectionHandlerTest` suite
- full `./scripts/commit-gate.sh --ci`
- route-safe changed-files inspection: GREEN, zero findings, clean cleanup
- final Claude Opus cross-repository review: APPROVE; Gemini/Antigravity returned no artifact

## Follow-up
- Companion helper issue: cbusillo/codex-skills#540
- Land this plugin contract before the helper consumer PR.

Refs #104
