### PR TITLE
Add actionable JetBrains follow-up reminder

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -19,7 +19,7 @@
         "./scripts/test-release-contracts.sh",
         "./gradlew buildPlugin"
       ],
-      "workflowLint": "actionlint .github/workflows/ci.yml .github/workflows/release.yml .github/workflows/canary-release.yml",
+      "workflowLint": "actionlint .github/workflows/ci.yml .github/workflows/release.yml .github/workflows/canary-release.yml .github/workflows/issue-290-followup-reminder.yml",
       "shellLint": "shellcheck --severity=warning scripts/*.sh",
       "all": "./scripts/test-all.sh",
       "plugin": "JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew test",
@@ -87,6 +87,7 @@
     "CodeQL",
     "Dependabot Updates",
     "Dependency Graph",
+    "JetBrains Follow-up Reminder",
     "Release",
     "Canary Release"
   ],

--- a/.github/workflows/issue-290-followup-reminder.yml
+++ b/.github/workflows/issue-290-followup-reminder.yml
@@ -1,0 +1,119 @@
+---
+name: JetBrains Follow-up Reminder
+
+"on":
+  schedule:
+    - cron: "17 13 2-4 9 *"
+      timezone: "Etc/UTC"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: issue-290-followup-reminder
+  cancel-in-progress: false
+
+env:
+  ISSUE_NUMBER: "290"
+  REQUIRED_LABEL: "plan:waiting"
+  DUE_ON: "2026-09-02"
+  EXPIRES_ON: "2026-09-04"
+  REMINDER_MARKER: "<!-- issue-290-followup-reminder:v1 -->"
+
+jobs:
+  dry-run:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+    steps:
+      - name: Preview reminder decision
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          issue_json=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${ISSUE_NUMBER}")
+          state=$(jq -r '.state' <<<"$issue_json")
+          locked=$(jq -r '.locked' <<<"$issue_json")
+          has_label=$(jq -r --arg label "$REQUIRED_LABEL" 'any(.labels[]; .name == $label)' <<<"$issue_json")
+          comments_json=$(gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/issues/${ISSUE_NUMBER}/comments")
+          existing_comment=$(
+            jq -r --arg marker "$REMINDER_MARKER" \
+              '[.[][] | select(.user.login == "github-actions[bot]" and (.body | contains($marker)))][0].id // ""' \
+              <<<"$comments_json"
+          )
+
+          printf 'date_window=%s..%s\n' "$DUE_ON" "$EXPIRES_ON"
+          printf 'issue_state=%s\n' "$state"
+          printf 'issue_locked=%s\n' "$locked"
+          printf 'required_label_present=%s\n' "$has_label"
+          printf 'reminder_already_posted=%s\n' "$([[ -n "$existing_comment" ]] && echo true || echo false)"
+
+          if [[ "$state" == "open" && "$locked" == "false" && "$has_label" == "true" && -z "$existing_comment" ]]; then
+            echo "would_post=true once the scheduled date window opens"
+          else
+            echo "would_post=false"
+          fi
+
+  scheduled-reminder:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Post reminder once when due
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          today=$(date -u +%F)
+          if [[ "$today" < "$DUE_ON" || "$today" > "$EXPIRES_ON" ]]; then
+            echo "Reminder is outside its active date window."
+            exit 0
+          fi
+
+          issue_json=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${ISSUE_NUMBER}")
+          state=$(jq -r '.state' <<<"$issue_json")
+          locked=$(jq -r '.locked' <<<"$issue_json")
+          has_label=$(jq -r --arg label "$REQUIRED_LABEL" 'any(.labels[]; .name == $label)' <<<"$issue_json")
+          if [[ "$state" != "open" || "$locked" != "false" || "$has_label" != "true" ]]; then
+            echo "Issue is no longer an open, unlocked waiting plan."
+            exit 0
+          fi
+
+          comments_json=$(gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/issues/${ISSUE_NUMBER}/comments")
+          existing_comment=$(
+            jq -r --arg marker "$REMINDER_MARKER" \
+              '[.[][] | select(.user.login == "github-actions[bot]" and (.body | contains($marker)))][0].id // ""' \
+              <<<"$comments_json"
+          )
+          if [[ -n "$existing_comment" ]]; then
+            echo "Reminder was already posted."
+            exit 0
+          fi
+
+          issue_json=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${ISSUE_NUMBER}")
+          state=$(jq -r '.state' <<<"$issue_json")
+          locked=$(jq -r '.locked' <<<"$issue_json")
+          has_label=$(jq -r --arg label "$REQUIRED_LABEL" 'any(.labels[]; .name == $label)' <<<"$issue_json")
+          if [[ "$state" != "open" || "$locked" != "false" || "$has_label" != "true" ]]; then
+            echo "Issue changed before the reminder write; skipping."
+            exit 0
+          fi
+
+          body=$(cat <<'EOF'
+          <!-- issue-290-followup-reminder:v1 -->
+          @cbusillo Follow-up reminder: check JetBrains issue `IJPL-252476` for a response.
+
+          Action:
+          - If JetBrains replied, record the response and next decision in #290 and #324.
+          - If there is no reply, send a short follow-up and keep the Stable release blocked.
+          - Reconcile #270 and draft PR #325 before changing or replacing Stable update `1130387`.
+
+          Related consumer work: cbusillo/codex-skills#497.
+          EOF
+          )
+
+          gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body "$body"


### PR DESCRIPTION
## Summary

- add a scheduled reminder for the JetBrains follow-up tracked by #290
- mention `@cbusillo` once between September 2 and September 4, 2026 when the
  issue is still open and labeled `plan:waiting`
- link the actionable work in #324, #270, PR #325, and
  `cbusillo/codex-skills#497`
- provide a read-only manual dispatch that previews whether the reminder would
  post

## Safety

- scheduled writes use only `issues: write`
- manual dispatch uses only `issues: read`
- no checkout, PAT, repository secret, or third-party action is required
- a stable hidden marker and workflow concurrency prevent duplicate comments
- the workflow rechecks issue state and label immediately before posting

## Validation

- `actionlint` passed for all repository workflows
- `.github/github.json` parses with `jq`
- the read-only decision logic currently reports that #290 would receive the
  reminder when the date window opens
- the repository commit gate passed

Refs #290
Refs #324
