### PR TITLE
Add minimal reproducer for IJPL-252476

### DIFF
--- a/reproducers/ijpl-252476-global-inspection/.gitignore
+++ b/reproducers/ijpl-252476-global-inspection/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/.intellijPlatform/
+/build/
+/fixtures/**/.idea/

--- a/reproducers/ijpl-252476-global-inspection/OBSERVED.md
+++ b/reproducers/ijpl-252476-global-inspection/OBSERVED.md
@@ -1,0 +1,49 @@
+# Observed Live Result
+
+The reproducer was run on September 2, 2026 with:
+
+- PyCharm 2026.2.1, build `PY-262.9437.214`
+- macOS 27.0 on Apple silicon
+- the bundled JetBrains Runtime, Java 25.0.3
+- the default inspection profile
+- `fixtures/python-project`, after indexing completed
+
+PyCharm showed two editor problems in `known_problem.py`. The reproducer also
+counted eight files in the project `AnalysisScope` before either inspection
+call.
+
+## XML Export
+
+`performInspectionsWithProgressAndExportResults(scope, false, false, ...)`
+returned normally after 25 ms and reported 431 used tools. It returned no result
+paths and created no XML files.
+
+The IDE log recorded:
+
+```text
+AnalysisScope - Scanning scope took 2 ms
+GlobalInspectionContextBase - Cancelling inspection progress
+```
+
+## Offline Export
+
+`launchInspectionsOffline(scope, outputDirectory, false, resultPaths)` was run
+in a fresh IDE session. It returned normally after 20 ms and reported 431 used
+tools. It also returned no result paths and created no XML files.
+
+The IDE log recorded a 3 ms scope scan followed by `Cancelling inspection
+progress`.
+
+## Cleanup
+
+For both runs, `context.close(false)` failed because the context had no
+`InspectionResultsView`; `context.cleanup()` then completed successfully. The
+reproducer records the complete exception in `report.txt`.
+
+These results show the main ambiguity we need help resolving: both methods
+returned normally even though the known findings were not exported and the IDE
+logged that inspection progress was being canceled.
+
+This evidence covers the XML-only result path. It does not claim that a
+separately installed `InspectionProblemConsumer` would also receive zero local
+findings.

