### PR TITLE
Prototype supported global context path and record no-go evidence

### DIFF
--- a/src/main/kotlin/com/shiny/inspectionmcp/GlobalInspectionContextBoundary.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/GlobalInspectionContextBoundary.kt
@@ -1,19 +1,23 @@
 package com.shiny.inspectionmcp
 
 import com.intellij.analysis.AnalysisScope
+import com.intellij.codeInspection.CommonProblemDescriptor
 import com.intellij.codeInspection.GlobalInspectionContext
 import com.intellij.codeInspection.InspectionManager
 import com.intellij.codeInspection.ex.GlobalInspectionContextEx
+import com.intellij.codeInspection.ex.InspectionProblemConsumer
 import com.intellij.codeInspection.ex.InspectionProfileImpl
 import com.intellij.codeInspection.ex.InspectionToolWrapper
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.Comparator
+import java.util.concurrent.atomic.AtomicInteger
 
 internal data class StandardGlobalInspectionExecutionResult(
     val exportedResultPathCount: Int,
     val exportedResultPathCountTruncated: Boolean,
     val exportDirectoryDeleted: Boolean,
+    val consumedProblemCount: Int,
 )
 
 @Suppress("UnstableApiUsage")
@@ -31,19 +35,28 @@ internal class GlobalInspectionContextBoundary private constructor(
 
     fun presentation(toolWrapper: InspectionToolWrapper<*, *>) = context.getPresentation(toolWrapper)
 
-    fun performInspectionsWithProgressAndExportResults(scope: AnalysisScope): StandardGlobalInspectionExecutionResult {
+    fun launchInspectionsOffline(
+        scope: AnalysisScope,
+        consumeProblem: (CommonProblemDescriptor, InspectionToolWrapper<*, *>) -> Unit,
+    ): StandardGlobalInspectionExecutionResult {
         val exportDirectory = Files.createTempDirectory("jetbrains-inspection-export-")
         val exportedResultPaths = mutableListOf<Path>()
+        val consumedProblemCount = AtomicInteger()
         var exportedResultPathCount = 0
         var exportedResultPathCountTruncated = false
         var exportDirectoryDeleted = false
 
+        context.setProblemConsumer(
+            InspectionProblemConsumer { _, descriptor, toolWrapper ->
+                consumedProblemCount.incrementAndGet()
+                consumeProblem(descriptor, toolWrapper)
+            }
+        )
         try {
-            context.performInspectionsWithProgressAndExportResults(
+            context.launchInspectionsOffline(
                 scope,
-                false,
-                false,
                 exportDirectory,
+                false,
                 exportedResultPaths,
             )
             exportedResultPathCount = exportedResultPaths.size.coerceAtMost(MAX_EXPORTED_RESULT_PATHS)
@@ -56,6 +69,7 @@ internal class GlobalInspectionContextBoundary private constructor(
             exportedResultPathCount = exportedResultPathCount,
             exportedResultPathCountTruncated = exportedResultPathCountTruncated,
             exportDirectoryDeleted = exportDirectoryDeleted,
+            consumedProblemCount = consumedProblemCount.get(),
         )
     }
 
@@ -77,12 +91,14 @@ internal class GlobalInspectionContextBoundary private constructor(
 
     companion object {
         fun createStandard(inspectionManager: InspectionManager): GlobalInspectionContextBoundary {
-            val context = inspectionManager.createNewGlobalContext() as? GlobalInspectionContextEx
-                ?: error("InspectionManager.createNewGlobalContext() did not return GlobalInspectionContextEx")
+            val context = synchronized(inspectionManager) {
+                inspectionManager.createNewGlobalContext() as? GlobalInspectionContextEx
+                    ?: error("InspectionManager.createNewGlobalContext() did not return GlobalInspectionContextEx")
+            }
             return GlobalInspectionContextBoundary(
                 inspectionManager = inspectionManager,
                 context = context,
-                synchronizeLifecycle = false,
+                synchronizeLifecycle = true,
             )
         }
 

--- a/src/main/kotlin/com/shiny/inspectionmcp/GlobalInspectionContextBoundary.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/GlobalInspectionContextBoundary.kt
@@ -4,7 +4,6 @@ import com.intellij.analysis.AnalysisScope
 import com.intellij.codeInspection.GlobalInspectionContext
 import com.intellij.codeInspection.InspectionManager
 import com.intellij.codeInspection.ex.GlobalInspectionContextEx
-import com.intellij.codeInspection.ex.InspectionManagerEx
 import com.intellij.codeInspection.ex.InspectionProfileImpl
 import com.intellij.codeInspection.ex.InspectionToolWrapper
 import java.nio.file.Files
@@ -19,8 +18,9 @@ internal data class StandardGlobalInspectionExecutionResult(
 
 @Suppress("UnstableApiUsage")
 internal class GlobalInspectionContextBoundary private constructor(
-    private val inspectionManager: InspectionManagerEx,
+    private val inspectionManager: InspectionManager,
     private val context: GlobalInspectionContextEx,
+    private val synchronizeLifecycle: Boolean,
 ) {
     fun configure(profile: InspectionProfileImpl, scope: AnalysisScope) {
         context.setExternalProfile(profile)
@@ -61,31 +61,29 @@ internal class GlobalInspectionContextBoundary private constructor(
 
     fun publicContext(): GlobalInspectionContext = context
 
-    fun close(save: Boolean) {
-        context.close(save)
+    fun close(noSuspiciousCodeFound: Boolean) {
+        if (synchronizeLifecycle) {
+            synchronized(inspectionManager) {
+                context.close(noSuspiciousCodeFound)
+            }
+        } else {
+            context.close(noSuspiciousCodeFound)
+        }
     }
 
     fun cleanup() {
         context.cleanup()
     }
 
-    fun removeFromRunningContexts() {
-        inspectionManager.runningContexts.remove(context)
-    }
-
-    fun removeFromRunningContextsSynchronously() {
-        synchronized(inspectionManager) {
-            inspectionManager.runningContexts.remove(context)
-        }
-    }
-
     companion object {
         fun createStandard(inspectionManager: InspectionManager): GlobalInspectionContextBoundary {
             val context = inspectionManager.createNewGlobalContext() as? GlobalInspectionContextEx
                 ?: error("InspectionManager.createNewGlobalContext() did not return GlobalInspectionContextEx")
-            val inspectionManagerEx = inspectionManager as? InspectionManagerEx
-                ?: error("InspectionManager did not provide InspectionManagerEx lifecycle support")
-            return GlobalInspectionContextBoundary(inspectionManagerEx, context)
+            return GlobalInspectionContextBoundary(
+                inspectionManager = inspectionManager,
+                context = context,
+                synchronizeLifecycle = false,
+            )
         }
 
         fun createForExactFile(inspectionManager: InspectionManager): GlobalInspectionContextBoundary {
@@ -93,9 +91,11 @@ internal class GlobalInspectionContextBoundary private constructor(
                 inspectionManager.createNewGlobalContext() as? GlobalInspectionContextEx
                     ?: error("InspectionManager.createNewGlobalContext() did not return GlobalInspectionContextEx")
             }
-            val inspectionManagerEx = inspectionManager as? InspectionManagerEx
-                ?: error("InspectionManager did not provide InspectionManagerEx lifecycle support")
-            return GlobalInspectionContextBoundary(inspectionManagerEx, context)
+            return GlobalInspectionContextBoundary(
+                inspectionManager = inspectionManager,
+                context = context,
+                synchronizeLifecycle = true,
+            )
         }
 
         private fun deleteRecursively(path: Path): Boolean = runCatching {

--- a/src/main/kotlin/com/shiny/inspectionmcp/GlobalInspectionContextBoundary.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/GlobalInspectionContextBoundary.kt
@@ -2,21 +2,25 @@ package com.shiny.inspectionmcp
 
 import com.intellij.analysis.AnalysisScope
 import com.intellij.codeInspection.GlobalInspectionContext
+import com.intellij.codeInspection.InspectionManager
 import com.intellij.codeInspection.ex.GlobalInspectionContextEx
-import com.intellij.codeInspection.ex.GlobalInspectionContextImpl
-import com.intellij.codeInspection.ex.InspectListener
 import com.intellij.codeInspection.ex.InspectionManagerEx
 import com.intellij.codeInspection.ex.InspectionProfileImpl
 import com.intellij.codeInspection.ex.InspectionToolWrapper
-import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.NotNullLazyValue
-import com.intellij.psi.PsiFile
-import com.intellij.ui.content.ContentManager
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Comparator
+
+internal data class StandardGlobalInspectionExecutionResult(
+    val exportedResultPathCount: Int,
+    val exportedResultPathCountTruncated: Boolean,
+    val exportDirectoryDeleted: Boolean,
+)
 
 @Suppress("UnstableApiUsage")
 internal class GlobalInspectionContextBoundary private constructor(
     private val inspectionManager: InspectionManagerEx,
-    private val context: GlobalInspectionContextImpl,
+    private val context: GlobalInspectionContextEx,
 ) {
     fun configure(profile: InspectionProfileImpl, scope: AnalysisScope) {
         context.setExternalProfile(profile)
@@ -27,8 +31,32 @@ internal class GlobalInspectionContextBoundary private constructor(
 
     fun presentation(toolWrapper: InspectionToolWrapper<*, *>) = context.getPresentation(toolWrapper)
 
-    fun performInspectionsWithProgress(scope: AnalysisScope) {
-        context.performInspectionsWithProgress(scope, false, false)
+    fun performInspectionsWithProgressAndExportResults(scope: AnalysisScope): StandardGlobalInspectionExecutionResult {
+        val exportDirectory = Files.createTempDirectory("jetbrains-inspection-export-")
+        val exportedResultPaths = mutableListOf<Path>()
+        var exportedResultPathCount = 0
+        var exportedResultPathCountTruncated = false
+        var exportDirectoryDeleted = false
+
+        try {
+            context.performInspectionsWithProgressAndExportResults(
+                scope,
+                false,
+                false,
+                exportDirectory,
+                exportedResultPaths,
+            )
+            exportedResultPathCount = exportedResultPaths.size.coerceAtMost(MAX_EXPORTED_RESULT_PATHS)
+            exportedResultPathCountTruncated = exportedResultPaths.size > MAX_EXPORTED_RESULT_PATHS
+        } finally {
+            exportDirectoryDeleted = deleteRecursively(exportDirectory)
+        }
+
+        return StandardGlobalInspectionExecutionResult(
+            exportedResultPathCount = exportedResultPathCount,
+            exportedResultPathCountTruncated = exportedResultPathCountTruncated,
+            exportDirectoryDeleted = exportDirectoryDeleted,
+        )
     }
 
     fun publicContext(): GlobalInspectionContext = context
@@ -52,88 +80,30 @@ internal class GlobalInspectionContextBoundary private constructor(
     }
 
     companion object {
-        fun create(inspectionManager: InspectionManagerEx): GlobalInspectionContextBoundary {
-            val context = inspectionManager.createNewGlobalContext()
-            return GlobalInspectionContextBoundary(inspectionManager, context)
+        fun createStandard(inspectionManager: InspectionManager): GlobalInspectionContextBoundary {
+            val context = inspectionManager.createNewGlobalContext() as? GlobalInspectionContextEx
+                ?: error("InspectionManager.createNewGlobalContext() did not return GlobalInspectionContextEx")
+            val inspectionManagerEx = inspectionManager as? InspectionManagerEx
+                ?: error("InspectionManager did not provide InspectionManagerEx lifecycle support")
+            return GlobalInspectionContextBoundary(inspectionManagerEx, context)
         }
 
-        fun createForExactFile(inspectionManager: InspectionManagerEx): GlobalInspectionContextBoundary {
+        fun createForExactFile(inspectionManager: InspectionManager): GlobalInspectionContextBoundary {
             val context = synchronized(inspectionManager) {
-                inspectionManager.createNewGlobalContext()
+                inspectionManager.createNewGlobalContext() as? GlobalInspectionContextEx
+                    ?: error("InspectionManager.createNewGlobalContext() did not return GlobalInspectionContextEx")
             }
-            return GlobalInspectionContextBoundary(inspectionManager, context)
+            val inspectionManagerEx = inspectionManager as? InspectionManagerEx
+                ?: error("InspectionManager did not provide InspectionManagerEx lifecycle support")
+            return GlobalInspectionContextBoundary(inspectionManagerEx, context)
         }
 
-        fun createAttested(
-            inspectionManager: InspectionManagerEx,
-            project: Project,
-            collector: NativeInspectionExecutionProofCollector,
-        ): GlobalInspectionContextBoundary {
-            val context = NativeAttestedGlobalInspectionContext(project, inspectionManager.contentManager, collector)
-            inspectionManager.runningContexts.add(context)
-            context.openSynchronousFileTraversalGate()
-            return GlobalInspectionContextBoundary(inspectionManager, context)
-        }
-    }
-}
+        private fun deleteRecursively(path: Path): Boolean = runCatching {
+            Files.walk(path).use { paths ->
+                paths.sorted(Comparator.reverseOrder()).forEach(Files::deleteIfExists)
+            }
+        }.isSuccess
 
-@Suppress("UnstableApiUsage")
-private class NativeAttestedGlobalInspectionContext(
-    project: Project,
-    contentManager: NotNullLazyValue<out ContentManager>,
-    collector: NativeInspectionExecutionProofCollector,
-) : GlobalInspectionContextImpl(project, contentManager) {
-    private val platformPublisher = project.messageBus.syncPublisher(GlobalInspectionContextEx.INSPECT_TOPIC)
-    private val attestedPublisher = object : InspectListener {
-        override fun fileAnalyzed(file: PsiFile, eventProject: Project) {
-            platformPublisher.fileAnalyzed(file, eventProject)
-            collector.recordExactFileAnalyzed(file, eventProject)
-        }
-
-        override fun inspectionFinished(
-            durationMillis: Long,
-            threadId: Long,
-            problemCount: Int,
-            toolWrapper: InspectionToolWrapper<*, *>,
-            inspectionKind: InspectListener.InspectionKind,
-            file: PsiFile?,
-            eventProject: Project,
-        ) {
-            platformPublisher.inspectionFinished(
-                durationMillis,
-                threadId,
-                problemCount,
-                toolWrapper,
-                inspectionKind,
-                file,
-                eventProject,
-            )
-            collector.recordExactInspectionFinished(problemCount, toolWrapper, inspectionKind, eventProject)
-        }
-
-        override fun activityFinished(
-            durationMillis: Long,
-            threadId: Long,
-            activityKind: String,
-            eventProject: Project,
-        ) {
-            platformPublisher.activityFinished(durationMillis, threadId, activityKind, eventProject)
-            collector.recordExactActivityFinished(eventProject)
-        }
-
-        override fun inspectionFailed(
-            toolShortName: String,
-            throwable: Throwable,
-            file: PsiFile?,
-            eventProject: Project,
-        ) {
-            platformPublisher.inspectionFailed(toolShortName, throwable, file, eventProject)
-        }
-    }
-
-    override fun getInspectionEventPublisher(): InspectListener = attestedPublisher
-
-    fun openSynchronousFileTraversalGate() {
-        myViewClosed = false
+        private const val MAX_EXPORTED_RESULT_PATHS = 100
     }
 }

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -95,6 +95,7 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import java.security.MessageDigest
 import java.util.UUID
+import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
@@ -5863,6 +5864,9 @@ class InspectionHandler : HttpRequestHandler() {
         var globalContextForCleanup: GlobalInspectionContextBoundary? = null
         var nativeProofConnection: MessageBusConnection? = null
         var standardExecutionResult: StandardGlobalInspectionExecutionResult? = null
+        val standardConsumedProblems = ConcurrentLinkedQueue<
+            Pair<com.intellij.codeInspection.CommonProblemDescriptor, com.intellij.codeInspection.ex.InspectionToolWrapper<*, *>>
+            >()
         try {
             if (!isCurrentInspectionRun(key, runId)) {
                 return
@@ -6248,7 +6252,9 @@ class InspectionHandler : HttpRequestHandler() {
             globalContext.configure(profile, scope)
             try {
                 @Suppress("UnstableApiUsage")
-                globalContext.performInspectionsWithProgressAndExportResults(scope).also {
+                globalContext.launchInspectionsOffline(scope) { descriptor, toolWrapper ->
+                    standardConsumedProblems += descriptor to toolWrapper
+                }.also {
                     standardExecutionResult = it
                     if (!it.exportDirectoryDeleted) {
                         nativeProofCollector?.markUnavailable("native_export_directory_cleanup_failed")
@@ -6298,6 +6304,7 @@ class InspectionHandler : HttpRequestHandler() {
                                 profile,
                                 targetToolShortNames,
                                 fallbackScopeFiles,
+                                standardConsumedProblems.toList(),
                                 cancellationCheck = { checkInspectionRunCancellation(key, runId) },
                             ).also {
                                 extractedFromContextSucceeded = true
@@ -8422,6 +8429,9 @@ class InspectionHandler : HttpRequestHandler() {
         selectedProfile: InspectionProfile?,
         targetToolShortNames: Set<String>,
         fallbackScopeFiles: List<com.intellij.psi.PsiFile>,
+        consumedProblems: List<
+            Pair<com.intellij.codeInspection.CommonProblemDescriptor, com.intellij.codeInspection.ex.InspectionToolWrapper<*, *>>
+            >,
         cancellationCheck: () -> Unit,
     ): InspectionModelExtraction {
         cancellationCheck()
@@ -8431,12 +8441,18 @@ class InspectionHandler : HttpRequestHandler() {
             cancellationCheck()
             presentationHolder.set(
                 app.runReadAction<InspectionModelExtraction, Exception> {
-                    extractProblemsFromContext(
-                        globalContext,
-                        project,
-                        selectedProfile,
-                        targetToolShortNames,
-                        cancellationCheck,
+                    mergeProblemConsumerResults(
+                        base = extractProblemsFromContext(
+                            globalContext,
+                            project,
+                            selectedProfile,
+                            targetToolShortNames,
+                            cancellationCheck,
+                        ),
+                        consumedProblems = consumedProblems,
+                        selectedProfile = selectedProfile,
+                        project = project,
+                        cancellationCheck = cancellationCheck,
                     )
                 }
             )
@@ -8474,6 +8490,33 @@ class InspectionHandler : HttpRequestHandler() {
             targetToolShortNames = targetToolShortNames,
             fallbackScopeFiles = fallbackScopeFiles,
             cancellationCheck = cancellationCheck,
+        )
+    }
+
+    private fun mergeProblemConsumerResults(
+        base: InspectionModelExtraction,
+        consumedProblems: List<
+            Pair<com.intellij.codeInspection.CommonProblemDescriptor, com.intellij.codeInspection.ex.InspectionToolWrapper<*, *>>
+            >,
+        selectedProfile: InspectionProfile?,
+        project: Project,
+        cancellationCheck: () -> Unit,
+    ): InspectionModelExtraction {
+        if (consumedProblems.isEmpty()) {
+            return base
+        }
+        val seen = base.problems.mapTo(LinkedHashSet(), ::problemKey)
+        val additionalProblems = mutableListOf<Map<String, Any>>()
+        for ((descriptor, toolWrapper) in consumedProblems) {
+            cancellationCheck()
+            val problem = buildProblemMap(descriptor, toolWrapper, selectedProfile, project) ?: continue
+            if (seen.add(problemKey(problem))) {
+                additionalProblems += problem
+            }
+        }
+        return base.copy(
+            problems = base.problems + additionalProblems,
+            problemDescriptorCount = maxOf(base.problemDescriptorCount, consumedProblems.size),
         )
     }
 
@@ -8950,6 +8993,8 @@ class InspectionHandler : HttpRequestHandler() {
             "execution_proof_exported_result_path_count" to result.exportedResultPathCount,
             "execution_proof_exported_result_path_count_truncated" to result.exportedResultPathCountTruncated,
             "execution_proof_export_directory_deleted" to result.exportDirectoryDeleted,
+            "execution_proof_problem_consumer_count" to result.consumedProblemCount,
+            "execution_proof_standard_execution_method" to "launch_inspections_offline",
         )
     }
 

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -1817,11 +1817,6 @@ class InspectionHandler : HttpRequestHandler() {
         (Project, InspectionProjectInputsFingerprint) -> InspectionProjectContentTracker? = { project, fingerprint ->
             createProjectContentTracker(project, fingerprint)
         }
-    internal var nativeGlobalInspectionContextFactory:
-        (InspectionManagerEx, Project, NativeInspectionExecutionProofCollector) -> GlobalInspectionContextBoundary =
-        { inspectionManager, project, collector ->
-            GlobalInspectionContextBoundary.createAttested(inspectionManager, project, collector)
-        }
     internal var lifecycleCloseExecutor: (Runnable) -> Unit = { task ->
         ApplicationManager.getApplication().executeOnPooledThread(task)
     }
@@ -5866,8 +5861,9 @@ class InspectionHandler : HttpRequestHandler() {
         var captureScheduled = false
         var projectContentTracker: InspectionProjectContentTracker? = null
         var inspectionInputFingerprint: InspectionProjectInputsFingerprint? = null
-        var nativeGlobalContext: GlobalInspectionContextBoundary? = null
+        var globalContextForCleanup: GlobalInspectionContextBoundary? = null
         var nativeProofConnection: MessageBusConnection? = null
+        var standardExecutionResult: StandardGlobalInspectionExecutionResult? = null
         try {
             if (!isCurrentInspectionRun(key, runId)) {
                 return
@@ -6211,8 +6207,7 @@ class InspectionHandler : HttpRequestHandler() {
             )
             val executionProofMode = inspectionExecutionProofMode(effectiveCaptureScope.scopeParam)
 
-            @Suppress("USELESS_CAST")
-            val inspectionManager = InspectionManager.getInstance(project) as InspectionManagerEx
+            val inspectionManager = InspectionManager.getInstance(project)
             var nativeScopeEnumerationFailure: Throwable? = null
             val nativeExpectedFilePaths = if (executionProofMode == InspectionExecutionProofMode.NATIVE_ATTESTED) {
                 try {
@@ -6237,28 +6232,29 @@ class InspectionHandler : HttpRequestHandler() {
             } else {
                 null
             }
-            val globalContext = if (nativeProofCollector == null) {
-                GlobalInspectionContextBoundary.create(inspectionManager)
-            } else {
+            val globalContext = GlobalInspectionContextBoundary.createStandard(inspectionManager)
+            globalContextForCleanup = globalContext
+            if (nativeProofCollector != null) {
                 try {
-                    val context = nativeGlobalInspectionContextFactory(inspectionManager, project, nativeProofCollector)
                     nativeProofConnection = project.messageBus.connect().apply {
                         subscribe(GlobalInspectionContextEx.INSPECT_TOPIC, nativeProofCollector)
                     }
-                    nativeGlobalContext = context
-                    context
                 } catch (error: Throwable) {
                     runCatching { nativeProofConnection?.disconnect() }
                     nativeProofConnection = null
-                    nativeProofCollector.markUnavailable("native_attestation_context_creation_failed")
-                    logger.warn("Native inspection attestation context was unavailable; inspection remains fail-closed.", error)
-                    GlobalInspectionContextBoundary.create(inspectionManager)
+                    nativeProofCollector.markUnavailable("native_attestation_subscription_failed")
+                    logger.warn("Native inspection event subscription was unavailable; inspection remains fail-closed.", error)
                 }
             }
             globalContext.configure(profile, scope)
             try {
                 @Suppress("UnstableApiUsage")
-                globalContext.performInspectionsWithProgress(scope)
+                globalContext.performInspectionsWithProgressAndExportResults(scope).also {
+                    standardExecutionResult = it
+                    if (!it.exportDirectoryDeleted) {
+                        nativeProofCollector?.markUnavailable("native_export_directory_cleanup_failed")
+                    }
+                }
                 nativeProofCollector?.markCompletedNormally()
             } catch (error: Throwable) {
                 nativeProofCollector?.markUnavailable("native_inspection_aborted")
@@ -6631,6 +6627,7 @@ class InspectionHandler : HttpRequestHandler() {
                         // Fix 7: Always include proof diagnostics; keep polling exit reason separate
                         val proofDiagnostic = buildProofDiagnostic(boundedProof) +
                             buildNativeProofDiagnostic(nativeProof) +
+                            buildStandardExecutionDiagnostic(standardExecutionResult) +
                             mapOf(
                                 "execution_proof_mapped_finding_count" to scopedProofFindingCount,
                             )
@@ -6811,7 +6808,7 @@ class InspectionHandler : HttpRequestHandler() {
         } finally {
             runCatching { nativeProofConnection?.disconnect() }
                 .onFailure { error -> logger.warn("Native inspection event subscription cleanup failed for ${project.name}", error) }
-            nativeGlobalContext?.let { context ->
+            globalContextForCleanup?.let { context ->
                 val closeSucceeded = runCatching {
                     val closeAction = Runnable { context.close(false) }
                     val application = ApplicationManager.getApplication()
@@ -8943,6 +8940,18 @@ class InspectionHandler : HttpRequestHandler() {
             "execution_proof_established" to proof.proofEstablished,
             "execution_proof_clean" to proof.proofClean,
         ).filterValues { it != null }
+    }
+
+    private fun buildStandardExecutionDiagnostic(
+        result: StandardGlobalInspectionExecutionResult?,
+    ): Map<String, Any?> {
+        result ?: return emptyMap()
+        return mapOf(
+            "execution_proof_standard_context" to true,
+            "execution_proof_exported_result_path_count" to result.exportedResultPathCount,
+            "execution_proof_exported_result_path_count_truncated" to result.exportedResultPathCountTruncated,
+            "execution_proof_export_directory_deleted" to result.exportDirectoryDeleted,
+        )
     }
 
     internal data class EnabledLocalToolEnumeration(

--- a/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/InspectionHandler.kt
@@ -6,7 +6,6 @@ import com.intellij.codeInspection.InspectionEngine
 import com.intellij.codeInspection.InspectionProfile
 import com.intellij.codeInspection.InspectionManager
 import com.intellij.codeInspection.ex.GlobalInspectionContextEx
-import com.intellij.codeInspection.ex.InspectionManagerEx
 import com.intellij.codeInspection.ex.InspectionProfileImpl
 import com.intellij.ide.DataManager
 import com.intellij.ide.RecentProjectsManagerBase
@@ -6255,6 +6254,7 @@ class InspectionHandler : HttpRequestHandler() {
                         nativeProofCollector?.markUnavailable("native_export_directory_cleanup_failed")
                     }
                 }
+                nativeProofCollector?.markUnavailable("standard_context_event_attribution_unproven")
                 nativeProofCollector?.markCompletedNormally()
             } catch (error: Throwable) {
                 nativeProofCollector?.markUnavailable("native_inspection_aborted")
@@ -6810,7 +6810,7 @@ class InspectionHandler : HttpRequestHandler() {
                 .onFailure { error -> logger.warn("Native inspection event subscription cleanup failed for ${project.name}", error) }
             globalContextForCleanup?.let { context ->
                 val closeSucceeded = runCatching {
-                    val closeAction = Runnable { context.close(false) }
+                    val closeAction = Runnable { context.close(true) }
                     val application = ApplicationManager.getApplication()
                     if (application.isDispatchThread) {
                         closeAction.run()
@@ -6824,7 +6824,6 @@ class InspectionHandler : HttpRequestHandler() {
                     runCatching { context.cleanup() }
                         .onFailure { error -> logger.warn("Native inspection context fallback cleanup failed for ${project.name}", error) }
                 }
-                context.removeFromRunningContexts()
             }
             projectContentTracker?.close()
             if (!captureScheduled) {
@@ -9029,7 +9028,7 @@ class InspectionHandler : HttpRequestHandler() {
         profile: InspectionProfileImpl,
         psiFile: com.intellij.psi.PsiFile,
     ): GlobalInspectionContextBoundary {
-        val inspectionManager = InspectionManager.getInstance(project) as InspectionManagerEx
+        val inspectionManager = InspectionManager.getInstance(project)
         val context = GlobalInspectionContextBoundary.createForExactFile(inspectionManager)
         return try {
             context.configure(profile, AnalysisScope(psiFile))
@@ -9045,15 +9044,14 @@ class InspectionHandler : HttpRequestHandler() {
     private fun cleanupExactFileExecutionContext(
         context: GlobalInspectionContextBoundary,
     ) {
-        var cleanupFailure: Exception? = null
         try {
-            context.cleanup()
-        } catch (error: Exception) {
-            cleanupFailure = error
-        } finally {
-            context.removeFromRunningContextsSynchronously()
+            context.close(true)
+        } catch (closeError: Exception) {
+            runCatching { context.cleanup() }
+                .exceptionOrNull()
+                ?.let(closeError::addSuppressed)
+            throw closeError
         }
-        cleanupFailure?.let { throw it }
     }
 
     @Suppress("UnstableApiUsage")

--- a/src/main/kotlin/com/shiny/inspectionmcp/NativeInspectionExecutionProof.kt
+++ b/src/main/kotlin/com/shiny/inspectionmcp/NativeInspectionExecutionProof.kt
@@ -82,9 +82,11 @@ internal class NativeInspectionExecutionProofCollector(
     @Volatile
     private var skippedReason: String? = null
 
-    override fun fileAnalyzed(file: PsiFile, eventProject: Project) = Unit
+    override fun fileAnalyzed(file: PsiFile, eventProject: Project) {
+        recordFileAnalyzed(file, eventProject)
+    }
 
-    fun recordExactFileAnalyzed(file: PsiFile, eventProject: Project) {
+    private fun recordFileAnalyzed(file: PsiFile, eventProject: Project) {
         if (eventProject !== project) return
         fileAnalyzedCount.incrementAndGet()
         runCatching { file.virtualFile?.path }.getOrNull()?.let(analyzedFiles::add)
@@ -102,29 +104,11 @@ internal class NativeInspectionExecutionProofCollector(
     ) {
         if (eventProject !== project) return
         if (
-            inspectionKind != InspectListener.InspectionKind.LOCAL &&
-            inspectionKind != InspectListener.InspectionKind.LOCAL_PRIORITY
-        ) {
-            return
-        }
-        val filePath = runCatching { file?.virtualFile?.path }.getOrNull() ?: return
-        if (filePath !in expectedFiles) return
-        recordInspectionFinished(problemCount, toolWrapper, inspectionKind)
-    }
-
-    @Suppress("REDUNDANT_ELSE_IN_WHEN")
-    fun recordExactInspectionFinished(
-        problemCount: Int,
-        toolWrapper: InspectionToolWrapper<*, *>,
-        inspectionKind: InspectListener.InspectionKind,
-        eventProject: Project,
-    ) {
-        if (eventProject !== project) return
-        if (
             inspectionKind == InspectListener.InspectionKind.LOCAL ||
             inspectionKind == InspectListener.InspectionKind.LOCAL_PRIORITY
         ) {
-            return
+            val filePath = runCatching { file?.virtualFile?.path }.getOrNull() ?: return
+            if (filePath !in expectedFiles) return
         }
         recordInspectionFinished(problemCount, toolWrapper, inspectionKind)
     }
@@ -153,9 +137,7 @@ internal class NativeInspectionExecutionProofCollector(
         threadId: Long,
         activityKind: String,
         eventProject: Project,
-    ) = Unit
-
-    fun recordExactActivityFinished(eventProject: Project) {
+    ) {
         if (eventProject === project) activityFinishedCount.incrementAndGet()
     }
 

--- a/src/test/kotlin/com/shiny/inspectionmcp/GlobalInspectionContextBoundaryTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/GlobalInspectionContextBoundaryTest.kt
@@ -1,8 +1,8 @@
 package com.shiny.inspectionmcp
 
 import com.intellij.analysis.AnalysisScope
-import com.intellij.codeInspection.ex.GlobalInspectionContextImpl
-import com.intellij.codeInspection.ex.InspectionManagerEx
+import com.intellij.codeInspection.InspectionManager
+import com.intellij.codeInspection.ex.GlobalInspectionContextEx
 import com.intellij.openapi.progress.ProcessCanceledException
 import io.mockk.every
 import io.mockk.mockk
@@ -16,8 +16,8 @@ import java.nio.file.Path
 class GlobalInspectionContextBoundaryTest {
     @Test
     fun `creates the standard GlobalInspectionContextEx from InspectionManager`() {
-        val inspectionManager = mockk<InspectionManagerEx>()
-        val context = mockk<GlobalInspectionContextImpl>()
+        val inspectionManager = mockk<InspectionManager>()
+        val context = mockk<GlobalInspectionContextEx>()
         every { inspectionManager.createNewGlobalContext() } returns context
 
         val boundary = GlobalInspectionContextBoundary.createStandard(inspectionManager)
@@ -28,8 +28,8 @@ class GlobalInspectionContextBoundaryTest {
 
     @Test
     fun `executes through export results and removes the run export directory`() {
-        val inspectionManager = mockk<InspectionManagerEx>()
-        val context = mockk<GlobalInspectionContextImpl>()
+        val inspectionManager = mockk<InspectionManager>()
+        val context = mockk<GlobalInspectionContextEx>()
         val scope = mockk<AnalysisScope>()
         var exportDirectory: Path? = null
         every { inspectionManager.createNewGlobalContext() } returns context
@@ -58,8 +58,8 @@ class GlobalInspectionContextBoundaryTest {
 
     @Test
     fun `cancellation propagates and still removes the run export directory`() {
-        val inspectionManager = mockk<InspectionManagerEx>()
-        val context = mockk<GlobalInspectionContextImpl>()
+        val inspectionManager = mockk<InspectionManager>()
+        val context = mockk<GlobalInspectionContextEx>()
         val scope = mockk<AnalysisScope>()
         var exportDirectory: Path? = null
         every { inspectionManager.createNewGlobalContext() } returns context

--- a/src/test/kotlin/com/shiny/inspectionmcp/GlobalInspectionContextBoundaryTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/GlobalInspectionContextBoundaryTest.kt
@@ -1,11 +1,15 @@
 package com.shiny.inspectionmcp
 
 import com.intellij.analysis.AnalysisScope
+import com.intellij.codeInspection.CommonProblemDescriptor
 import com.intellij.codeInspection.InspectionManager
 import com.intellij.codeInspection.ex.GlobalInspectionContextEx
+import com.intellij.codeInspection.ex.InspectionProblemConsumer
+import com.intellij.codeInspection.ex.InspectionToolWrapper
 import com.intellij.openapi.progress.ProcessCanceledException
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -27,32 +31,41 @@ class GlobalInspectionContextBoundaryTest {
     }
 
     @Test
-    fun `executes through export results and removes the run export directory`() {
+    fun `launches offline with a problem consumer and removes the run export directory`() {
         val inspectionManager = mockk<InspectionManager>()
         val context = mockk<GlobalInspectionContextEx>()
         val scope = mockk<AnalysisScope>()
+        val descriptor = mockk<CommonProblemDescriptor>()
+        val toolWrapper = mockk<InspectionToolWrapper<*, *>>()
+        val consumerSlot = slot<InspectionProblemConsumer>()
+        val consumedProblems = mutableListOf<Pair<CommonProblemDescriptor, InspectionToolWrapper<*, *>>>()
         var exportDirectory: Path? = null
         every { inspectionManager.createNewGlobalContext() } returns context
+        every { context.setProblemConsumer(capture(consumerSlot)) } returns Unit
         every {
-            context.performInspectionsWithProgressAndExportResults(
+            context.launchInspectionsOffline(
                 scope,
-                false,
-                false,
                 any(),
+                false,
                 any(),
             )
         } answers {
-            exportDirectory = arg<Path>(3)
-            val exportedPaths = arg<MutableList<Path>>(4)
+            exportDirectory = arg<Path>(1)
+            val exportedPaths = arg<MutableList<Path>>(3)
             exportedPaths.add(requireNotNull(exportDirectory).resolve("result.xml"))
+            consumerSlot.captured.consume(mockk(), descriptor, toolWrapper)
         }
 
         val result = GlobalInspectionContextBoundary.createStandard(inspectionManager)
-            .performInspectionsWithProgressAndExportResults(scope)
+            .launchInspectionsOffline(scope) { problemDescriptor, wrapper ->
+                consumedProblems += problemDescriptor to wrapper
+            }
 
         assertThat(result.exportedResultPathCount).isEqualTo(1)
         assertThat(result.exportedResultPathCountTruncated).isFalse()
         assertThat(result.exportDirectoryDeleted).isTrue()
+        assertThat(result.consumedProblemCount).isEqualTo(1)
+        assertThat(consumedProblems).containsExactly(descriptor to toolWrapper)
         assertThat(Files.exists(requireNotNull(exportDirectory))).isFalse()
     }
 
@@ -63,24 +76,25 @@ class GlobalInspectionContextBoundaryTest {
         val scope = mockk<AnalysisScope>()
         var exportDirectory: Path? = null
         every { inspectionManager.createNewGlobalContext() } returns context
+        every { context.setProblemConsumer(any()) } returns Unit
         every {
-            context.performInspectionsWithProgressAndExportResults(
+            context.launchInspectionsOffline(
                 scope,
-                false,
-                false,
                 any(),
+                false,
                 any(),
             )
         } answers {
-            exportDirectory = arg<Path>(3)
+            exportDirectory = arg<Path>(1)
             throw ProcessCanceledException()
         }
 
         assertThatThrownBy {
             GlobalInspectionContextBoundary.createStandard(inspectionManager)
-                .performInspectionsWithProgressAndExportResults(scope)
+                .launchInspectionsOffline(scope) { _, _ -> }
         }.isInstanceOf(ProcessCanceledException::class.java)
 
         assertThat(Files.exists(requireNotNull(exportDirectory))).isFalse()
+        verify(exactly = 1) { context.setProblemConsumer(any()) }
     }
 }

--- a/src/test/kotlin/com/shiny/inspectionmcp/GlobalInspectionContextBoundaryTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/GlobalInspectionContextBoundaryTest.kt
@@ -1,0 +1,86 @@
+package com.shiny.inspectionmcp
+
+import com.intellij.analysis.AnalysisScope
+import com.intellij.codeInspection.ex.GlobalInspectionContextImpl
+import com.intellij.codeInspection.ex.InspectionManagerEx
+import com.intellij.openapi.progress.ProcessCanceledException
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+
+class GlobalInspectionContextBoundaryTest {
+    @Test
+    fun `creates the standard GlobalInspectionContextEx from InspectionManager`() {
+        val inspectionManager = mockk<InspectionManagerEx>()
+        val context = mockk<GlobalInspectionContextImpl>()
+        every { inspectionManager.createNewGlobalContext() } returns context
+
+        val boundary = GlobalInspectionContextBoundary.createStandard(inspectionManager)
+
+        assertThat(boundary.publicContext()).isSameAs(context)
+        verify(exactly = 1) { inspectionManager.createNewGlobalContext() }
+    }
+
+    @Test
+    fun `executes through export results and removes the run export directory`() {
+        val inspectionManager = mockk<InspectionManagerEx>()
+        val context = mockk<GlobalInspectionContextImpl>()
+        val scope = mockk<AnalysisScope>()
+        var exportDirectory: Path? = null
+        every { inspectionManager.createNewGlobalContext() } returns context
+        every {
+            context.performInspectionsWithProgressAndExportResults(
+                scope,
+                false,
+                false,
+                any(),
+                any(),
+            )
+        } answers {
+            exportDirectory = arg<Path>(3)
+            val exportedPaths = arg<MutableList<Path>>(4)
+            exportedPaths.add(requireNotNull(exportDirectory).resolve("result.xml"))
+        }
+
+        val result = GlobalInspectionContextBoundary.createStandard(inspectionManager)
+            .performInspectionsWithProgressAndExportResults(scope)
+
+        assertThat(result.exportedResultPathCount).isEqualTo(1)
+        assertThat(result.exportedResultPathCountTruncated).isFalse()
+        assertThat(result.exportDirectoryDeleted).isTrue()
+        assertThat(Files.exists(requireNotNull(exportDirectory))).isFalse()
+    }
+
+    @Test
+    fun `cancellation propagates and still removes the run export directory`() {
+        val inspectionManager = mockk<InspectionManagerEx>()
+        val context = mockk<GlobalInspectionContextImpl>()
+        val scope = mockk<AnalysisScope>()
+        var exportDirectory: Path? = null
+        every { inspectionManager.createNewGlobalContext() } returns context
+        every {
+            context.performInspectionsWithProgressAndExportResults(
+                scope,
+                false,
+                false,
+                any(),
+                any(),
+            )
+        } answers {
+            exportDirectory = arg<Path>(3)
+            throw ProcessCanceledException()
+        }
+
+        assertThatThrownBy {
+            GlobalInspectionContextBoundary.createStandard(inspectionManager)
+                .performInspectionsWithProgressAndExportResults(scope)
+        }.isInstanceOf(ProcessCanceledException::class.java)
+
+        assertThat(Files.exists(requireNotNull(exportDirectory))).isFalse()
+    }
+}

--- a/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/InspectionHandlerTest.kt
@@ -41,6 +41,8 @@ import com.intellij.codeInspection.InspectionManager
 import com.intellij.codeInspection.GlobalInspectionContext
 import com.intellij.codeInspection.ui.InspectionResultsView
 import com.intellij.profile.codeInspection.InspectionProjectProfileManager
+import com.intellij.codeInspection.ex.GlobalInspectionContextImpl
+import com.intellij.codeInspection.ex.InspectionManagerEx
 import com.intellij.codeInspection.ex.InspectionProfileImpl
 import com.intellij.openapi.util.ThrowableComputable
 import com.intellij.psi.PsiDirectory
@@ -243,8 +245,8 @@ class InspectionHandlerTest {
         mockProjectManager = mockk<ProjectManager>()
         mockVirtualFileManager = mockk<VirtualFileManager>()
         mockWindowManager = mockk<WindowManager>()
-        mockInspectionManager = mockk<InspectionManager>()
-        mockGlobalContext = mockk<GlobalInspectionContext>()
+        mockInspectionManager = mockk<InspectionManagerEx>()
+        mockGlobalContext = mockk<GlobalInspectionContextImpl>(relaxed = true)
         mockProfileManager = mockk<InspectionProjectProfileManager>()
         mockProfile = mockk<InspectionProfileImpl>()
         mockApplication = mockk<Application>()

--- a/src/test/kotlin/com/shiny/inspectionmcp/NativeInspectionExecutionProofTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/NativeInspectionExecutionProofTest.kt
@@ -172,6 +172,29 @@ class NativeInspectionExecutionProofTest {
     }
 
     @Test
+    fun `standard context events cannot establish run-bound proof`() {
+        val collector = NativeInspectionExecutionProofCollector(project, setOf(filePath))
+
+        collector.markUnavailable("standard_context_event_attribution_unproven")
+        collector.fileAnalyzed(file, project)
+        collector.inspectionFinished(
+            10L,
+            1L,
+            0,
+            tool,
+            InspectListener.InspectionKind.LOCAL,
+            file,
+            project,
+        )
+        collector.markCompletedNormally()
+
+        val result = collector.result()
+        assertFalse(result.proofEstablished)
+        assertFalse(result.proofClean)
+        assertEquals("standard_context_event_attribution_unproven", result.proofBlockReason)
+    }
+
+    @Test
     fun `normal return without execution events remains unproven`() {
         val collector = NativeInspectionExecutionProofCollector(project, setOf(filePath))
 

--- a/src/test/kotlin/com/shiny/inspectionmcp/NativeInspectionExecutionProofTest.kt
+++ b/src/test/kotlin/com/shiny/inspectionmcp/NativeInspectionExecutionProofTest.kt
@@ -38,7 +38,7 @@ class NativeInspectionExecutionProofTest {
             file,
             project,
         )
-        collector.recordExactFileAnalyzed(file, project)
+        collector.fileAnalyzed(file, project)
         collector.markCompletedNormally()
 
         val result = collector.result()
@@ -62,7 +62,15 @@ class NativeInspectionExecutionProofTest {
     fun `global inspection completion without file traversal remains unproven`() {
         val collector = NativeInspectionExecutionProofCollector(project, setOf(filePath))
 
-        collector.recordExactInspectionFinished(0, tool, InspectListener.InspectionKind.GLOBAL, project)
+        collector.inspectionFinished(
+            10L,
+            1L,
+            0,
+            tool,
+            InspectListener.InspectionKind.GLOBAL,
+            null,
+            project,
+        )
         collector.markCompletedNormally()
 
         val result = collector.result()
@@ -76,8 +84,16 @@ class NativeInspectionExecutionProofTest {
     fun `global simple inspection with file traversal establishes clean native proof`() {
         val collector = NativeInspectionExecutionProofCollector(project, setOf(filePath))
 
-        collector.recordExactFileAnalyzed(file, project)
-        collector.recordExactInspectionFinished(0, tool, InspectListener.InspectionKind.GLOBAL_SIMPLE, project)
+        collector.fileAnalyzed(file, project)
+        collector.inspectionFinished(
+            10L,
+            1L,
+            0,
+            tool,
+            InspectListener.InspectionKind.GLOBAL_SIMPLE,
+            null,
+            project,
+        )
         collector.markCompletedNormally()
 
         val result = collector.result()
@@ -99,7 +115,7 @@ class NativeInspectionExecutionProofTest {
             file,
             project,
         )
-        collector.recordExactFileAnalyzed(file, project)
+        collector.fileAnalyzed(file, project)
         collector.markCompletedNormally()
 
         val result = collector.result()
@@ -122,7 +138,7 @@ class NativeInspectionExecutionProofTest {
             file,
             project,
         )
-        collector.recordExactFileAnalyzed(file, project)
+        collector.fileAnalyzed(file, project)
         collector.inspectionFailed("UnusedSymbol", IllegalStateException("boom"), file, project)
         collector.markCompletedNormally()
 
@@ -146,7 +162,7 @@ class NativeInspectionExecutionProofTest {
             file,
             project,
         )
-        collector.recordExactFileAnalyzed(file, project)
+        collector.fileAnalyzed(file, project)
         collector.markUnavailable("native_inspection_aborted")
 
         val result = collector.result()
@@ -171,7 +187,7 @@ class NativeInspectionExecutionProofTest {
         val collector = NativeInspectionExecutionProofCollector(project, setOf(filePath))
         val otherProject = mockk<Project>()
 
-        collector.recordExactFileAnalyzed(file, otherProject)
+        collector.fileAnalyzed(file, otherProject)
         collector.inspectionFinished(
             10L,
             1L,
@@ -199,8 +215,16 @@ class NativeInspectionExecutionProofTest {
         }
         val collector = NativeInspectionExecutionProofCollector(project, setOf(filePath))
 
-        collector.recordExactFileAnalyzed(invalidFile, project)
-        collector.recordExactInspectionFinished(0, invalidTool, InspectListener.InspectionKind.GLOBAL, project)
+        collector.fileAnalyzed(invalidFile, project)
+        collector.inspectionFinished(
+            10L,
+            1L,
+            0,
+            invalidTool,
+            InspectListener.InspectionKind.GLOBAL,
+            null,
+            project,
+        )
         collector.markCompletedNormally()
 
         val result = collector.result()
@@ -213,7 +237,7 @@ class NativeInspectionExecutionProofTest {
         val secondPath = "/tmp/TestProject/src/Other.kt"
         val collector = NativeInspectionExecutionProofCollector(project, setOf(filePath, secondPath))
 
-        collector.recordExactFileAnalyzed(file, project)
+        collector.fileAnalyzed(file, project)
         collector.markCompletedNormally()
 
         val result = collector.result()
@@ -226,7 +250,7 @@ class NativeInspectionExecutionProofTest {
     fun `full traversal without tool completion remains fail closed`() {
         val collector = NativeInspectionExecutionProofCollector(project, setOf(filePath))
 
-        collector.recordExactFileAnalyzed(file, project)
+        collector.fileAnalyzed(file, project)
         collector.markCompletedNormally()
 
         val result = collector.result()


### PR DESCRIPTION
## Summary

- prototype JetBrains' recommended `GlobalInspectionContextEx` broad-scope path
- replace direct standard-context construction with
  `InspectionManager.createNewGlobalContext()`
- keep broad clean proof fail-closed because project-wide inspection events are
  not attributable to the exact context/run
- preserve public context cleanup and exact-file lifecycle synchronization

## Validation

- focused plugin tests: passed
- commit gate/repository tests and plugin build: passed
- Plugin Verifier: expected allowlist mismatch; internal findings reduced from
  about 54 to 15 per 251/252/253/261/262 target
- live PyCharm 2026.2: `UNKNOWN/no_results`, 0 ms scope scan, canceled progress,
  no false GREEN

## No-Go Findings

This draft is evidence, not a merge candidate.

- export mode routes local-inspection findings to XML rather than the in-memory
  presentations consumed by the current extractor; this prototype deletes the
  temporary XML
- normal return does not expose all per-tool failures
- `INSPECT_TOPIC` has no context/run identity
- the tested live non-headless invocation did not traverse the requested scope

Independent Opus and Gemini reviews both reject merging the export prototype
as-is. Issue #324 records the required JetBrains follow-up questions and remains
waiting on clarification.

Refs #324
