### PR TITLE
Preserve active lifecycle probe state

### DIFF
--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -2950,6 +2950,20 @@ class InspectionHandler : HttpRequestHandler() {
                             probe = true,
                         )
                     }
+                lifecycleOpenKeys(project)
+                    .firstOrNull { key -> openingProjectRequests.containsKey(key) }
+                    ?.let { key ->
+                        val projectRoot = Paths.get(key)
+                        return lifecycleOpenAlreadyOpening(
+                            LifecycleOpenTarget(
+                                path = path,
+                                openPath = projectRoot,
+                                projectRoot = projectRoot,
+                                key = key,
+                            ),
+                            probe = true,
+                        )
+                    }
                 return lifecycleOpenAlreadyOpen(project, probe = true)
             }
             return probeLifecycleOpen(resolveLifecycleOpenTarget(path))
@@ -3139,6 +3153,9 @@ class InspectionHandler : HttpRequestHandler() {
             if (isUnresolvedLifecycleOpenActive(project)) {
                 return lifecycleOpenStateUnknown(target, project, probe = true)
             }
+        }
+        if (openingProjectRequests.containsKey(target.key)) {
+            return lifecycleOpenAlreadyOpening(target, probe = true)
         }
         findOpenProjectForLifecycleOpenKey(target.key)?.let { project ->
             return if (isUsableProject(project)) {

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -5544,6 +5544,51 @@ class InspectionHandlerTest {
     }
 
     @Test
+    fun `test lifecycle open probe reports active request while visible project awaits readiness`() {
+        val tempDir = Files.createTempDirectory("inspection-open-probe-active-request")
+        val openProjects = arrayOfNulls<Project>(1)
+        every { mockProjectManager.openProjects } answers { openProjects.filterNotNull().toTypedArray() }
+        val initializingProject = mockk<Project>()
+        every { initializingProject.isDefault } returns false
+        every { initializingProject.isDisposed } returns false
+        every { initializingProject.isInitialized } returns true
+        every { initializingProject.name } returns "inspection-open-probe-active-request"
+        every { initializingProject.basePath } returns tempDir.toString()
+        every { initializingProject.projectFilePath } returns tempDir.resolve(".idea/misc.xml").toString()
+        val scheduled = mutableListOf<Runnable>()
+        val guardPolls = mutableListOf<Runnable>()
+        every { mockApplication.invokeLater(any()) } answers {
+            scheduled += firstArg<Runnable>()
+        }
+        every { mockApplication.executeOnPooledThread(any<Runnable>()) } answers {
+            guardPolls += firstArg<Runnable>()
+            mockk(relaxed = true)
+        }
+        handler.openProjectPath = { _, beforeInit ->
+            openProjects[0] = initializingProject
+            beforeInit(initializingProject)
+            initializingProject
+        }
+
+        val first = processGetRequest(lifecycleOpenUri(tempDir))
+        scheduled.single().run()
+        val probe = processGetRequest(lifecycleOpenUri(tempDir, probe = true))
+
+        val firstBody = first.content().toString(Charsets.UTF_8)
+        val probeBody = probe.content().toString(Charsets.UTF_8)
+
+        assertEquals(HttpResponseStatus.OK, first.status())
+        assertEquals(HttpResponseStatus.OK, probe.status())
+        assertTrue(firstBody.contains("\"status\": \"opening\""))
+        assertTrue(probeBody.contains("\"status\": \"opening\""))
+        assertTrue(probeBody.contains("\"reason\": \"already_opening\""))
+        assertTrue(probeBody.contains("\"probe\": true"))
+        assertTrue(probeBody.contains("\"opening_scheduled\": false"))
+        assertEquals(1, scheduled.size)
+        assertEquals(1, guardPolls.size)
+    }
+
+    @Test
     fun `test lifecycle open resets diagnostic for a new attempt`() {
         val tempDir = Files.createTempDirectory("inspection-open-diagnostic-reset")
         every { mockProjectManager.openProjects } returns emptyArray()


### PR DESCRIPTION
## Summary
- report `opening` from read-only lifecycle probes while the matching readiness guard remains active
- preserve existing already-open probe behavior, including paths that are no longer resolvable on disk
- add a regression test for the project-visible/readiness-pending race

## Validation
- regression test failed on unchanged `main`, then passed with the fix
- full 225-test `InspectionHandlerTest` class passed
- `./scripts/commit-gate.sh --ci` passed
- exact-diff independent review approved; Antigravity returned no artifact
- JetBrains closeout routed to the exact worktree and cleaned up successfully; IntelliJ 2026.2.1 reported the repo's broad existing warning baseline (5,171 warnings across whole changed files), with no surfaced finding on the modified probe branches or regression test

This is a focused follow-up to the lifecycle diagnostic contract landed in #314.