--- a/reproducers/ijpl-252476-global-inspection/README.md
+++ b/reproducers/ijpl-252476-global-inspection/README.md
@@ -1,0 +1,91 @@
+# IJPL-252476 Global Inspection Reproducer
+
+This is a standalone IntelliJ Platform plugin for
+[IJPL-252476](https://youtrack.jetbrains.com/issue/IJPL-252476). It reproduces
+the live-IDE behavior discussed in that issue without running the production
+Inspection API plugin.
+
+The plugin creates a standard context with
+`InspectionManager.createNewGlobalContext()` and offers two separate actions:
+
+- `performInspectionsWithProgressAndExportResults()` with XML export enabled
+- `launchInspectionsOffline()` with XML export and no problem consumer
+
+Each action runs in its own modal progress task. Run them in separate IDE
+sessions so a failed context cleanup or canceled progress indicator from one
+attempt cannot affect the other.
+
+The offline action intentionally does not install an `InspectionProblemConsumer`.
+For local tools, the consumer-backed presentation can deliver findings to the
+callback instead of writing the per-tool XML file. This reproducer keeps XML as
+the only result path so it directly tests the approach requested by JetBrains.
+
+## Build
+
+Java 21 is required. From the repository root:
+
+```bash
+JAVA_HOME=$(/usr/libexec/java_home -v 21) \
+  ./gradlew -p reproducers/ijpl-252476-global-inspection clean buildPlugin
+```
+
+By default the reproducer downloads and runs PyCharm Professional 2026.2.1. To
+use a locally installed IDE instead, pass its application path:
+
+```bash
+JAVA_HOME=$(/usr/libexec/java_home -v 21) \
+  ./gradlew -p reproducers/ijpl-252476-global-inspection runIde \
+  -PlocalIdePath="$HOME/Applications/PyCharm.app"
+```
+
+## Reproduce
+
+1. Start the sandbox IDE with the `runIde` command above.
+2. Open `fixtures/python-project` as a project.
+3. Wait for indexing and code analysis to finish.
+4. Confirm that `known_problem.py` visibly reports at least one problem in the
+   editor, such as the unused local variable or unresolved reference.
+5. Run `Tools → IJPL-252476 Reproducer → Run XML Export`.
+6. Save the report path and exit the sandbox IDE.
+7. Start a fresh sandbox IDE, reopen the fixture, and run
+   `Tools → IJPL-252476 Reproducer → Run Offline Export`.
+
+Each action displays the directory containing its evidence. The directory is
+also available under the IDE log directory:
+
+```text
+<IDE log directory>/ijpl-252476/<UTC timestamp>-<mode>-<run ID>/
+├── report.txt
+└── xml/
+```
+
+The report records the IDE and project, scope file count, inspection profile,
+context implementation, progress-indicator state, call duration, exceptions,
+exported paths, actual files, and cleanup outcome. The XML files are
+intentionally preserved.
+
+## What To Attach
+
+For each action, attach:
+
+- `report.txt`
+- the complete `xml` directory
+- the matching section of `idea.log`
+
+The timestamps and run directory in `report.txt` make it possible to correlate
+the report with the IDE log.
+
+## Expected Result
+
+The known problem should appear in the exported results. A normal return with
+no XML files is important evidence because the project and scope are known to
+contain an inspection problem.
+
+The reproducer tests the XML-only path requested in the latest YouTrack reply.
+It does not test whether an `InspectionProblemConsumer` could receive the same
+local findings instead of XML.
+
+This reproducer deliberately does not inspect `GlobalInspectionContextImpl`
+fields, subscribe to `InspectListener`, or read Inspection Results UI state.
+
+The first recorded live run is summarized in [OBSERVED.md](OBSERVED.md).

--- a/reproducers/ijpl-252476-global-inspection/build.gradle.kts
+++ b/reproducers/ijpl-252476-global-inspection/build.gradle.kts
@@ -1,0 +1,62 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    id("java")
+    id("org.jetbrains.kotlin.jvm") version "2.4.0"
+    id("org.jetbrains.intellij.platform") version "2.18.1"
+}
+
+group = "com.shiny.ijpl252476"
+version = "1.0.0"
+
+repositories {
+    mavenCentral()
+    intellijPlatform {
+        defaultRepositories()
+    }
+}
+
+dependencies {
+    intellijPlatform {
+        val localIdePath = providers.gradleProperty("localIdePath")
+        if (localIdePath.isPresent) {
+            local(localIdePath)
+        } else {
+            pycharmProfessional("2026.2.1")
+        }
+    }
+}
+kotlin {
+    jvmToolchain(21)
+}
+
+tasks {
+    withType<JavaCompile> {
+        sourceCompatibility = "21"
+        targetCompatibility = "21"
+    }
+
+    withType<KotlinCompile> {
+        compilerOptions {
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+        }
+    }
+}
+
+intellijPlatform {
+    pluginConfiguration {
+        name = "IJPL-252476 Global Inspection Reproducer"
+        description = "Minimal reproducer for synchronous global inspection XML export from a live IDE plugin"
+        version = project.version.toString()
+
+        vendor {
+            name = "Shiny Computers"
+            email = "info@shinycomputers.com"
+        }
+
+        ideaVersion {
+            sinceBuild = "251"
+            untilBuild = "262.*"
+        }
+    }
+}

--- a/reproducers/ijpl-252476-global-inspection/fixtures/python-project/known_problem.py
+++ b/reproducers/ijpl-252476-global-inspection/fixtures/python-project/known_problem.py
@@ -1,0 +1,7 @@
+
+def greet(name):
+    unused_value = "this should be reported"
+    return missing_name
+
+
+print(greet("JetBrains"))

