### PR TITLE
Ignore generated editor severity state

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -2,6 +2,7 @@
 /.name
 /shelf/
 /workspace.xml
+/editor.xml
 # Editor-based HTTP Client requests
 /httpRequests/
 # Datasource local storage ignored files


### PR DESCRIPTION
## Summary
- ignore IntelliJ-generated `.idea/editor.xml` project severity state
- keep the shared checkout clean without deleting local IDE configuration

## Validation
- `git check-ignore -v .idea/editor.xml`
- `git diff --check`
- commit gate passed via the repository commit hook
