### PR TITLE
Pin CI actions and refresh version examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           java-version: "21"
           distribution: "temurin"
@@ -31,14 +31,14 @@ jobs:
 
       - name: Lint GitHub Actions workflows for pull requests
         if: github.event_name == 'pull_request'
-        uses: reviewdog/action-actionlint@v1
+        uses: reviewdog/action-actionlint@d63ba7532e0942965320cd8d73cbae4c7b3c5283 # v1
         with:
           fail_level: error
           reporter: github-pr-annotations
 
       - name: Lint GitHub Actions workflows for pushes
         if: github.event_name == 'push'
-        uses: reviewdog/action-actionlint@v1
+        uses: reviewdog/action-actionlint@d63ba7532e0942965320cd8d73cbae4c7b3c5283 # v1
         with:
           fail_level: error
           reporter: github-check
@@ -50,7 +50,7 @@ jobs:
         run: ./scripts/commit-gate.sh --ci
 
       - name: Upload test results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: test-results

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Typical response (truncated):
       "name": "IntelliJ IDEA Ultimate",
       "product_code": "IU",
       "channel": "stable",
-      "plugin_version": "1.13.17",
+      "plugin_version": "1.14.0",
       "plugin_build_fingerprint": "abc123def456abc123def456abc123def456abcd-clean"
     }
   },
@@ -270,7 +270,7 @@ routing state.
       "version": "2025.1.1",
       "product_code": "IU",
       "channel": "stable",
-      "plugin_version": "1.13.17",
+      "plugin_version": "1.14.0",
       "plugin_build_fingerprint": "abc123def456abc123def456abc123def456abcd-clean"
     }
   },
@@ -932,7 +932,7 @@ Shortcut:
 ./scripts/release.sh --patch
 
 # After that PR merges and local main is updated
-./scripts/release.sh tag v1.13.17
+./scripts/release.sh tag vX.Y.Z
 ```
 
 Prepare mode never commits or pushes directly to `main` and never creates a

--- a/scripts/test-release-contracts.sh
+++ b/scripts/test-release-contracts.sh
@@ -845,6 +845,14 @@ PY
 from pathlib import Path
 import re
 
+for workflow_path in sorted(Path(".github/workflows").glob("*.yml")):
+    for line in workflow_path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("uses:") and not re.search(r"@[0-9a-f]{40}(?:\s+#\s+v\d+)?$", stripped):
+            raise SystemExit(
+                f"workflow action is not pinned to a full commit SHA in {workflow_path}: {stripped}"
+            )
+
 build = Path("build.gradle.kts").read_text(encoding="utf-8")
 canary_validator = Path("scripts/validate-canary-artifact.sh").read_text(encoding="utf-8")
 stable_validator = Path("scripts/validate-stable-artifact.sh").read_text(encoding="utf-8")
@@ -869,11 +877,6 @@ package = workflow.split("\n  package:\n", 1)[1].split("\n  verify:\n", 1)[0]
 verify = workflow.split("\n  verify:\n", 1)[1].split("\n  release:\n", 1)[0]
 release = workflow.split("\n  release:\n", 1)[1].split("\n  publish:\n", 1)[0]
 publish = workflow.split("\n  publish:\n", 1)[1]
-
-for line in workflow.splitlines():
-    stripped = line.strip()
-    if stripped.startswith("uses:") and not re.search(r"@[0-9a-f]{40}(?:\s+#\s+v\d+)?$", stripped):
-        raise SystemExit(f"Stable workflow action is not pinned to a full commit SHA: {stripped}")
 
 if "Run commit gate" not in test or "PUBLISH_TOKEN" in test:
     raise SystemExit("Stable test job trust boundary is invalid")
@@ -965,11 +968,6 @@ package = workflow.split("\n  package:\n", 1)[1].split("\n  verify:\n", 1)[0]
 verify = workflow.split("\n  verify:\n", 1)[1].split("\n  publish:\n", 1)[0]
 publish = workflow.split("\n  publish:\n", 1)[1].split("\n  release:\n", 1)[0]
 release = workflow.split("\n  release:\n", 1)[1]
-
-for line in workflow.splitlines():
-    stripped = line.strip()
-    if stripped.startswith("uses:") and not re.search(r"@[0-9a-f]{40}(?:\s+#\s+v\d+)?$", stripped):
-        raise SystemExit(f"canary workflow action is not pinned to a full commit SHA: {stripped}")
 
 build_steps = [
     "Verify trusted workflow ref",


### PR DESCRIPTION
## Summary
- pin CI workflow actions to reviewed full commit SHAs
- enforce SHA pinning across every repository workflow
- refresh stale plugin-version and release-tag examples

## Validation
- `actionlint .github/workflows/ci.yml .github/workflows/release.yml .github/workflows/canary-release.yml`
- `bash -n scripts/test-release-contracts.sh`
- `./scripts/test-release-contracts.sh`
- full commit hook / repository gate passed

Dependabot remains configured for the `github-actions` ecosystem and can keep the pinned action references current.