--- a/reproducers/ijpl-252476-global-inspection/gradle.properties
+++ b/reproducers/ijpl-252476-global-inspection/gradle.properties
@@ -1,0 +1,4 @@
+kotlin.stdlib.default.dependency=false
+org.gradle.configuration-cache=true
+org.gradle.caching=true
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8

--- a/reproducers/ijpl-252476-global-inspection/settings.gradle.kts
+++ b/reproducers/ijpl-252476-global-inspection/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "ijpl-252476-global-inspection-reproducer"

--- a/reproducers/ijpl-252476-global-inspection/src/main/kotlin/com/shiny/ijpl252476/Ijpl252476ReproducerAction.kt
+++ b/reproducers/ijpl-252476-global-inspection/src/main/kotlin/com/shiny/ijpl252476/Ijpl252476ReproducerAction.kt
@@ -1,0 +1,375 @@
+package com.shiny.ijpl252476
+
+import com.intellij.analysis.AnalysisScope
+import com.intellij.codeInspection.InspectionManager
+import com.intellij.codeInspection.ex.GlobalInspectionContextEx
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.application.ApplicationInfo
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.PathManager
+import com.intellij.openapi.progress.ProcessCanceledException
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.progress.Task
+import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.Messages
+import com.intellij.profile.codeInspection.InspectionProjectProfileManager
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+
+class RunExportReproducerAction : Ijpl252476ReproducerAction(ReproducerMode.XML_EXPORT)
+
+class RunOfflineReproducerAction : Ijpl252476ReproducerAction(ReproducerMode.OFFLINE_EXPORT)
+
+abstract class Ijpl252476ReproducerAction(
+    private val mode: ReproducerMode,
+) : AnAction() {
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
+
+    override fun update(event: AnActionEvent) {
+        val project = event.project
+        event.presentation.isEnabled = project != null && !DumbService.isDumb(project)
+    }
+
+    override fun actionPerformed(event: AnActionEvent) {
+        val project = event.project ?: return
+        ReproducerTask(project, mode).queue()
+    }
+}
+
+enum class ReproducerMode(
+    val reportName: String,
+    val taskTitle: String,
+) {
+    XML_EXPORT(
+        reportName = "xml-export",
+        taskTitle = "IJPL-252476 XML Export Reproducer",
+    ),
+    OFFLINE_EXPORT(
+        reportName = "offline-export",
+        taskTitle = "IJPL-252476 Offline Export Reproducer",
+    ),
+}
+
+private class ReproducerTask(
+    private val targetProject: Project,
+    private val mode: ReproducerMode,
+) : Task.Modal(targetProject, mode.taskTitle, true) {
+    private var result: ReproducerResult? = null
+
+    override fun run(indicator: ProgressIndicator) {
+        result = runReproducer(targetProject, mode, indicator)
+    }
+
+    override fun onSuccess() {
+        showResult(targetProject, result)
+    }
+
+    override fun onCancel() {
+        showResult(targetProject, result)
+    }
+
+    override fun onThrowable(error: Throwable) {
+        val message = buildString {
+            append("The reproducer task failed before it could finish its report.")
+            result?.let { append("\n\nPartial report: ${it.reportDirectory}") }
+            append("\n\n${error.javaClass.name}: ${error.message.orEmpty()}")
+        }
+        Messages.showErrorDialog(targetProject, message, mode.taskTitle)
+    }
+}
+
+private data class ReproducerResult(
+    val reportDirectory: Path,
+    val outcome: String,
+)
+
+@Suppress("UnstableApiUsage")
+private fun runReproducer(
+    project: Project,
+    mode: ReproducerMode,
+    indicator: ProgressIndicator,
+): ReproducerResult {
+    val runDirectory = createRunDirectory(mode)
+    val exportDirectory = runDirectory.resolve("xml")
+    Files.createDirectories(exportDirectory)
+    val report = ReproducerReport(runDirectory.resolve("report.txt"))
+    val exportedPaths = mutableListOf<Path>()
+    var context: GlobalInspectionContextEx? = null
+    var outcome = "failed_before_execution"
+
+    report.event(
+        "run.start",
+        environmentDetails(project, indicator) + mapOf(
+            "mode" to mode.reportName,
+            "run_directory" to runDirectory,
+            "export_directory" to exportDirectory,
+            "run_global_tools_only" to false,
+            "offline_inspections" to (mode == ReproducerMode.OFFLINE_EXPORT),
+        ),
+    )
+
+    try {
+        val scope = AnalysisScope(project)
+        val scopeFileCountStartedAt = System.nanoTime()
+        val scopeFileCount = scope.fileCount
+        report.event(
+            "scope.ready",
+            mapOf(
+                "display_name" to scope.displayName,
+                "file_count" to scopeFileCount,
+                "file_count_elapsed_ms" to elapsedMillis(scopeFileCountStartedAt),
+            ),
+        )
+
+        val inspectionManager = InspectionManager.getInstance(project)
+        val createdContext = inspectionManager.createNewGlobalContext()
+        context = createdContext as? GlobalInspectionContextEx
+            ?: error("createNewGlobalContext() returned ${createdContext.javaClass.name}")
+        val profile = InspectionProjectProfileManager.getInstance(project).currentProfile
+        context.setExternalProfile(profile)
+        context.currentScope = scope
+
+        report.event(
+            "context.ready",
+            mapOf(
+                "context_class" to context.javaClass.name,
+                "profile_name" to profile.name,
+            ),
+        )
+
+        report.event("inspection.call.start", progressDetails(indicator))
+        val inspectionStartedAt = System.nanoTime()
+        when (mode) {
+            ReproducerMode.XML_EXPORT -> context.performInspectionsWithProgressAndExportResults(
+                scope,
+                false,
+                false,
+                exportDirectory,
+                exportedPaths,
+            )
+            ReproducerMode.OFFLINE_EXPORT -> context.launchInspectionsOffline(
+                scope,
+                exportDirectory,
+                false,
+                exportedPaths,
+            )
+        }
+        report.event(
+            "inspection.call.returned",
+            progressDetails(indicator) + mapOf(
+                "elapsed_ms" to elapsedMillis(inspectionStartedAt),
+                "used_tool_count" to context.usedTools.size,
+            ),
+        )
+        outcome = "returned_normally"
+    } catch (canceled: ProcessCanceledException) {
+        outcome = "process_canceled_exception"
+        report.event(
+            "inspection.call.canceled",
+            progressDetails(indicator) + throwableDetails(canceled),
+        )
+    } catch (error: Throwable) {
+        outcome = "exception"
+        report.event(
+            "inspection.call.failed",
+            progressDetails(indicator) + throwableDetails(error),
+        )
+    } finally {
+        val exportedFileCount = reportExportSummary(report, exportDirectory, exportedPaths)
+        if (outcome == "returned_normally") {
+            outcome = if (exportedFileCount == 0) {
+                "returned_normally_without_exported_results"
+            } else {
+                "returned_normally_with_exported_results"
+            }
+        }
+        context?.let { closeContext(it, report) }
+        report.event(
+            "run.finished",
+            mapOf(
+                "outcome" to outcome,
+                "report_directory" to runDirectory,
+            ),
+        )
+    }
+
+    return ReproducerResult(runDirectory, outcome)
+}
+
+private fun createRunDirectory(mode: ReproducerMode): Path {
+    val timestamp = DateTimeFormatter
+        .ofPattern("yyyyMMdd'T'HHmmss'Z'")
+        .withZone(ZoneOffset.UTC)
+        .format(Instant.now())
+    val runName = "$timestamp-${mode.reportName}-${UUID.randomUUID().toString().take(8)}"
+    return Path.of(PathManager.getLogPath(), "ijpl-252476", runName).also(Files::createDirectories)
+}
+
+private fun environmentDetails(
+    project: Project,
+    indicator: ProgressIndicator,
+): Map<String, Any?> {
+    val applicationInfo = ApplicationInfo.getInstance()
+    return mapOf(
+        "ide_name" to applicationInfo.fullApplicationName,
+        "ide_version" to applicationInfo.fullVersion,
+        "ide_build" to applicationInfo.build.asString(),
+        "headless" to ApplicationManager.getApplication().isHeadlessEnvironment,
+        "project_name" to project.name,
+        "project_path" to project.basePath,
+        "project_is_dumb" to DumbService.isDumb(project),
+        "idea_log_path" to Path.of(PathManager.getLogPath(), "idea.log"),
+        "java_version" to System.getProperty("java.version"),
+        "os_name" to System.getProperty("os.name"),
+        "os_version" to System.getProperty("os.version"),
+    ) + progressDetails(indicator)
+}
+
+private fun progressDetails(indicator: ProgressIndicator): Map<String, Any?> {
+    val currentIndicator = ProgressManager.getInstance().progressIndicator
+    return mapOf(
+        "thread_name" to Thread.currentThread().name,
+        "thread_id" to Thread.currentThread().threadId(),
+        "is_dispatch_thread" to ApplicationManager.getApplication().isDispatchThread,
+        "task_indicator_class" to indicator.javaClass.name,
+        "task_indicator_canceled" to indicator.isCanceled,
+        "current_indicator_class" to currentIndicator?.javaClass?.name,
+        "current_indicator_canceled" to currentIndicator?.isCanceled,
+    )
+}
+
+private fun reportExportSummary(
+    report: ReproducerReport,
+    exportDirectory: Path,
+    exportedPaths: List<Path>,
+): Int {
+    val files = runCatching {
+        Files.walk(exportDirectory).use { paths ->
+            paths.filter(Files::isRegularFile).sorted().toList()
+        }
+    }.getOrElse { error ->
+        report.event("export.scan.failed", throwableDetails(error))
+        emptyList()
+    }
+
+    report.event(
+        "export.summary",
+        mapOf(
+            "reported_path_count" to exportedPaths.size,
+            "reported_paths" to exportedPaths.joinToString("\n"),
+            "actual_file_count" to files.size,
+            "actual_files" to files.joinToString("\n") { path ->
+                "${exportDirectory.relativize(path)} (${Files.size(path)} bytes)"
+            },
+        ),
+    )
+    return files.size
+}
+
+private fun closeContext(
+    context: GlobalInspectionContextEx,
+    report: ReproducerReport,
+) {
+    val closeResult = runCatching {
+        val closeAction = Runnable { context.close(false) }
+        val application = ApplicationManager.getApplication()
+        if (application.isDispatchThread) {
+            closeAction.run()
+        } else {
+            application.invokeAndWait(closeAction)
+        }
+    }
+
+    if (closeResult.isSuccess) {
+        report.event("context.closed")
+        return
+    }
+
+    val closeError = closeResult.exceptionOrNull() ?: return
+    report.event("context.close.failed", throwableDetails(closeError))
+    runCatching { context.cleanup() }
+        .onSuccess { report.event("context.cleanup.completed") }
+        .onFailure { cleanupError -> report.event("context.cleanup.failed", throwableDetails(cleanupError)) }
+}
+
+private fun throwableDetails(error: Throwable): Map<String, Any?> {
+    val stackTrace = StringWriter().also { writer ->
+        error.printStackTrace(PrintWriter(writer))
+    }.toString()
+    return mapOf(
+        "exception_class" to error.javaClass.name,
+        "exception_message" to error.message,
+        "stack_trace" to stackTrace,
+    )
+}
+
+private fun elapsedMillis(startedAtNanos: Long): Long =
+    Duration.ofNanos(System.nanoTime() - startedAtNanos).toMillis()
+
+private fun showResult(
+    project: Project,
+    result: ReproducerResult?,
+) {
+    if (result == null) {
+        Messages.showErrorDialog(
+            project,
+            "The reproducer did not create a report.",
+            "IJPL-252476 Reproducer",
+        )
+        return
+    }
+
+    Messages.showInfoMessage(
+        project,
+        "Outcome: ${result.outcome}\n\nReport and XML files:\n${result.reportDirectory}",
+        "IJPL-252476 Reproducer",
+    )
+}
+
+private class ReproducerReport(
+    private val reportPath: Path,
+) {
+    private val startedAt = Instant.now()
+
+    @Synchronized
+    fun event(
+        name: String,
+        values: Map<String, Any?> = emptyMap(),
+    ) {
+        val now = Instant.now()
+        val text = buildString {
+            append("=== ")
+            append(now)
+            append(" | +")
+            append(Duration.between(startedAt, now).toMillis())
+            append(" ms | ")
+            append(name)
+            append(" ===\n")
+            values.forEach { (key, value) ->
+                append(key)
+                append('=')
+                append(value?.toString()?.replace("\n", "\n  ") ?: "null")
+                append('\n')
+            }
+            append('\n')
+        }
+        Files.writeString(
+            reportPath,
+            text,
+            StandardOpenOption.CREATE,
+            StandardOpenOption.APPEND,
+        )
+    }
+}

--- a/reproducers/ijpl-252476-global-inspection/src/main/resources/META-INF/plugin.xml
+++ b/reproducers/ijpl-252476-global-inspection/src/main/resources/META-INF/plugin.xml
@@ -1,0 +1,26 @@
+<idea-plugin>
+    <id>com.shiny.ijpl252476.reproducer</id>
+    <name>IJPL-252476 Global Inspection Reproducer</name>
+    <vendor email="info@shinycomputers.com">Shiny Computers</vendor>
+
+    <description><![CDATA[
+        Minimal reproducer for IJPL-252476. It runs the global inspection XML export APIs
+        from a modal progress task and preserves the exported files and a detailed report.
+    ]]></description>
+
+    <depends>com.intellij.modules.platform</depends>
+
+    <actions>
+        <group id="Ijpl252476.Reproducer.Group"
+               text="IJPL-252476 Reproducer"
+               popup="true">
+            <add-to-group group-id="ToolsMenu" anchor="last"/>
+            <action id="Ijpl252476.Reproducer.Export"
+                    class="com.shiny.ijpl252476.RunExportReproducerAction"
+                    text="Run XML Export"/>
+            <action id="Ijpl252476.Reproducer.Offline"
+                    class="com.shiny.ijpl252476.RunOfflineReproducerAction"
+                    text="Run Offline Export"/>
+        </group>
+    </actions>
+</idea-plugin>


### PR DESCRIPTION
## Summary

- add a standalone PyCharm plugin reproducer for `IJPL-252476` without changing the production plugin or root build
- exercise `performInspectionsWithProgressAndExportResults` and `launchInspectionsOffline` in separate modal tasks and fresh IDE sessions
- preserve a detailed report and exported XML, plus a known-problem Python fixture and the first observed live result

## Live result

PyCharm 2026.2.1 (`PY-262.9437.214`) showed two editor problems in the fixture, and the project `AnalysisScope` contained eight files.

- XML export returned normally after 25 ms with 431 used tools, zero result paths, and zero XML files
- offline export, in a fresh IDE session, returned normally after 20 ms with 431 used tools, zero result paths, and zero XML files
- both IDE logs recorded a 2–3 ms scope scan followed by `Cancelling inspection progress`
- `context.close(false)` failed because no `InspectionResultsView` existed; fallback `cleanup()` completed

The reproducer intentionally tests the XML-only path from JetBrains' latest reply. It does not claim that an `InspectionProblemConsumer` would also receive zero local findings.

## Validation

- `./gradlew -p reproducers/ijpl-252476-global-inspection clean buildPlugin verifyPluginStructure`
- same build against the installed PyCharm 2026.2.1 using `-PlocalIdePath`
- both actions exercised in live, non-headless PyCharm sandbox sessions
- repository commit gate passed through the commit hook

The route-safe IDE helper was inconclusive: `changed_files` required a Python SDK for the fixture, while the narrowed Kotlin scan treated the standalone nested build as outside the root source layout and detected helper-created IDE metadata. The standalone compiler/build and live PyCharm runs are the relevant evidence for this reproducer.

Refs #324
Refs #290